### PR TITLE
Add countdown timer and warning to waiting-for-driver screen

### DIFF
--- a/RidestrUI/Sources/RidestrUI/Components/RideStatusCard.swift
+++ b/RidestrUI/Sources/RidestrUI/Components/RideStatusCard.swift
@@ -104,21 +104,8 @@ private struct WaitingContentView: View {
 
     @Environment(\.ridestrTheme) private var theme
     @State private var startDate = Date.now
-    @State private var remaining: Int
 
     private let warningThreshold = 30
-
-    init(totalSeconds: Int, fareEstimate: FareEstimate?, paymentMethods: [String],
-         driverName: String?, onCancel: (() -> Void)?) {
-        self.totalSeconds = totalSeconds
-        self.fareEstimate = fareEstimate
-        self.paymentMethods = paymentMethods
-        self.driverName = driverName
-        self.onCancel = onCancel
-        self._remaining = State(initialValue: totalSeconds)
-    }
-
-    private var isWarning: Bool { remaining <= warningThreshold && remaining > 0 }
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 0.5)) { context in
@@ -179,7 +166,7 @@ private struct WaitingContentView: View {
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 14)
                         .background(theme.surfaceSecondaryColor)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
                         .padding(.horizontal, 24)
                 }
                 Spacer().frame(height: 40)


### PR DESCRIPTION
## Summary
Replaces the indefinite spinner on the "Waiting for driver" screen with a circular countdown timer matching the Android rider app:

- **Circular arc** depleting clockwise with mm:ss in the center
- **Warning state at 30s remaining**: orange color, "Driver hasn't responded yet — Would you like to keep waiting?"
- **Driver name**: "Waiting for John..." when available
- **Fare estimate** shown during wait (already added in PR #15)

The SDK's existing 120-second `scheduleStageTimeout` handles the actual termination — this PR adds the visual feedback.

## Test plan
- [ ] Xcode build succeeds
- [ ] UI tests pass (26/26)
- [ ] Timer counts down from 2:00
- [ ] At 0:30, UI turns orange with warning message
- [ ] Cancel button works throughout
- [ ] Timer resets if view reappears

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)