### PR TITLE
Decompose AppState into thin shell + SyncCoordinator + ConnectionCoordinator

### DIFF
--- a/RoadFlare/RoadFlare/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlare/ViewModels/AppState.swift
@@ -59,8 +59,7 @@ final class AppState {
     private let keychainStorage = KeychainStorage(service: "com.roadflare.keys")
     private let driversPersistence = UserDefaultsDriversPersistence()
     private var roadflareSyncStore: RoadflareSyncStateStore?
-    private var connectionWatchdogTask: Task<Void, Never>?
-    private var isAutoReconnecting = false
+    private let connectionCoordinator = ConnectionCoordinator()
     private var isPublishingProfileBackup = false
     private var profileBackupRepublishRequested = false
     private var profileBackupSettingsTemplate = SettingsBackupContent()
@@ -562,7 +561,12 @@ final class AppState {
         )
         self.rideCoordinator = coordinator
         await coordinator.restoreLiveSubscriptions()
-        restartConnectionWatchdog()
+        connectionCoordinator.start(
+            interval: Self.connectionWatchdogInterval,
+            shouldReconnect: { [weak self] in self?.authState == .ready },
+            isConnected: { [weak self] in await self?.relayManager?.isConnected ?? false },
+            reconnect: { [weak self] in await self?.reconnectAndRestoreSession() }
+        )
     }
 
     private func setupServices(keypair: NostrKeypair) async {
@@ -602,7 +606,12 @@ final class AppState {
         self.rideCoordinator = coordinator
         AppLogger.auth.info("Starting subscriptions... (\(repo.drivers.count) drivers loaded)")
         await coordinator.restoreLiveSubscriptions()
-        restartConnectionWatchdog()
+        connectionCoordinator.start(
+            interval: Self.connectionWatchdogInterval,
+            shouldReconnect: { [weak self] in self?.authState == .ready },
+            isConnected: { [weak self] in await self?.relayManager?.isConnected ?? false },
+            reconnect: { [weak self] in await self?.reconnectAndRestoreSession() }
+        )
     }
 
     private func configureDriversRepositoryTracking(
@@ -663,7 +672,7 @@ final class AppState {
     }
 
     private func prepareForIdentityReplacement(clearPersistedSyncState: Bool) async {
-        stopConnectionWatchdog()
+        connectionCoordinator.stop()
         await rideCoordinator?.stopAll()
         await relayManager?.disconnect()
 
@@ -696,31 +705,4 @@ final class AppState {
         bitcoinPrice.stop()
     }
 
-    private func restartConnectionWatchdog() {
-        connectionWatchdogTask?.cancel()
-        connectionWatchdogTask = Task { [weak self] in
-            while !Task.isCancelled {
-                try? await Task.sleep(for: Self.connectionWatchdogInterval)
-                guard let self else { return }
-                await self.autoReconnectIfNeeded()
-            }
-        }
-    }
-
-    private func stopConnectionWatchdog() {
-        connectionWatchdogTask?.cancel()
-        connectionWatchdogTask = nil
-        isAutoReconnecting = false
-    }
-
-    private func autoReconnectIfNeeded() async {
-        guard authState == .ready,
-              !isAutoReconnecting,
-              let rm = relayManager,
-              !(await rm.isConnected) else { return }
-
-        isAutoReconnecting = true
-        defer { isAutoReconnecting = false }
-        await reconnectAndRestoreSession()
-    }
 }

--- a/RoadFlare/RoadFlare/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlare/ViewModels/AppState.swift
@@ -13,6 +13,9 @@ enum AuthState {
 }
 
 /// Central app state coordinator. Owns SDK services and manages auth lifecycle.
+///
+/// Views access this via `@Environment(AppState.self)`. All sync orchestration
+/// is delegated to `SyncCoordinator`; connection watchdog to `ConnectionCoordinator`.
 @Observable
 @MainActor
 final class AppState {
@@ -54,26 +57,14 @@ final class AppState {
     var syncRestoredLocations: Int = 0
     var syncRestoredName: Bool = false
 
-    // MARK: - Storage
+    // MARK: - Private Coordinators & Storage
 
     private let keychainStorage = KeychainStorage(service: "com.roadflare.keys")
     private let driversPersistence = UserDefaultsDriversPersistence()
-    private var roadflareSyncStore: RoadflareSyncStateStore?
+    private var syncCoordinator: SyncCoordinator?
     private let connectionCoordinator = ConnectionCoordinator()
-    private var isPublishingProfileBackup = false
-    private var profileBackupRepublishRequested = false
-    private var profileBackupSettingsTemplate = SettingsBackupContent()
 
     // MARK: - Init
-
-    init() {
-        settings.onProfileChanged = { [weak self] in
-            self?.roadflareSyncStore?.markDirty(.profile)
-        }
-        settings.onProfileBackupChanged = { [weak self] in
-            self?.roadflareSyncStore?.markDirty(.profileBackup)
-        }
-    }
 
     private static let hasLaunchedKey = "roadflare_has_launched"
 
@@ -134,105 +125,49 @@ final class AppState {
 
         // Navigate based on what was restored
         if settings.profileName.isEmpty {
-            // No name → go to profile setup
             authState = .profileIncomplete
         } else if settings.roadflarePaymentMethods.isEmpty {
-            // Have name but no payment methods → go to payment setup
             authState = .paymentSetup
         } else {
-            // Have both → fully ready
             settings.profileCompleted = true
             authState = .ready
         }
     }
 
     /// Mark profile name as set, publish Kind 0 to Nostr, move to payment setup.
-    /// Does NOT publish Kind 30177 yet — payment methods aren't set until next step.
     func completeProfileSetup(name: String) async {
         settings.profileName = name
-        roadflareSyncStore?.markDirty(.profile)
-        await publishProfile()
+        syncCoordinator?.markDirty(.profile)
+        await syncCoordinator?.publishProfile()
         authState = .paymentSetup
     }
 
     /// Mark payment setup as done, finish onboarding. Publishes profile + settings backup.
     func completePaymentSetup() async {
         settings.profileCompleted = true
-        roadflareSyncStore?.markDirty(.profileBackup)
-        await saveAndPublishSettings()
+        syncCoordinator?.markDirty(.profileBackup)
+        await syncCoordinator?.saveAndPublishSettings()
         authState = .ready
     }
 
-    /// Publish Kind 0 metadata to Nostr.
-    func publishProfile() async {
-        guard let service = roadflareDomainService else { return }
-        let profile = UserProfileContent(
-            name: settings.profileName,
-            displayName: settings.profileName
-        )
-        do {
-            let event = try await service.publishProfile(profile)
-            roadflareSyncStore?.markPublished(.profile, at: event.createdAt)
-            AppLogger.auth.info("Published profile to Nostr")
-        } catch {
-            AppLogger.auth.info("Failed to publish profile: \(error)")
-        }
-    }
+    // MARK: - Forwarding to SyncCoordinator
 
-    /// Publish Kind 30177 encrypted profile backup (settings + saved locations) to Nostr.
-    func publishProfileBackup() async {
-        guard let service = roadflareDomainService else { return }
-        if isPublishingProfileBackup {
-            profileBackupRepublishRequested = true
-            return
-        }
-
-        isPublishingProfileBackup = true
-        defer { isPublishingProfileBackup = false }
-
-        repeat {
-            profileBackupRepublishRequested = false
-            let backup = buildProfileBackupContent()
-            do {
-                let event = try await service.publishProfileBackup(backup)
-                roadflareSyncStore?.markPublished(.profileBackup, at: event.createdAt)
-                AppLogger.auth.info("Published profile backup to Nostr")
-            } catch {
-                AppLogger.auth.info("Failed to publish profile backup: \(error)")
-            }
-        } while profileBackupRepublishRequested
-    }
+    func publishProfile() async { await syncCoordinator?.publishProfile() }
+    func publishProfileBackup() async { await syncCoordinator?.publishProfileBackup() }
+    func saveAndPublishSettings() async { await syncCoordinator?.saveAndPublishSettings() }
 
     func buildProfileBackupContent() -> ProfileBackupContent {
-        var settingsBackup = profileBackupSettingsTemplate
-        settingsBackup.roadflarePaymentMethods = settings.roadflarePaymentMethods
-
-        return ProfileBackupContent(
-            savedLocations: savedLocations.locations.map { loc in
-                SavedLocationBackup(
-                    displayName: loc.displayName, lat: loc.latitude, lon: loc.longitude,
-                    addressLine: loc.addressLine,
-                    isPinned: loc.isPinned,
-                    nickname: loc.nickname,
-                    timestampMs: loc.timestampMs
-                )
-            },
-            settings: settingsBackup
-        )
+        syncCoordinator?.buildProfileBackupContent()
+            ?? ProfileBackupContent(savedLocations: [], settings: SettingsBackupContent())
     }
 
-    func preserveProfileBackupSettingsTemplate(_ settings: SettingsBackupContent) {
-        profileBackupSettingsTemplate = settings
+    func preserveProfileBackupSettingsTemplate(_ s: SettingsBackupContent) {
+        syncCoordinator?.preserveProfileBackupSettingsTemplate(s)
     }
 
-    /// Publish both Kind 0 (public profile) and Kind 30177 (encrypted backup) to Nostr.
-    func saveAndPublishSettings() async {
-        await publishProfile()
-        await publishProfileBackup()
-    }
+    // MARK: - Driver Key Management
 
     /// Try to restore a specific driver's key from our Kind 30011 backup on the relay.
-    /// Used during mid-session re-add when the key was lost locally but exists in the backup.
     func restoreKeyFromBackup(driverPubkey: String) async {
         guard let service = roadflareDomainService,
               let repo = driversRepository else { return }
@@ -260,7 +195,6 @@ final class AppState {
     }
 
     /// Send Kind 3187 follow notification to a driver (real-time nudge).
-    /// The rider's Kind 30011 p-tags are the source of truth — this is just a push notification.
     func sendFollowNotification(driverPubkey: String) async {
         guard let kp = keypair, let rm = relayManager,
               !settings.profileName.isEmpty else { return }
@@ -277,11 +211,23 @@ final class AppState {
         }
     }
 
+    // MARK: - Connection & Foreground
+
     /// Called when app returns to foreground. Reconnects relays and restarts subscriptions if needed.
     func handleForeground() async {
         guard authState == .ready else { return }
         await reconnectAndRestoreSession()
     }
+
+    func reconnectAndRestoreSession() async {
+        guard let rm = relayManager else { return }
+        await rm.reconnectIfNeeded()
+        guard await rm.isConnected else { return }
+        await syncCoordinator?.flushPendingSyncPublishes(rideCoordinator: rideCoordinator)
+        await rideCoordinator?.restoreLiveSubscriptions()
+    }
+
+    // MARK: - Auth Helpers
 
     func resolveLocalAuthState() -> AuthState {
         if settings.profileName.isEmpty {
@@ -301,243 +247,24 @@ final class AppState {
         authState = .loggedOut
     }
 
-    private func detachRepositoryTrackingCallbacks() {
-        driversRepository?.onDriversChanged = nil
-        rideHistory.onRidesChanged = nil
-        savedLocations.onChange = nil
-        savedLocations.onFavoritesChanged = nil
-    }
-
-    // MARK: - Private
-
-    /// Fetch, resolve, and apply RoadFlare startup state using SDK-owned helpers.
-    private func performStartupSync(repo: FollowedDriversRepository, importFlow: Bool) async {
-        guard let service = roadflareDomainService else { return }
-
-        let remote = await service.fetchStartupRemoteState()
-
-        if importFlow { syncStatus = "Restoring your profile..." }
-        await applyProfileResolution(remote: remote.profile)
-        if importFlow { syncRestoredName = !settings.profileName.isEmpty }
-
-        if importFlow { syncStatus = "Restoring your drivers..." }
-        await applyFollowedDriversResolution(repo: repo, remote: remote.followedDrivers)
-        if importFlow { syncRestoredDrivers = repo.drivers.count }
-
-        if importFlow { syncStatus = "Restoring settings..." }
-        await applyProfileBackupResolution(remote: remote.profileBackup)
-        if importFlow { syncRestoredLocations = savedLocations.locations.count }
-
-        if importFlow { syncStatus = "Restoring ride history..." }
-        await applyRideHistoryResolution(remote: remote.rideHistory)
-
-        if importFlow { syncStatus = "Loading driver info..." }
-        let driverProfiles = await service.fetchDriverProfiles(pubkeys: repo.allPubkeys)
-        for (pubkey, snapshot) in driverProfiles {
-            repo.cacheDriverProfile(pubkey: pubkey, profile: snapshot.value)
-        }
-        if !driverProfiles.isEmpty {
-            AppLogger.auth.info("Fetched profiles for \(driverProfiles.count) driver(s)")
-        }
-
-        if importFlow {
-            syncStatus = "Done!"
-            try? await Task.sleep(for: .seconds(1))
-        }
-    }
-
-    private func applyProfileResolution(
-        remote: RoadflareDomainService.StartupRemoteDomain<UserProfileContent>
-    ) async {
-        guard let syncStore = roadflareSyncStore else { return }
-        let metadata = syncStore.metadata(for: .profile)
-        let resolution = RoadflareDomainService.resolve(
-            domain: .profile,
-            metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt
-        )
-        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
-            metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt,
-            hasLocalState: !settings.profileName.isEmpty
-        )
-
-        if resolution.source == .remote,
-           let snapshot = remote.snapshot,
-           snapshot.createdAt == remote.latestSeenCreatedAt {
-            let name = snapshot.value.displayName ?? snapshot.value.name ?? ""
-            settings.performWithoutChangeTracking {
-                settings.profileName = name
-            }
-            if !name.isEmpty {
-                AppLogger.auth.info("Restored profile name from Nostr: \(name)")
-            }
-            syncStore.markPublished(.profile, at: snapshot.createdAt)
-        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
-            AppLogger.auth.warning("Latest profile metadata is not decodable; preserving local profile state")
-        } else if resolution.shouldPublishLocal || shouldSeedLegacyLocal {
-            if shouldSeedLegacyLocal {
-                syncStore.markDirty(.profile)
-            }
-            await publishProfile()
-        }
-    }
-
-    private func applyFollowedDriversResolution(
-        repo: FollowedDriversRepository,
-        remote: RoadflareDomainService.StartupRemoteDomain<FollowedDriversContent>
-    ) async {
-        guard let service = roadflareDomainService else { return }
-        guard let syncStore = roadflareSyncStore else { return }
-        let metadata = syncStore.metadata(for: .followedDrivers)
-        let resolution = RoadflareDomainService.resolve(
-            domain: .followedDrivers,
-            metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt
-        )
-        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
-            metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt,
-            hasLocalState: repo.hasDrivers
-        )
-
-        if resolution.source == .remote,
-           let snapshot = remote.snapshot,
-           snapshot.createdAt == remote.latestSeenCreatedAt {
-            repo.restoreFromNostr(content: snapshot.value)
-            syncStore.markPublished(.followedDrivers, at: snapshot.createdAt)
-            if !snapshot.value.drivers.isEmpty {
-                AppLogger.auth.info("Restored \(snapshot.value.drivers.count) drivers from Nostr")
-            }
-        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
-            AppLogger.auth.warning("Latest followed-drivers snapshot is not decodable; preserving local driver state")
-        } else if resolution.shouldPublishLocal || shouldSeedLegacyLocal {
-            if shouldSeedLegacyLocal {
-                syncStore.markDirty(.followedDrivers)
-            }
-            do {
-                let event = try await service.publishFollowedDriversList(repo.drivers)
-                syncStore.markPublished(.followedDrivers, at: event.createdAt)
-                AppLogger.auth.info("Published followed drivers list to Nostr")
-            } catch {
-                AppLogger.auth.info("Failed to publish followed drivers list: \(error)")
-            }
-        }
-    }
-
-    private func applyProfileBackupResolution(
-        remote: RoadflareDomainService.StartupRemoteDomain<ProfileBackupContent>
-    ) async {
-        guard roadflareDomainService != nil else { return }
-        guard let syncStore = roadflareSyncStore else { return }
-        if let snapshot = remote.snapshot {
-            preserveProfileBackupSettingsTemplate(snapshot.value.settings)
-        }
-        let metadata = syncStore.metadata(for: .profileBackup)
-        let resolution = RoadflareDomainService.resolve(
-            domain: .profileBackup,
-            metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt
-        )
-        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
-            metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt,
-            hasLocalState: !settings.roadflarePaymentMethods.isEmpty
-                || !savedLocations.locations.isEmpty
-        )
-
-        if resolution.source == .remote,
-           let snapshot = remote.snapshot,
-           snapshot.createdAt == remote.latestSeenCreatedAt {
-            applyRemoteProfileBackup(snapshot.value)
-            syncStore.markPublished(.profileBackup, at: snapshot.createdAt)
-        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
-            AppLogger.auth.warning("Latest profile backup is not decodable; preserving local backup state")
-        } else if resolution.shouldPublishLocal || shouldSeedLegacyLocal {
-            if shouldSeedLegacyLocal {
-                syncStore.markDirty(.profileBackup)
-            }
-            await publishProfileBackup()
-        }
-    }
-
-    private func applyRemoteProfileBackup(_ backup: ProfileBackupContent) {
-        preserveProfileBackupSettingsTemplate(backup.settings)
-        settings.performWithoutChangeTracking {
-            settings.setRoadflarePaymentMethods(backup.settings.roadflarePaymentMethods)
-        }
-
-        savedLocations.restoreFromBackup(backup.savedLocations.map { loc in
-            SavedLocation(
-                latitude: loc.lat,
-                longitude: loc.lon,
-                displayName: loc.displayName,
-                addressLine: loc.addressLine ?? loc.displayName,
-                isPinned: loc.isPinned,
-                nickname: loc.nickname,
-                timestampMs: loc.timestampMs ?? Int(Date.now.timeIntervalSince1970 * 1000)
-            )
-        })
-
-        if !backup.savedLocations.isEmpty {
-            AppLogger.auth.info("Restored \(backup.savedLocations.count) saved locations")
-        }
-    }
-
-    private func applyRideHistoryResolution(
-        remote: RoadflareDomainService.StartupRemoteDomain<RideHistoryBackupContent>
-    ) async {
-        guard let service = roadflareDomainService else { return }
-        guard let syncStore = roadflareSyncStore else { return }
-        let metadata = syncStore.metadata(for: .rideHistory)
-        let resolution = RoadflareDomainService.resolve(
-            domain: .rideHistory,
-            metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt
-        )
-        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
-            metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt,
-            hasLocalState: !rideHistory.rides.isEmpty
-        )
-
-        if resolution.source == .remote,
-           let snapshot = remote.snapshot,
-           snapshot.createdAt == remote.latestSeenCreatedAt {
-            // Remote is authoritative — full replace (matches other domain patterns)
-            rideHistory.restoreFromBackup(snapshot.value.rides)
-            syncStore.markPublished(.rideHistory, at: snapshot.createdAt)
-            if !snapshot.value.rides.isEmpty {
-                AppLogger.auth.info("Restored \(snapshot.value.rides.count) ride(s) from Nostr")
-            }
-        } else if (resolution.shouldPublishLocal || shouldSeedLegacyLocal), !rideHistory.rides.isEmpty {
-            if shouldSeedLegacyLocal {
-                syncStore.markDirty(.rideHistory)
-            }
-            do {
-                let content = RideHistoryBackupContent(rides: rideHistory.rides)
-                let event = try await service.publishRideHistoryBackup(content)
-                syncStore.markPublished(.rideHistory, at: event.createdAt)
-                AppLogger.auth.info("Published ride history backup to Nostr")
-            } catch {
-                AppLogger.auth.info("Failed to publish ride history backup: \(error)")
-            }
-        }
-    }
+    // MARK: - Service Setup
 
     /// Setup with sync status updates for the import flow UI.
     private func setupServicesWithSync(keypair: NostrKeypair) async {
         let rm = RelayManager(keypair: keypair)
         self.relayManager = rm
+
+        let sync = SyncCoordinator(settings: settings, savedLocations: savedLocations, rideHistory: rideHistory)
         let syncStore = RoadflareSyncStateStore(namespace: keypair.publicKeyHex)
-        self.roadflareSyncStore = syncStore
+        let service = RoadflareDomainService(relayManager: rm, keypair: keypair)
+        sync.configure(syncStore: syncStore, domainService: service)
+        self.syncCoordinator = sync
+        self.roadflareDomainService = service
+
         let repo = FollowedDriversRepository(persistence: driversPersistence)
         self.driversRepository = repo
-        configureDriversRepositoryTracking(repo, syncStore: syncStore)
-        configureRideHistoryTracking(syncStore: syncStore)
-        configureSavedLocationsTracking(syncStore: syncStore)
-        let service = RoadflareDomainService(relayManager: rm, keypair: keypair)
-        self.roadflareDomainService = service
+        sync.wireTrackingCallbacks(driversRepo: repo)
+
         self.fareCalculator = FareCalculator()
         self.remoteConfigManager = RemoteConfigManager(relayManager: rm)
         bitcoinPrice.start()
@@ -550,14 +277,21 @@ final class AppState {
             try? await Task.sleep(for: .seconds(1))
         }
 
-        await performStartupSync(repo: repo, importFlow: true)
+        await sync.performStartupSync(repo: repo, importFlow: true) { [weak self] progress in
+            switch progress {
+            case .status(let msg): self?.syncStatus = msg
+            case .profileRestored(let found): self?.syncRestoredName = found
+            case .driversRestored(let count): self?.syncRestoredDrivers = count
+            case .locationsRestored(let count): self?.syncRestoredLocations = count
+            }
+        }
 
         let coordinator = RideCoordinator(
             relayManager: rm, keypair: keypair,
             driversRepository: repo, settings: settings,
             rideHistory: rideHistory, bitcoinPrice: bitcoinPrice,
             roadflareDomainService: service,
-            roadflareSyncStore: syncStore
+            roadflareSyncStore: sync.roadflareSyncStore
         )
         self.rideCoordinator = coordinator
         await coordinator.restoreLiveSubscriptions()
@@ -572,15 +306,18 @@ final class AppState {
     private func setupServices(keypair: NostrKeypair) async {
         let rm = RelayManager(keypair: keypair)
         self.relayManager = rm
+
+        let sync = SyncCoordinator(settings: settings, savedLocations: savedLocations, rideHistory: rideHistory)
         let syncStore = RoadflareSyncStateStore(namespace: keypair.publicKeyHex)
-        self.roadflareSyncStore = syncStore
+        let service = RoadflareDomainService(relayManager: rm, keypair: keypair)
+        sync.configure(syncStore: syncStore, domainService: service)
+        self.syncCoordinator = sync
+        self.roadflareDomainService = service
+
         let repo = FollowedDriversRepository(persistence: driversPersistence)
         self.driversRepository = repo
-        configureDriversRepositoryTracking(repo, syncStore: syncStore)
-        configureRideHistoryTracking(syncStore: syncStore)
-        configureSavedLocationsTracking(syncStore: syncStore)
-        let service = RoadflareDomainService(relayManager: rm, keypair: keypair)
-        self.roadflareDomainService = service
+        sync.wireTrackingCallbacks(driversRepo: repo)
+
         self.fareCalculator = FareCalculator()
         self.remoteConfigManager = RemoteConfigManager(relayManager: rm)
         bitcoinPrice.start()
@@ -594,14 +331,14 @@ final class AppState {
             AppLogger.auth.info(" Relay connection FAILED: \(error)")
         }
 
-        await performStartupSync(repo: repo, importFlow: false)
+        await sync.performStartupSync(repo: repo, importFlow: false)
 
         let coordinator = RideCoordinator(
             relayManager: rm, keypair: keypair,
             driversRepository: repo, settings: settings,
             rideHistory: rideHistory, bitcoinPrice: bitcoinPrice,
             roadflareDomainService: service,
-            roadflareSyncStore: syncStore
+            roadflareSyncStore: sync.roadflareSyncStore
         )
         self.rideCoordinator = coordinator
         AppLogger.auth.info("Starting subscriptions... (\(repo.drivers.count) drivers loaded)")
@@ -614,75 +351,21 @@ final class AppState {
         )
     }
 
-    private func configureDriversRepositoryTracking(
-        _ repo: FollowedDriversRepository,
-        syncStore: RoadflareSyncStateStore?
-    ) {
-        repo.onDriversChanged = { source in
-            guard source == .local else { return }
-            syncStore?.markDirty(.followedDrivers)
-        }
-    }
-
-    private func configureRideHistoryTracking(syncStore: RoadflareSyncStateStore?) {
-        rideHistory.onRidesChanged = {
-            syncStore?.markDirty(.rideHistory)
-        }
-    }
-
-    private func configureSavedLocationsTracking(syncStore: RoadflareSyncStateStore?) {
-        savedLocations.onChange = {
-            syncStore?.markDirty(.profileBackup)
-        }
-    }
-
-    func reconnectAndRestoreSession() async {
-        guard let rm = relayManager else { return }
-        await rm.reconnectIfNeeded()
-        guard await rm.isConnected else { return }
-        await flushPendingSyncPublishes()
-        await rideCoordinator?.restoreLiveSubscriptions()
-    }
-
-    private func flushPendingSyncPublishes() async {
-        guard let rm = relayManager,
-              let syncStore = roadflareSyncStore,
-              await rm.isConnected else { return }
-
-        if syncStore.metadata(for: .profile).isDirty {
-            await publishProfile()
-        }
-        if syncStore.metadata(for: .followedDrivers).isDirty {
-            await rideCoordinator?.publishFollowedDriversList()
-        }
-        if syncStore.metadata(for: .profileBackup).isDirty {
-            await publishProfileBackup()
-        }
-        if syncStore.metadata(for: .rideHistory).isDirty, !rideHistory.rides.isEmpty {
-            do {
-                let content = RideHistoryBackupContent(rides: rideHistory.rides)
-                if let service = roadflareDomainService {
-                    let event = try await service.publishRideHistoryBackup(content)
-                    syncStore.markPublished(.rideHistory, at: event.createdAt)
-                }
-            } catch {
-                // Will retry on next reconnect
-            }
-        }
-    }
+    // MARK: - Identity Replacement
 
     private func prepareForIdentityReplacement(clearPersistedSyncState: Bool) async {
+        // 1. Connection
         connectionCoordinator.stop()
+
+        // 2. Ride + relay
         await rideCoordinator?.stopAll()
         await relayManager?.disconnect()
 
-        let syncStore = roadflareSyncStore
-        roadflareSyncStore = nil
-        if clearPersistedSyncState {
-            syncStore?.clearAll()
-        }
+        // 3. Sync (detaches ALL callbacks before any clearAll)
+        syncCoordinator?.teardown(clearPersistedState: clearPersistedSyncState)
+        syncCoordinator = nil
 
-        detachRepositoryTrackingCallbacks()
+        // 4. Repository data (callbacks already nil'd by teardown)
         driversRepository?.clearAll()
         if driversRepository == nil {
             driversPersistence.saveDrivers([])
@@ -691,11 +374,13 @@ final class AppState {
         rideHistory.clearAll()
         savedLocations.clearAll()
         settings.clearAll()
-        profileBackupSettingsTemplate = SettingsBackupContent()
         RideStatePersistence.clear()
+
+        // 5. UI state
         requestRideDriverPubkey = nil
         selectedTab = 0
 
+        // 6. Nil service refs
         rideCoordinator = nil
         relayManager = nil
         roadflareDomainService = nil
@@ -704,5 +389,4 @@ final class AppState {
         remoteConfigManager = nil
         bitcoinPrice.stop()
     }
-
 }

--- a/RoadFlare/RoadFlare/ViewModels/ConnectionCoordinator.swift
+++ b/RoadFlare/RoadFlare/ViewModels/ConnectionCoordinator.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Owns the periodic relay connection watchdog task.
+///
+/// Checks connectivity on a fixed interval and triggers reconnection
+/// when the relay drops. All behavior is injected via closures so the
+/// coordinator has no direct dependencies on AppState or SDK services.
+@MainActor
+final class ConnectionCoordinator {
+    private var watchdogTask: Task<Void, Never>?
+    private var isReconnecting = false
+
+    /// Start the periodic watchdog.
+    ///
+    /// - Parameters:
+    ///   - interval: Time between connectivity checks.
+    ///   - shouldReconnect: Return `true` when the app is in a state that needs a relay (e.g. `.ready`).
+    ///   - isConnected: Async check for current relay connectivity.
+    ///   - reconnect: Async action to reconnect relays and restore subscriptions.
+    func start(
+        interval: Duration,
+        shouldReconnect: @escaping @MainActor () -> Bool,
+        isConnected: @escaping @MainActor () async -> Bool,
+        reconnect: @escaping @MainActor () async -> Void
+    ) {
+        watchdogTask?.cancel()
+        watchdogTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: interval)
+                guard let self, !self.isReconnecting, shouldReconnect() else { continue }
+                guard !(await isConnected()) else { continue }
+                self.isReconnecting = true
+                defer { self.isReconnecting = false }
+                await reconnect()
+            }
+        }
+    }
+
+    /// Stop the watchdog and cancel any in-flight reconnection.
+    func stop() {
+        watchdogTask?.cancel()
+        watchdogTask = nil
+        isReconnecting = false
+    }
+}

--- a/RoadFlare/RoadFlare/ViewModels/SyncCoordinator.swift
+++ b/RoadFlare/RoadFlare/ViewModels/SyncCoordinator.swift
@@ -1,0 +1,412 @@
+import Foundation
+import os
+import RidestrSDK
+
+/// Progress updates from startup sync, consumed by AppState for UI.
+enum SyncProgress {
+    case status(String)
+    case profileRestored(nameFound: Bool)
+    case driversRestored(count: Int)
+    case locationsRestored(count: Int)
+}
+
+/// Owns Nostr sync orchestration: startup resolution, publish methods,
+/// dirty tracking callbacks, and flush-on-reconnect.
+///
+/// AppState creates and holds this privately. Views never access it directly.
+/// All sync-related state (roadflareSyncStore, publish flags, backup template)
+/// lives here instead of on AppState, reducing AppState's responsibility surface.
+@MainActor
+final class SyncCoordinator {
+    // MARK: - Owned State
+
+    private(set) var roadflareSyncStore: RoadflareSyncStateStore?
+    private(set) var roadflareDomainService: RoadflareDomainService?
+    private var isPublishingProfileBackup = false
+    private var profileBackupRepublishRequested = false
+    private var profileBackupSettingsTemplate = SettingsBackupContent()
+
+    // MARK: - Injected References (owned by AppState)
+
+    private let settings: UserSettings
+    private let savedLocations: SavedLocationsRepository
+    private let rideHistory: RideHistoryRepository
+
+    // Weak ref for callback teardown
+    private weak var trackedDriversRepo: FollowedDriversRepository?
+
+    // MARK: - Init
+
+    init(settings: UserSettings, savedLocations: SavedLocationsRepository,
+         rideHistory: RideHistoryRepository) {
+        self.settings = settings
+        self.savedLocations = savedLocations
+        self.rideHistory = rideHistory
+    }
+
+    /// Set owned services after relay connection is established.
+    func configure(syncStore: RoadflareSyncStateStore, domainService: RoadflareDomainService) {
+        self.roadflareSyncStore = syncStore
+        self.roadflareDomainService = domainService
+    }
+
+    /// Forward markDirty for AppState methods that need it (completeProfileSetup, etc.)
+    func markDirty(_ domain: RoadflareSyncDomain) {
+        roadflareSyncStore?.markDirty(domain)
+    }
+
+    // MARK: - Tracking Callbacks
+
+    /// Wire ALL change-tracking callbacks: settings + repositories.
+    /// Replaces: configureDriversRepositoryTracking, configureRideHistoryTracking,
+    ///           configureSavedLocationsTracking, and settings callbacks from AppState.init().
+    /// MUST be called after configure() so roadflareSyncStore is set.
+    func wireTrackingCallbacks(driversRepo: FollowedDriversRepository) {
+        let store = roadflareSyncStore
+        trackedDriversRepo = driversRepo
+
+        // Settings callbacks (previously in AppState.init — safe to move since
+        // they no-op before setup via optional chaining anyway)
+        settings.onProfileChanged = { store?.markDirty(.profile) }
+        settings.onProfileBackupChanged = { store?.markDirty(.profileBackup) }
+
+        // Repository callbacks
+        driversRepo.onDriversChanged = { source in
+            guard source == .local else { return }
+            store?.markDirty(.followedDrivers)
+        }
+        rideHistory.onRidesChanged = { store?.markDirty(.rideHistory) }
+        savedLocations.onChange = { store?.markDirty(.profileBackup) }
+    }
+
+    // MARK: - Teardown
+
+    /// Detach ALL callbacks and clear sync state. Called during identity replacement.
+    /// MUST be called BEFORE any clearAll() calls on repositories to prevent
+    /// stale callbacks from writing dirty flags.
+    func teardown(clearPersistedState: Bool) {
+        // Detach all callbacks first
+        settings.onProfileChanged = nil
+        settings.onProfileBackupChanged = nil
+        trackedDriversRepo?.onDriversChanged = nil
+        rideHistory.onRidesChanged = nil
+        savedLocations.onChange = nil
+        savedLocations.onFavoritesChanged = nil
+
+        // Clear sync store
+        if clearPersistedState {
+            roadflareSyncStore?.clearAll()
+        }
+        roadflareSyncStore = nil
+        roadflareDomainService = nil
+        profileBackupSettingsTemplate = SettingsBackupContent()
+    }
+
+    // MARK: - Startup Sync
+
+    /// Orchestrate startup sync across all 4 domains.
+    /// - Parameters:
+    ///   - repo: The followed drivers repository (created by AppState during setup).
+    ///   - importFlow: Whether to report progress for the sync UI screen.
+    ///   - onProgress: Callback for UI state updates (maps to AppState's sync properties).
+    func performStartupSync(
+        repo: FollowedDriversRepository,
+        importFlow: Bool,
+        onProgress: (@MainActor (SyncProgress) -> Void)? = nil
+    ) async {
+        guard let service = roadflareDomainService else { return }
+
+        let remote = await service.fetchStartupRemoteState()
+
+        if importFlow { onProgress?(.status("Restoring your profile...")) }
+        await applyProfileResolution(remote: remote.profile)
+        if importFlow { onProgress?(.profileRestored(nameFound: !settings.profileName.isEmpty)) }
+
+        if importFlow { onProgress?(.status("Restoring your drivers...")) }
+        await applyFollowedDriversResolution(repo: repo, remote: remote.followedDrivers)
+        if importFlow { onProgress?(.driversRestored(count: repo.drivers.count)) }
+
+        if importFlow { onProgress?(.status("Restoring settings...")) }
+        await applyProfileBackupResolution(remote: remote.profileBackup)
+        if importFlow { onProgress?(.locationsRestored(count: savedLocations.locations.count)) }
+
+        if importFlow { onProgress?(.status("Restoring ride history...")) }
+        await applyRideHistoryResolution(remote: remote.rideHistory)
+
+        if importFlow { onProgress?(.status("Loading driver info...")) }
+        let driverProfiles = await service.fetchDriverProfiles(pubkeys: repo.allPubkeys)
+        for (pubkey, snapshot) in driverProfiles {
+            repo.cacheDriverProfile(pubkey: pubkey, profile: snapshot.value)
+        }
+        if !driverProfiles.isEmpty {
+            AppLogger.auth.info("Fetched profiles for \(driverProfiles.count) driver(s)")
+        }
+
+        if importFlow {
+            onProgress?(.status("Done!"))
+            try? await Task.sleep(for: .seconds(1))
+        }
+    }
+
+    // MARK: - Publish Methods
+
+    /// Publish Kind 0 metadata to Nostr.
+    func publishProfile() async {
+        guard let service = roadflareDomainService else { return }
+        let profile = UserProfileContent(
+            name: settings.profileName,
+            displayName: settings.profileName
+        )
+        do {
+            let event = try await service.publishProfile(profile)
+            roadflareSyncStore?.markPublished(.profile, at: event.createdAt)
+            AppLogger.auth.info("Published profile to Nostr")
+        } catch {
+            AppLogger.auth.info("Failed to publish profile: \(error)")
+        }
+    }
+
+    /// Publish Kind 30177 encrypted profile backup (settings + saved locations) to Nostr.
+    func publishProfileBackup() async {
+        guard let service = roadflareDomainService else { return }
+        if isPublishingProfileBackup {
+            profileBackupRepublishRequested = true
+            return
+        }
+
+        isPublishingProfileBackup = true
+        defer { isPublishingProfileBackup = false }
+
+        repeat {
+            profileBackupRepublishRequested = false
+            let backup = buildProfileBackupContent()
+            do {
+                let event = try await service.publishProfileBackup(backup)
+                roadflareSyncStore?.markPublished(.profileBackup, at: event.createdAt)
+                AppLogger.auth.info("Published profile backup to Nostr")
+            } catch {
+                AppLogger.auth.info("Failed to publish profile backup: \(error)")
+            }
+        } while profileBackupRepublishRequested
+    }
+
+    /// Publish both Kind 0 and Kind 30177.
+    func saveAndPublishSettings() async {
+        await publishProfile()
+        await publishProfileBackup()
+    }
+
+    func buildProfileBackupContent() -> ProfileBackupContent {
+        var settingsBackup = profileBackupSettingsTemplate
+        settingsBackup.roadflarePaymentMethods = settings.roadflarePaymentMethods
+
+        return ProfileBackupContent(
+            savedLocations: savedLocations.locations.map { loc in
+                SavedLocationBackup(
+                    displayName: loc.displayName, lat: loc.latitude, lon: loc.longitude,
+                    addressLine: loc.addressLine,
+                    isPinned: loc.isPinned,
+                    nickname: loc.nickname,
+                    timestampMs: loc.timestampMs
+                )
+            },
+            settings: settingsBackup
+        )
+    }
+
+    func preserveProfileBackupSettingsTemplate(_ settings: SettingsBackupContent) {
+        profileBackupSettingsTemplate = settings
+    }
+
+    // MARK: - Flush on Reconnect
+
+    /// Publish any dirty sync domains. Caller must verify relay connectivity first.
+    func flushPendingSyncPublishes(rideCoordinator: RideCoordinator?) async {
+        guard let syncStore = roadflareSyncStore else { return }
+
+        if syncStore.metadata(for: .profile).isDirty {
+            await publishProfile()
+        }
+        if syncStore.metadata(for: .followedDrivers).isDirty {
+            await rideCoordinator?.publishFollowedDriversList()
+        }
+        if syncStore.metadata(for: .profileBackup).isDirty {
+            await publishProfileBackup()
+        }
+        if syncStore.metadata(for: .rideHistory).isDirty, !rideHistory.rides.isEmpty {
+            do {
+                let content = RideHistoryBackupContent(rides: rideHistory.rides)
+                if let service = roadflareDomainService {
+                    let event = try await service.publishRideHistoryBackup(content)
+                    syncStore.markPublished(.rideHistory, at: event.createdAt)
+                }
+            } catch {
+                // Will retry on next reconnect
+            }
+        }
+    }
+
+    // MARK: - Resolution Methods
+
+    private func applyProfileResolution(
+        remote: RoadflareDomainService.StartupRemoteDomain<UserProfileContent>
+    ) async {
+        guard let syncStore = roadflareSyncStore else { return }
+        let metadata = syncStore.metadata(for: .profile)
+        let resolution = RoadflareDomainService.resolve(
+            domain: .profile, metadata: metadata,
+            remoteCreatedAt: remote.latestSeenCreatedAt
+        )
+        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
+            metadata: metadata, remoteCreatedAt: remote.latestSeenCreatedAt,
+            hasLocalState: !settings.profileName.isEmpty
+        )
+
+        if resolution.source == .remote,
+           let snapshot = remote.snapshot,
+           snapshot.createdAt == remote.latestSeenCreatedAt {
+            let name = snapshot.value.displayName ?? snapshot.value.name ?? ""
+            settings.performWithoutChangeTracking {
+                settings.profileName = name
+            }
+            if !name.isEmpty {
+                AppLogger.auth.info("Restored profile name from Nostr: \(name)")
+            }
+            syncStore.markPublished(.profile, at: snapshot.createdAt)
+        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
+            AppLogger.auth.warning("Latest profile metadata is not decodable; preserving local profile state")
+        } else if resolution.shouldPublishLocal || shouldSeedLegacyLocal {
+            if shouldSeedLegacyLocal { syncStore.markDirty(.profile) }
+            await publishProfile()
+        }
+    }
+
+    private func applyFollowedDriversResolution(
+        repo: FollowedDriversRepository,
+        remote: RoadflareDomainService.StartupRemoteDomain<FollowedDriversContent>
+    ) async {
+        guard let service = roadflareDomainService else { return }
+        guard let syncStore = roadflareSyncStore else { return }
+        let metadata = syncStore.metadata(for: .followedDrivers)
+        let resolution = RoadflareDomainService.resolve(
+            domain: .followedDrivers, metadata: metadata,
+            remoteCreatedAt: remote.latestSeenCreatedAt
+        )
+        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
+            metadata: metadata, remoteCreatedAt: remote.latestSeenCreatedAt,
+            hasLocalState: repo.hasDrivers
+        )
+
+        if resolution.source == .remote,
+           let snapshot = remote.snapshot,
+           snapshot.createdAt == remote.latestSeenCreatedAt {
+            repo.restoreFromNostr(content: snapshot.value)
+            syncStore.markPublished(.followedDrivers, at: snapshot.createdAt)
+            if !snapshot.value.drivers.isEmpty {
+                AppLogger.auth.info("Restored \(snapshot.value.drivers.count) drivers from Nostr")
+            }
+        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
+            AppLogger.auth.warning("Latest followed-drivers snapshot is not decodable; preserving local driver state")
+        } else if resolution.shouldPublishLocal || shouldSeedLegacyLocal {
+            if shouldSeedLegacyLocal { syncStore.markDirty(.followedDrivers) }
+            do {
+                let event = try await service.publishFollowedDriversList(repo.drivers)
+                syncStore.markPublished(.followedDrivers, at: event.createdAt)
+                AppLogger.auth.info("Published followed drivers list to Nostr")
+            } catch {
+                AppLogger.auth.info("Failed to publish followed drivers list: \(error)")
+            }
+        }
+    }
+
+    private func applyProfileBackupResolution(
+        remote: RoadflareDomainService.StartupRemoteDomain<ProfileBackupContent>
+    ) async {
+        guard roadflareDomainService != nil else { return }
+        guard let syncStore = roadflareSyncStore else { return }
+        if let snapshot = remote.snapshot {
+            preserveProfileBackupSettingsTemplate(snapshot.value.settings)
+        }
+        let metadata = syncStore.metadata(for: .profileBackup)
+        let resolution = RoadflareDomainService.resolve(
+            domain: .profileBackup, metadata: metadata,
+            remoteCreatedAt: remote.latestSeenCreatedAt
+        )
+        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
+            metadata: metadata, remoteCreatedAt: remote.latestSeenCreatedAt,
+            hasLocalState: !settings.roadflarePaymentMethods.isEmpty
+                || !savedLocations.locations.isEmpty
+        )
+
+        if resolution.source == .remote,
+           let snapshot = remote.snapshot,
+           snapshot.createdAt == remote.latestSeenCreatedAt {
+            applyRemoteProfileBackup(snapshot.value)
+            syncStore.markPublished(.profileBackup, at: snapshot.createdAt)
+        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
+            AppLogger.auth.warning("Latest profile backup is not decodable; preserving local backup state")
+        } else if resolution.shouldPublishLocal || shouldSeedLegacyLocal {
+            if shouldSeedLegacyLocal { syncStore.markDirty(.profileBackup) }
+            await publishProfileBackup()
+        }
+    }
+
+    private func applyRemoteProfileBackup(_ backup: ProfileBackupContent) {
+        preserveProfileBackupSettingsTemplate(backup.settings)
+        settings.performWithoutChangeTracking {
+            settings.setRoadflarePaymentMethods(backup.settings.roadflarePaymentMethods)
+        }
+
+        savedLocations.restoreFromBackup(backup.savedLocations.map { loc in
+            SavedLocation(
+                latitude: loc.lat,
+                longitude: loc.lon,
+                displayName: loc.displayName,
+                addressLine: loc.addressLine ?? loc.displayName,
+                isPinned: loc.isPinned,
+                nickname: loc.nickname,
+                timestampMs: loc.timestampMs ?? Int(Date.now.timeIntervalSince1970 * 1000)
+            )
+        })
+
+        if !backup.savedLocations.isEmpty {
+            AppLogger.auth.info("Restored \(backup.savedLocations.count) saved locations")
+        }
+    }
+
+    private func applyRideHistoryResolution(
+        remote: RoadflareDomainService.StartupRemoteDomain<RideHistoryBackupContent>
+    ) async {
+        guard let service = roadflareDomainService else { return }
+        guard let syncStore = roadflareSyncStore else { return }
+        let metadata = syncStore.metadata(for: .rideHistory)
+        let resolution = RoadflareDomainService.resolve(
+            domain: .rideHistory, metadata: metadata,
+            remoteCreatedAt: remote.latestSeenCreatedAt
+        )
+        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
+            metadata: metadata, remoteCreatedAt: remote.latestSeenCreatedAt,
+            hasLocalState: !rideHistory.rides.isEmpty
+        )
+
+        if resolution.source == .remote,
+           let snapshot = remote.snapshot,
+           snapshot.createdAt == remote.latestSeenCreatedAt {
+            rideHistory.restoreFromBackup(snapshot.value.rides)
+            syncStore.markPublished(.rideHistory, at: snapshot.createdAt)
+            if !snapshot.value.rides.isEmpty {
+                AppLogger.auth.info("Restored \(snapshot.value.rides.count) ride(s) from Nostr")
+            }
+        } else if (resolution.shouldPublishLocal || shouldSeedLegacyLocal), !rideHistory.rides.isEmpty {
+            if shouldSeedLegacyLocal { syncStore.markDirty(.rideHistory) }
+            do {
+                let content = RideHistoryBackupContent(rides: rideHistory.rides)
+                let event = try await service.publishRideHistoryBackup(content)
+                syncStore.markPublished(.rideHistory, at: event.createdAt)
+                AppLogger.auth.info("Published ride history backup to Nostr")
+            } catch {
+                AppLogger.auth.info("Failed to publish ride history backup: \(error)")
+            }
+        }
+    }
+}

--- a/RoadFlare/RoadFlareTests/RoadFlareTests.swift
+++ b/RoadFlare/RoadFlareTests/RoadFlareTests.swift
@@ -304,30 +304,25 @@ struct AppStateTests {
 
     @MainActor
     @Test func profileBackupContentIncludesPinnedAndRecentLocations() {
-        let appState = AppState()
-        appState.settings.setRoadflarePaymentMethods(["zelle", "venmo-business"])
+        // SyncCoordinator owns buildProfileBackupContent, so test it directly
+        let settings = UserSettings(defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!)
+        let savedLocations = SavedLocationsRepository(persistence: InMemorySavedLocationsPersistence())
+        let rideHistory = RideHistoryRepository(persistence: InMemoryRideHistoryPersistence())
+        let sync = SyncCoordinator(settings: settings, savedLocations: savedLocations, rideHistory: rideHistory)
 
-        appState.savedLocations.save(SavedLocation(
-            id: "fav",
-            latitude: 36.17,
-            longitude: -115.14,
-            displayName: "Home",
-            addressLine: "123 Main St",
-            isPinned: true,
-            nickname: "Home",
-            timestampMs: 100
+        settings.setRoadflarePaymentMethods(["zelle", "venmo-business"])
+        savedLocations.save(SavedLocation(
+            id: "fav", latitude: 36.17, longitude: -115.14,
+            displayName: "Home", addressLine: "123 Main St",
+            isPinned: true, nickname: "Home", timestampMs: 100
         ))
-        appState.savedLocations.save(SavedLocation(
-            id: "recent",
-            latitude: 36.12,
-            longitude: -115.17,
-            displayName: "Airport",
-            addressLine: "Harry Reid Intl",
-            isPinned: false,
-            timestampMs: 200
+        savedLocations.save(SavedLocation(
+            id: "recent", latitude: 36.12, longitude: -115.17,
+            displayName: "Airport", addressLine: "Harry Reid Intl",
+            isPinned: false, timestampMs: 200
         ))
 
-        let backup = appState.buildProfileBackupContent()
+        let backup = sync.buildProfileBackupContent()
 
         #expect(backup.savedLocations.count == 2)
         #expect(backup.savedLocations.contains {
@@ -342,8 +337,12 @@ struct AppStateTests {
 
     @MainActor
     @Test func profileBackupContentPreservesImportedAndroidSettingsTemplate() {
-        let appState = AppState()
-        appState.preserveProfileBackupSettingsTemplate(
+        let settings = UserSettings(defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!)
+        let savedLocations = SavedLocationsRepository(persistence: InMemorySavedLocationsPersistence())
+        let rideHistory = RideHistoryRepository(persistence: InMemoryRideHistoryPersistence())
+        let sync = SyncCoordinator(settings: settings, savedLocations: savedLocations, rideHistory: rideHistory)
+
+        sync.preserveProfileBackupSettingsTemplate(
             SettingsBackupContent(
                 roadflarePaymentMethods: ["cash"],
                 notificationSoundEnabled: false,
@@ -356,9 +355,9 @@ struct AppStateTests {
                 mintUrl: "https://mint.example"
             )
         )
-        appState.settings.setRoadflarePaymentMethods(["zelle", "venmo-business"])
+        settings.setRoadflarePaymentMethods(["zelle", "venmo-business"])
 
-        let backup = appState.buildProfileBackupContent()
+        let backup = sync.buildProfileBackupContent()
 
         #expect(backup.settings.roadflarePaymentMethods == ["zelle", "venmo-business"])
         #expect(backup.settings.notificationSoundEnabled == false)
@@ -372,49 +371,48 @@ struct AppStateTests {
     }
 
     @MainActor
-    @Test func logoutDetachesTrackedRepositoryCallbacksBeforeClearAll() async {
-        let appState = AppState()
-        let defaults = UserDefaults(suiteName: "test_\(UUID().uuidString)")!
-        let syncStore = RoadflareSyncStateStore(defaults: defaults, namespace: UUID().uuidString)
+    @Test func syncCoordinatorTeardownDetachesCallbacksBeforeClearAll() async {
+        let settings = UserSettings(defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!)
+        let savedLocations = SavedLocationsRepository(persistence: InMemorySavedLocationsPersistence())
+        let rideHistory = RideHistoryRepository(persistence: InMemoryRideHistoryPersistence())
+        let sync = SyncCoordinator(settings: settings, savedLocations: savedLocations, rideHistory: rideHistory)
 
-        appState.rideHistory.onRidesChanged = {
-            syncStore.markDirty(.rideHistory)
-        }
-        appState.savedLocations.onChange = {
-            syncStore.markDirty(.profileBackup)
-        }
-        appState.savedLocations.onFavoritesChanged = {
-            syncStore.markDirty(.profileBackup)
-        }
+        let testDefaults = UserDefaults(suiteName: "test_\(UUID().uuidString)")!
+        let syncStore = RoadflareSyncStateStore(defaults: testDefaults, namespace: UUID().uuidString)
+        let relay = FakeRelayManager()
+        try? await relay.connect(to: DefaultRelays.all)
+        let keypair = try! NostrKeypair.generate()
+        let domainService = RoadflareDomainService(relayManager: relay, keypair: keypair)
+        sync.configure(syncStore: syncStore, domainService: domainService)
 
-        appState.rideHistory.addRide(
+        let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+        sync.wireTrackingCallbacks(driversRepo: repo)
+
+        // Add data that would trigger callbacks on clearAll
+        rideHistory.addRide(
             RideHistoryEntry(
-                id: "ride-1",
-                date: .now,
-                counterpartyPubkey: "driver",
-                pickupGeohash: "abc",
-                dropoffGeohash: "def",
+                id: "ride-1", date: .now, counterpartyPubkey: "driver",
+                pickupGeohash: "abc", dropoffGeohash: "def",
                 pickup: Location(latitude: 40, longitude: -74),
                 destination: Location(latitude: 41, longitude: -73),
-                fare: 12.50,
-                paymentMethod: "zelle"
+                fare: 12.50, paymentMethod: "zelle"
             )
         )
-        appState.savedLocations.save(
+        savedLocations.save(
             SavedLocation(
-                id: "home",
-                latitude: 36.17,
-                longitude: -115.14,
-                displayName: "Home",
-                addressLine: "123 Main St",
-                isPinned: true,
-                nickname: "Home"
+                id: "home", latitude: 36.17, longitude: -115.14,
+                displayName: "Home", addressLine: "123 Main St",
+                isPinned: true, nickname: "Home"
             )
         )
 
+        // Clear the syncStore to reset dirty flags, then teardown + clearAll
         syncStore.clearAll()
-        await appState.logout()
+        sync.teardown(clearPersistedState: true)
+        rideHistory.clearAll()
+        savedLocations.clearAll()
 
+        // Callbacks were nil'd before clearAll, so no dirty flags should be set
         #expect(syncStore.metadata(for: .rideHistory).isDirty == false)
         #expect(syncStore.metadata(for: .profileBackup).isDirty == false)
     }


### PR DESCRIPTION
## Summary
Decomposes the 99th-percentile hotspot `AppState.swift` (727 lines, 19 co-change partners, "bug-prone") into focused coordinators:

- **ConnectionCoordinator** (~45 lines): Watchdog task, auto-reconnect. Behavior injected via closures.
- **SyncCoordinator** (~412 lines): Sync resolution for 4 domains, publish methods, dirty tracking, flush-on-reconnect, startup sync orchestration.
- **AppState** (~392 lines, down 46% from 727): Thin shell with auth lifecycle, service init, forwarding methods.

### Key improvements
- All callback lifecycle (wire + teardown) consolidated in SyncCoordinator
- `teardown()` nils ALL callbacks before any `clearAll()` — prevents the stale-callback sync regression
- Settings callbacks moved from `AppState.init()` to `wireTrackingCallbacks()` where they belong
- `completeProfileSetup`/`completePaymentSetup` use `syncCoordinator.markDirty()` forwarding

### Zero view file changes

## Test plan (all verified by pre-push hook)
- [x] SDK tests pass (670/670)
- [x] UI tests pass (26/26)
- [x] App tests pass (85/85)
- [ ] Manual: logout -> re-login -> sync works
- [ ] Manual: background -> foreground reconnects
- [ ] Manual: complete ride -> history backs up

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)