### PR TITLE
Add branded loading animation to launch screen

### DIFF
--- a/RoadFlare/RoadFlare/Views/RootView.swift
+++ b/RoadFlare/RoadFlare/Views/RootView.swift
@@ -48,6 +48,7 @@ private struct LaunchLoadingView: View {
                 ProgressView()
                     .tint(Color.rfPrimary)
                     .scaleEffect(1.2)
+                    .accessibilityLabel("Loading")
             }
         }
         .onAppear { pulse = true }


### PR DESCRIPTION
## Summary
- Replace bare `ProgressView("Loading...")` with branded launch view
- Pulsing LaunchMark logo with a subtle scale + opacity animation
- Spinner below for activity feedback during relay connection

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)