### PR TITLE
Generalize sync resolution + move publish wrappers to SDK

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/ProfileBackupCoordinator.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/ProfileBackupCoordinator.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// Owns profile-backup publish state: Android-originated template field that
+/// round-trips, plus the republish-on-dirty loop machine that coalesces
+/// concurrent publish requests.
+///
+/// Thread safety: NSLock-protected state. The publish state machine is
+/// stricter than the sibling SDK repo pattern — atomic loop-exit and a
+/// generation counter protect against (a) the lost-update race between loop
+/// exit and `defer`, and (b) `clearAll()` firing while a publish is awaiting,
+/// allowing a new session to claim `isPublishing` without conflict. The
+/// `settingsTemplate` field matches sibling pattern (last-writer-wins under
+/// concurrent writers). `applyRemote` / `buildContent` assume
+/// `@MainActor`-serialized callers for multi-step consistency — they snapshot
+/// across multiple repos without holding a single lock.
+public final class ProfileBackupCoordinator: @unchecked Sendable {
+    private let domainService: RoadflareDomainService
+    private weak var syncStoreRef: RoadflareSyncStateStore?
+
+    private let lock = NSLock()
+    private var _settingsTemplate = SettingsBackupContent()
+    private var isPublishing = false
+    private var republishRequested = false
+    /// Bumped by `clearAll()` to invalidate in-flight publish sessions that
+    /// crossed a teardown boundary.
+    private var generation: UInt64 = 0
+
+    /// Current template state. Internal visibility — only needed by tests.
+    /// External callers mutate via `preserveSettingsTemplate` and read via
+    /// `buildContent`.
+    var settingsTemplate: SettingsBackupContent {
+        lock.withLock { _settingsTemplate }
+    }
+
+    public init(domainService: RoadflareDomainService, syncStore: RoadflareSyncStateStore) {
+        self.domainService = domainService
+        self.syncStoreRef = syncStore
+    }
+
+    // MARK: - Template
+
+    /// Preserve Android-originated template fields to round-trip on next publish.
+    public func preserveSettingsTemplate(_ template: SettingsBackupContent) {
+        lock.withLock { _settingsTemplate = template }
+    }
+
+    // MARK: - Apply Remote
+
+    /// Apply a remote backup: update template, restore payment methods via the
+    /// settings repo, restore saved locations. Caller provides repos.
+    public func applyRemote(
+        _ backup: ProfileBackupContent,
+        settings: UserSettingsRepository,
+        savedLocations: SavedLocationsRepository
+    ) {
+        preserveSettingsTemplate(backup.settings)
+        settings.performWithoutChangeTracking {
+            settings.setRoadflarePaymentMethods(backup.settings.roadflarePaymentMethods)
+        }
+        savedLocations.restoreFromBackup(backup.savedLocations.map { loc in
+            SavedLocation(
+                latitude: loc.lat,
+                longitude: loc.lon,
+                displayName: loc.displayName,
+                addressLine: loc.addressLine ?? loc.displayName,
+                isPinned: loc.isPinned,
+                nickname: loc.nickname,
+                timestampMs: loc.timestampMs ?? Int(Date.now.timeIntervalSince1970 * 1000)
+            )
+        })
+        if !backup.savedLocations.isEmpty {
+            RidestrLogger.info("[ProfileBackupCoordinator] Restored \(backup.savedLocations.count) saved locations")
+        }
+    }
+
+    // MARK: - Build Content
+
+    /// Build `ProfileBackupContent` from local state merged with the preserved
+    /// template. Android-originated fields round-trip untouched.
+    public func buildContent(
+        settings: UserSettingsRepository,
+        savedLocations: SavedLocationsRepository
+    ) -> ProfileBackupContent {
+        var settingsBackup = lock.withLock { _settingsTemplate }
+        settingsBackup.roadflarePaymentMethods = settings.roadflarePaymentMethods
+        return ProfileBackupContent(
+            savedLocations: savedLocations.locations.map { loc in
+                SavedLocationBackup(
+                    displayName: loc.displayName,
+                    lat: loc.latitude,
+                    lon: loc.longitude,
+                    addressLine: loc.addressLine,
+                    isPinned: loc.isPinned,
+                    nickname: loc.nickname,
+                    timestampMs: loc.timestampMs
+                )
+            },
+            settings: settingsBackup
+        )
+    }
+
+    // MARK: - Publish
+
+    /// Publish with republish-on-dirty loop: if state changes during publish,
+    /// republish with fresh content before returning.
+    ///
+    /// Correctness notes:
+    /// - Loop exit is atomic: "keep looping" vs "release isPublishing" happens
+    ///   in a single lock critical section.
+    /// - Generation counter invalidates sessions that crossed a `clearAll()`
+    ///   boundary: if `clearAll()` fired mid-await, our entry generation no
+    ///   longer matches, and we exit WITHOUT touching shared state (a new
+    ///   publish session may own it) and WITHOUT calling `markPublished`
+    ///   (identity has changed).
+    public func publishAndMark(
+        settings: UserSettingsRepository,
+        savedLocations: SavedLocationsRepository
+    ) async {
+        var entryGeneration: UInt64 = 0
+        let shouldQueue: Bool = lock.withLock {
+            if isPublishing {
+                republishRequested = true
+                return true
+            }
+            isPublishing = true
+            republishRequested = false
+            entryGeneration = generation
+            return false
+        }
+        guard !shouldQueue else { return }
+
+        while true {
+            let content = buildContent(settings: settings, savedLocations: savedLocations)
+            do {
+                let event = try await domainService.publishProfileBackup(content)
+                let stillValid: Bool = lock.withLock { generation == entryGeneration }
+                if stillValid {
+                    syncStoreRef?.markPublished(.profileBackup, at: event.createdAt)
+                    RidestrLogger.info("[ProfileBackupCoordinator] Published profile backup")
+                }
+            } catch {
+                RidestrLogger.info("[ProfileBackupCoordinator] Failed to publish profile backup: \(error.localizedDescription)")
+            }
+
+            // Atomic exit: either continue with a fresh iteration (consuming
+            // the republish request) OR release isPublishing. If generation
+            // changed, bail without touching shared state.
+            let shouldContinue: Bool = lock.withLock {
+                guard generation == entryGeneration else { return false }
+                if republishRequested {
+                    republishRequested = false
+                    return true
+                }
+                isPublishing = false
+                return false
+            }
+            if !shouldContinue { return }
+        }
+    }
+
+    // MARK: - Cleanup
+
+    /// Reset all state (identity replacement). Bumps `generation` to invalidate
+    /// any in-flight `publishAndMark` session whose await is still pending.
+    public func clearAll() {
+        lock.withLock {
+            _settingsTemplate = SettingsBackupContent()
+            isPublishing = false
+            republishRequested = false
+            generation &+= 1
+        }
+    }
+}

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/RoadflareDomainService.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/RoadflareDomainService.swift
@@ -178,6 +178,55 @@ public final class RoadflareDomainService: @unchecked Sendable {
         return event
     }
 
+    // MARK: - Publish-and-Mark Convenience Helpers
+    //
+    // Each helper: reads from its repo → builds content → publishes → marks
+    // syncStore published on success. Throws swallowed by logging.
+
+    public func publishProfileAndMark(
+        from settings: UserSettingsRepository,
+        syncStore: RoadflareSyncStateStore
+    ) async {
+        let profile = UserProfileContent(
+            name: settings.profileName,
+            displayName: settings.profileName
+        )
+        do {
+            let event = try await publishProfile(profile)
+            syncStore.markPublished(.profile, at: event.createdAt)
+            RidestrLogger.info("[RoadflareDomainService] Published profile")
+        } catch {
+            RidestrLogger.info("[RoadflareDomainService] Failed to publish profile: \(error.localizedDescription)")
+        }
+    }
+
+    public func publishFollowedDriversListAndMark(
+        from repository: FollowedDriversRepository,
+        syncStore: RoadflareSyncStateStore
+    ) async {
+        do {
+            let event = try await publishFollowedDriversList(repository.drivers)
+            syncStore.markPublished(.followedDrivers, at: event.createdAt)
+            RidestrLogger.info("[RoadflareDomainService] Published followed drivers list")
+        } catch {
+            RidestrLogger.info("[RoadflareDomainService] Failed to publish followed drivers list: \(error.localizedDescription)")
+        }
+    }
+
+    public func publishRideHistoryAndMark(
+        from rideHistory: RideHistoryRepository,
+        syncStore: RoadflareSyncStateStore
+    ) async {
+        let content = RideHistoryBackupContent(rides: rideHistory.rides)
+        do {
+            let event = try await publishRideHistoryBackup(content)
+            syncStore.markPublished(.rideHistory, at: event.createdAt)
+            RidestrLogger.info("[RoadflareDomainService] Published ride history backup")
+        } catch {
+            RidestrLogger.info("[RoadflareDomainService] Failed to publish ride history backup: \(error.localizedDescription)")
+        }
+    }
+
     public func fetchLatestRideHistoryState() async -> StartupRemoteDomain<RideHistoryBackupContent> {
         await fetchStartupRideHistoryState()
     }

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainResolver.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainResolver.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Configures how a single sync domain applies remote state and publishes
+/// local state. Provided by the app layer; consumed by `SyncDomainResolver`.
+///
+/// All closures are `@Sendable async` so they can cross actor boundaries.
+/// Callers that need `@MainActor` state access should wrap their work in
+/// `await MainActor.run { … }` inside the closure body.
+public struct SyncDomainStrategy<Value: Sendable>: Sendable {
+    public let domain: RoadflareSyncDomain
+    /// Whether the app has any non-empty local state for this domain.
+    /// Used to decide if legacy local state should seed the first publish.
+    public let hasLocalState: @Sendable () async -> Bool
+    /// Fires BEFORE resolution, whenever a snapshot is present.
+    /// Only `profileBackup` needs this today (Android template preservation).
+    public let onSnapshotSeen: (@Sendable (Value) async -> Void)?
+    /// Fires when remote wins. The resolver calls `markPublished` immediately
+    /// after, so this closure only handles state mutation + logging.
+    public let applyRemote: @Sendable (Value) async -> Void
+    /// Warning logged when the newest remote event is undecodable.
+    /// Logged by the resolver via `RidestrLogger.warning`.
+    public let undecodableWarning: String
+    /// Extra guard checked before `markDirty` / `publishLocal` fire.
+    /// Only `rideHistory` uses this today (`!rides.isEmpty`).
+    public let shouldPublishGuard: @Sendable () async -> Bool
+    /// Full publish flow INCLUDING `markPublished` on success.
+    public let publishLocal: @Sendable () async -> Void
+
+    public init(
+        domain: RoadflareSyncDomain,
+        hasLocalState: @escaping @Sendable () async -> Bool,
+        applyRemote: @escaping @Sendable (Value) async -> Void,
+        undecodableWarning: String,
+        publishLocal: @escaping @Sendable () async -> Void,
+        shouldPublishGuard: @escaping @Sendable () async -> Bool = { true },
+        onSnapshotSeen: (@Sendable (Value) async -> Void)? = nil
+    ) {
+        self.domain = domain
+        self.hasLocalState = hasLocalState
+        self.applyRemote = applyRemote
+        self.undecodableWarning = undecodableWarning
+        self.publishLocal = publishLocal
+        self.shouldPublishGuard = shouldPublishGuard
+        self.onSnapshotSeen = onSnapshotSeen
+    }
+}
+
+/// Generic startup-sync resolver for RoadFlare domains.
+///
+/// Given a `SyncDomainStrategy` and a `StartupRemoteDomain` fetched from the
+/// relay, chooses between remote-wins, local-publish, or legacy-seed based on
+/// the sync metadata. Logs a warning when the newest remote event is
+/// undecodable so local state is preserved without silent data drops.
+///
+/// This is a pure control-flow helper — it does no network I/O itself and
+/// mutates only the supplied `RoadflareSyncStateStore`.
+public enum SyncDomainResolver {
+    public static func apply<Value: Sendable>(
+        strategy: SyncDomainStrategy<Value>,
+        remote: RoadflareDomainService.StartupRemoteDomain<Value>,
+        syncStore: RoadflareSyncStateStore
+    ) async {
+        let metadata = syncStore.metadata(for: strategy.domain)
+        let resolution = RoadflareDomainService.resolve(
+            domain: strategy.domain,
+            metadata: metadata,
+            remoteCreatedAt: remote.latestSeenCreatedAt
+        )
+        let hasLocal = await strategy.hasLocalState()
+        let shouldSeed = RoadflareDomainService.shouldSeedLegacyLocalState(
+            metadata: metadata,
+            remoteCreatedAt: remote.latestSeenCreatedAt,
+            hasLocalState: hasLocal
+        )
+
+        if let snapshot = remote.snapshot {
+            await strategy.onSnapshotSeen?(snapshot.value)
+        }
+
+        if resolution.source == .remote,
+           let snapshot = remote.snapshot,
+           snapshot.createdAt == remote.latestSeenCreatedAt {
+            await strategy.applyRemote(snapshot.value)
+            syncStore.markPublished(strategy.domain, at: snapshot.createdAt)
+        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
+            RidestrLogger.warning("[SyncDomainResolver] \(strategy.undecodableWarning)")
+        } else if (resolution.shouldPublishLocal || shouldSeed), await strategy.shouldPublishGuard() {
+            if shouldSeed { syncStore.markDirty(strategy.domain) }
+            await strategy.publishLocal()
+        }
+    }
+}

--- a/RidestrSDK/Tests/RidestrSDKTests/Nostr/FakeRelayManager.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/Nostr/FakeRelayManager.swift
@@ -44,6 +44,7 @@ public final class FakeRelayManager: RelayManagerProtocol, @unchecked Sendable {
     public var shouldFailPublish = false
     public var shouldFailSubscribe = false
     public var subscribeDelay: Duration?
+    public var publishDelay: Duration?
     private var _isConnected = false
 
     /// Events to return immediately from subscribe calls, keyed by subscription ID.
@@ -98,6 +99,9 @@ public final class FakeRelayManager: RelayManagerProtocol, @unchecked Sendable {
     public func publish(_ event: NostrEvent) async throws -> String {
         if shouldFailPublish {
             throw RidestrError.relay(.notConnected)
+        }
+        if let publishDelay {
+            try? await Task.sleep(for: publishDelay)
         }
         lock.withLock { _publishedEvents.append(event) }
         return event.id

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/ProfileBackupCoordinatorTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/ProfileBackupCoordinatorTests.swift
@@ -151,9 +151,16 @@ struct ProfileBackupCoordinatorTests {
 
         await publishTask.value
 
-        // The new session should have published successfully.
-        // The invalidated old session's markPublished is skipped (stillValid=false).
+        // The new session's publish reached the relay.
         #expect(kit.syncStore.metadata(for: .profileBackup).lastSuccessfulPublishAt > 0)
+
+        // The old session's markPublished was suppressed by the generation
+        // check: the published timestamp must match the SECOND publish, not
+        // the first. Since the second publish ran after the first completed,
+        // its event is the last one in the relay's ordered list.
+        #expect(kit.relay.publishedEvents.count == 2)
+        let lastEvent = kit.relay.publishedEvents.last!
+        #expect(kit.syncStore.metadata(for: .profileBackup).lastSuccessfulPublishAt == lastEvent.createdAt)
     }
 
     @Test func publishAndMarkSecondCallAfterFirstCompletes() async throws {

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/ProfileBackupCoordinatorTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/ProfileBackupCoordinatorTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+@testable import RidestrSDK
+
+@Suite("ProfileBackupCoordinator Tests")
+struct ProfileBackupCoordinatorTests {
+    private func makeKit() async throws -> (
+        coordinator: ProfileBackupCoordinator,
+        service: RoadflareDomainService,
+        syncStore: RoadflareSyncStateStore,
+        settings: UserSettingsRepository,
+        savedLocations: SavedLocationsRepository,
+        relay: FakeRelayManager
+    ) {
+        let keypair = try NostrKeypair.generate()
+        let relay = FakeRelayManager()
+        try await relay.connect(to: [URL(string: "wss://fake")!])
+        let service = RoadflareDomainService(relayManager: relay, keypair: keypair)
+        let syncStore = RoadflareSyncStateStore(
+            defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+            namespace: UUID().uuidString
+        )
+        let coordinator = ProfileBackupCoordinator(domainService: service, syncStore: syncStore)
+        let settings = UserSettingsRepository(persistence: InMemoryUserSettingsPersistence())
+        let savedLocations = SavedLocationsRepository(persistence: InMemorySavedLocationsPersistence())
+        return (coordinator, service, syncStore, settings, savedLocations, relay)
+    }
+
+    @Test func preserveSettingsTemplateStoresValue() async throws {
+        let kit = try await makeKit()
+        let template = SettingsBackupContent(
+            roadflarePaymentMethods: ["cash"],
+            mintUrl: "https://mint.example"
+        )
+        kit.coordinator.preserveSettingsTemplate(template)
+        #expect(kit.coordinator.settingsTemplate.roadflarePaymentMethods == ["cash"])
+        #expect(kit.coordinator.settingsTemplate.mintUrl == "https://mint.example")
+    }
+
+    @Test func buildContentMergesTemplateAndRepos() async throws {
+        let kit = try await makeKit()
+        kit.coordinator.preserveSettingsTemplate(
+            SettingsBackupContent(
+                roadflarePaymentMethods: ["cash"],
+                notificationSoundEnabled: false,
+                mintUrl: "https://mint.example"
+            )
+        )
+        kit.settings.setRoadflarePaymentMethods(["zelle", "venmo"])
+        kit.savedLocations.save(SavedLocation(
+            latitude: 36.17, longitude: -115.14,
+            displayName: "Home", addressLine: "123 Main",
+            isPinned: true, nickname: "Home"
+        ))
+
+        let content = kit.coordinator.buildContent(settings: kit.settings, savedLocations: kit.savedLocations)
+
+        #expect(content.settings.roadflarePaymentMethods == ["zelle", "venmo"])
+        #expect(content.settings.notificationSoundEnabled == false)
+        #expect(content.settings.mintUrl == "https://mint.example")
+        #expect(content.savedLocations.count == 1)
+        #expect(content.savedLocations.first?.displayName == "Home")
+    }
+
+    @Test func applyRemoteRestoresState() async throws {
+        let kit = try await makeKit()
+        let backup = ProfileBackupContent(
+            savedLocations: [
+                SavedLocationBackup(
+                    displayName: "Work", lat: 36.10, lon: -115.10,
+                    addressLine: "Downtown", isPinned: true, nickname: "Work", timestampMs: 100
+                )
+            ],
+            settings: SettingsBackupContent(roadflarePaymentMethods: ["cash"])
+        )
+
+        kit.coordinator.applyRemote(backup, settings: kit.settings, savedLocations: kit.savedLocations)
+
+        #expect(kit.settings.roadflarePaymentMethods == ["cash"])
+        #expect(kit.savedLocations.locations.count == 1)
+        #expect(kit.savedLocations.locations.first?.displayName == "Work")
+        #expect(kit.coordinator.settingsTemplate.roadflarePaymentMethods == ["cash"])
+    }
+
+    @Test func publishAndMarkCallsMarkPublished() async throws {
+        let kit = try await makeKit()
+        kit.settings.setRoadflarePaymentMethods(["zelle"])
+
+        await kit.coordinator.publishAndMark(settings: kit.settings, savedLocations: kit.savedLocations)
+
+        #expect(kit.syncStore.metadata(for: .profileBackup).lastSuccessfulPublishAt > 0)
+        #expect(kit.relay.publishedEvents.count == 1)
+    }
+
+    @Test func publishAndMarkRepublishLoopCoalesces() async throws {
+        let kit = try await makeKit()
+        kit.settings.setRoadflarePaymentMethods(["zelle"])
+
+        // Fire two concurrent calls — second should coalesce into a republish.
+        async let first: Void = kit.coordinator.publishAndMark(settings: kit.settings, savedLocations: kit.savedLocations)
+        async let second: Void = kit.coordinator.publishAndMark(settings: kit.settings, savedLocations: kit.savedLocations)
+        _ = await (first, second)
+
+        // First call publishes once, second sets republishRequested → first loops and publishes again.
+        // Since the relay is fake and completes immediately, the second call's guard may or may not
+        // coalesce in time. We accept either 1 or 2 published events (both are valid outcomes).
+        #expect(kit.relay.publishedEvents.count >= 1)
+    }
+
+    @Test func publishAndMarkFailurePathSkipsMarkPublished() async throws {
+        let kit = try await makeKit()
+        kit.relay.shouldFailPublish = true
+        kit.settings.setRoadflarePaymentMethods(["zelle"])
+
+        await kit.coordinator.publishAndMark(settings: kit.settings, savedLocations: kit.savedLocations)
+
+        #expect(kit.syncStore.metadata(for: .profileBackup).lastSuccessfulPublishAt == 0)
+    }
+
+    @Test func clearAllResetsTemplateAndState() async throws {
+        let kit = try await makeKit()
+        kit.coordinator.preserveSettingsTemplate(
+            SettingsBackupContent(roadflarePaymentMethods: ["cash"])
+        )
+
+        kit.coordinator.clearAll()
+
+        #expect(kit.coordinator.settingsTemplate.roadflarePaymentMethods.isEmpty)
+    }
+
+    @Test func clearAllDuringInFlightPublishDoesNotClobberNewSession() async throws {
+        let kit = try await makeKit()
+        kit.settings.setRoadflarePaymentMethods(["zelle"])
+
+        // Use a slow publish to create an await window
+        kit.relay.publishDelay = .milliseconds(100)
+
+        let publishTask = Task {
+            await kit.coordinator.publishAndMark(settings: kit.settings, savedLocations: kit.savedLocations)
+        }
+
+        // Let publish start its await
+        try await Task.sleep(for: .milliseconds(20))
+
+        // Fire clearAll during publish (bumps generation)
+        kit.coordinator.clearAll()
+
+        // New publish session starts clean
+        kit.settings.setRoadflarePaymentMethods(["venmo"])
+        await kit.coordinator.publishAndMark(settings: kit.settings, savedLocations: kit.savedLocations)
+
+        await publishTask.value
+
+        // The new session should have published successfully.
+        // The invalidated old session's markPublished is skipped (stillValid=false).
+        #expect(kit.syncStore.metadata(for: .profileBackup).lastSuccessfulPublishAt > 0)
+    }
+
+    @Test func publishAndMarkSecondCallAfterFirstCompletes() async throws {
+        let kit = try await makeKit()
+        kit.settings.setRoadflarePaymentMethods(["zelle"])
+
+        await kit.coordinator.publishAndMark(settings: kit.settings, savedLocations: kit.savedLocations)
+        let firstTimestamp = kit.syncStore.metadata(for: .profileBackup).lastSuccessfulPublishAt
+
+        try await Task.sleep(for: .milliseconds(10))
+        kit.settings.setRoadflarePaymentMethods(["venmo"])
+        await kit.coordinator.publishAndMark(settings: kit.settings, savedLocations: kit.savedLocations)
+
+        let secondTimestamp = kit.syncStore.metadata(for: .profileBackup).lastSuccessfulPublishAt
+        #expect(secondTimestamp >= firstTimestamp)
+        #expect(kit.relay.publishedEvents.count == 2)
+    }
+}

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RoadflareDomainServiceTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RoadflareDomainServiceTests.swift
@@ -325,4 +325,66 @@ struct RoadflareDomainServiceTests {
         #expect(profiles["driver-a"]?.value.name == "Older A")
         #expect(profiles["driver-a"]?.createdAt == 100)
     }
+
+    // MARK: - publishAndMark Convenience Helpers
+
+    @Test func publishProfileAndMarkMarksSyncStore() async throws {
+        let keypair = try NostrKeypair.generate()
+        let relay = FakeRelayManager()
+        try await relay.connect(to: [URL(string: "wss://fake")!])
+        let service = RoadflareDomainService(relayManager: relay, keypair: keypair)
+        let syncStore = RoadflareSyncStateStore(
+            defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+            namespace: UUID().uuidString
+        )
+        let settings = UserSettingsRepository(persistence: InMemoryUserSettingsPersistence())
+        _ = settings.setProfileName("Alice")
+
+        await service.publishProfileAndMark(from: settings, syncStore: syncStore)
+
+        #expect(syncStore.metadata(for: .profile).lastSuccessfulPublishAt > 0)
+        #expect(relay.publishedEvents.count == 1)
+    }
+
+    @Test func publishFollowedDriversListAndMarkMarksSyncStore() async throws {
+        let keypair = try NostrKeypair.generate()
+        let relay = FakeRelayManager()
+        try await relay.connect(to: [URL(string: "wss://fake")!])
+        let service = RoadflareDomainService(relayManager: relay, keypair: keypair)
+        let syncStore = RoadflareSyncStateStore(
+            defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+            namespace: UUID().uuidString
+        )
+        let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+        repo.addDriver(FollowedDriver(pubkey: "d1", addedAt: 100, name: "Alice"))
+
+        await service.publishFollowedDriversListAndMark(from: repo, syncStore: syncStore)
+
+        #expect(syncStore.metadata(for: .followedDrivers).lastSuccessfulPublishAt > 0)
+        #expect(relay.publishedEvents.count == 1)
+    }
+
+    @Test func publishRideHistoryAndMarkMarksSyncStore() async throws {
+        let keypair = try NostrKeypair.generate()
+        let relay = FakeRelayManager()
+        try await relay.connect(to: [URL(string: "wss://fake")!])
+        let service = RoadflareDomainService(relayManager: relay, keypair: keypair)
+        let syncStore = RoadflareSyncStateStore(
+            defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+            namespace: UUID().uuidString
+        )
+        let history = RideHistoryRepository(persistence: InMemoryRideHistoryPersistence())
+        history.addRide(RideHistoryEntry(
+            id: "r1", date: .now, counterpartyPubkey: "driver",
+            pickupGeohash: "abc", dropoffGeohash: "def",
+            pickup: Location(latitude: 40, longitude: -74),
+            destination: Location(latitude: 41, longitude: -73),
+            fare: 10.0, paymentMethod: "zelle"
+        ))
+
+        await service.publishRideHistoryAndMark(from: history, syncStore: syncStore)
+
+        #expect(syncStore.metadata(for: .rideHistory).lastSuccessfulPublishAt > 0)
+        #expect(relay.publishedEvents.count == 1)
+    }
 }

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainResolverTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainResolverTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Testing
+@testable import RidestrSDK
+
+private struct TestValue: Sendable, Equatable {
+    let payload: String
+}
+
+private final class CallRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _applyRemoteCalls: [String] = []
+    private var _publishLocalCalls: Int = 0
+    private var _snapshotSeenCalls: [String] = []
+
+    var applyRemoteCalls: [String] { lock.withLock { _applyRemoteCalls } }
+    var publishLocalCalls: Int { lock.withLock { _publishLocalCalls } }
+    var snapshotSeenCalls: [String] { lock.withLock { _snapshotSeenCalls } }
+
+    func recordApplyRemote(_ s: String) { lock.withLock { _applyRemoteCalls.append(s) } }
+    func recordPublishLocal() { lock.withLock { _publishLocalCalls += 1 } }
+    func recordSnapshotSeen(_ s: String) { lock.withLock { _snapshotSeenCalls.append(s) } }
+}
+
+@Suite("SyncDomainResolver Tests")
+struct SyncDomainResolverTests {
+    private func makeSyncStore() -> RoadflareSyncStateStore {
+        RoadflareSyncStateStore(
+            defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+            namespace: UUID().uuidString
+        )
+    }
+
+    private func makeStrategy(
+        recorder: CallRecorder,
+        hasLocalState: @escaping @Sendable () -> Bool = { false },
+        shouldPublishGuard: @escaping @Sendable () -> Bool = { true },
+        includeSnapshotSeen: Bool = false
+    ) -> SyncDomainStrategy<TestValue> {
+        let onSnapshotSeen: (@Sendable (TestValue) async -> Void)? = includeSnapshotSeen
+            ? { @Sendable value in recorder.recordSnapshotSeen(value.payload) }
+            : nil
+        return SyncDomainStrategy<TestValue>(
+            domain: .profile,
+            hasLocalState: { @Sendable in hasLocalState() },
+            applyRemote: { @Sendable value in recorder.recordApplyRemote(value.payload) },
+            undecodableWarning: "test undecodable warning",
+            publishLocal: { @Sendable in recorder.recordPublishLocal() },
+            shouldPublishGuard: { @Sendable in shouldPublishGuard() },
+            onSnapshotSeen: onSnapshotSeen
+        )
+    }
+
+    private func makeRemote(
+        latestSeen: Int?,
+        snapshot: RoadflareRemoteSnapshot<TestValue>?
+    ) -> RoadflareDomainService.StartupRemoteDomain<TestValue> {
+        RoadflareDomainService.StartupRemoteDomain(
+            latestSeenCreatedAt: latestSeen,
+            snapshot: snapshot
+        )
+    }
+
+    // Test 1: Remote snapshot wins (fresh + decodable + metadata clean)
+    @Test func remoteWinsAppliesSnapshotAndMarksPublished() async {
+        let syncStore = makeSyncStore()
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(recorder: recorder)
+        let snapshot = RoadflareRemoteSnapshot(eventId: "e1", createdAt: 100, value: TestValue(payload: "remote"))
+        let remote = makeRemote(latestSeen: 100, snapshot: snapshot)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.applyRemoteCalls == ["remote"])
+        #expect(recorder.publishLocalCalls == 0)
+        #expect(syncStore.metadata(for: .profile).lastSuccessfulPublishAt == 100)
+    }
+
+    // Test 2: Remote newer but undecodable → warn only, no state change
+    @Test func remoteNewerButUndecodableOnlyWarns() async {
+        let syncStore = makeSyncStore()
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(recorder: recorder)
+        let remote = makeRemote(latestSeen: 100, snapshot: nil)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.applyRemoteCalls.isEmpty)
+        #expect(recorder.publishLocalCalls == 0)
+        #expect(syncStore.metadata(for: .profile).lastSuccessfulPublishAt == 0)
+    }
+
+    // Test 3: Stale-but-decodable snapshot → treated as undecodable
+    @Test func staleDecodableSnapshotTreatedAsUndecodable() async {
+        let syncStore = makeSyncStore()
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(recorder: recorder)
+        let snapshot = RoadflareRemoteSnapshot(eventId: "e1", createdAt: 50, value: TestValue(payload: "stale"))
+        let remote = makeRemote(latestSeen: 100, snapshot: snapshot)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.applyRemoteCalls.isEmpty)
+        #expect(recorder.publishLocalCalls == 0)
+        #expect(syncStore.metadata(for: .profile).lastSuccessfulPublishAt == 0)
+    }
+
+    // Test 4: Local dirty → publishLocal called
+    @Test func localDirtyPublishes() async {
+        let syncStore = makeSyncStore()
+        syncStore.markDirty(.profile)
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(recorder: recorder)
+        let snapshot = RoadflareRemoteSnapshot(eventId: "e1", createdAt: 100, value: TestValue(payload: "remote"))
+        let remote = makeRemote(latestSeen: 100, snapshot: snapshot)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.applyRemoteCalls.isEmpty)
+        #expect(recorder.publishLocalCalls == 1)
+    }
+
+    // Test 5: Seed legacy (remote absent, metadata pristine, hasLocalState=true)
+    @Test func seedLegacyMarksDirtyThenPublishes() async {
+        let syncStore = makeSyncStore()
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(recorder: recorder, hasLocalState: { true })
+        let remote = makeRemote(latestSeen: nil, snapshot: nil)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.publishLocalCalls == 1)
+    }
+
+    // Test 6: Seed blocked by absent local state
+    @Test func seedBlockedByAbsentLocalState() async {
+        let syncStore = makeSyncStore()
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(recorder: recorder, hasLocalState: { false })
+        let remote = makeRemote(latestSeen: nil, snapshot: nil)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.applyRemoteCalls.isEmpty)
+        #expect(recorder.publishLocalCalls == 0)
+        #expect(!syncStore.metadata(for: .profile).isDirty)
+    }
+
+    // Test 7: Seed blocked by shouldPublishGuard=false → critical: no markDirty
+    @Test func seedBlockedByGuardDoesNotMarkDirty() async {
+        let syncStore = makeSyncStore()
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(
+            recorder: recorder,
+            hasLocalState: { true },
+            shouldPublishGuard: { false }
+        )
+        let remote = makeRemote(latestSeen: nil, snapshot: nil)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.publishLocalCalls == 0)
+        #expect(!syncStore.metadata(for: .profile).isDirty)
+    }
+
+    // Test 8: onSnapshotSeen fires regardless of resolution (local wins)
+    @Test func onSnapshotSeenFiresEvenWhenLocalWins() async {
+        let syncStore = makeSyncStore()
+        syncStore.markPublished(.profile, at: 200)  // local is newer
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(recorder: recorder, includeSnapshotSeen: true)
+        let snapshot = RoadflareRemoteSnapshot(eventId: "e1", createdAt: 100, value: TestValue(payload: "seen"))
+        let remote = makeRemote(latestSeen: 100, snapshot: snapshot)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.snapshotSeenCalls == ["seen"])
+        #expect(recorder.applyRemoteCalls.isEmpty)
+    }
+
+    // Test 9: onSnapshotSeen absent when snapshot nil
+    @Test func onSnapshotSeenNotCalledWhenSnapshotNil() async {
+        let syncStore = makeSyncStore()
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(recorder: recorder, hasLocalState: { true }, includeSnapshotSeen: true)
+        let remote = makeRemote(latestSeen: nil, snapshot: nil)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.snapshotSeenCalls.isEmpty)
+    }
+
+    // Test 10: Equal timestamps resolve to local (strict `>` in resolve)
+    @Test func equalTimestampsResolveLocal() async {
+        let syncStore = makeSyncStore()
+        syncStore.markPublished(.profile, at: 100)
+        let recorder = CallRecorder()
+        let strategy = makeStrategy(recorder: recorder)
+        let snapshot = RoadflareRemoteSnapshot(eventId: "e1", createdAt: 100, value: TestValue(payload: "equal"))
+        let remote = makeRemote(latestSeen: 100, snapshot: snapshot)
+
+        await SyncDomainResolver.apply(strategy: strategy, remote: remote, syncStore: syncStore)
+
+        #expect(recorder.applyRemoteCalls.isEmpty)
+    }
+}

--- a/RoadFlare/RoadFlare/RoadFlareApp.swift
+++ b/RoadFlare/RoadFlare/RoadFlareApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 import RidestrSDK
 
 @main
@@ -6,6 +7,20 @@ struct RoadFlareApp: App {
     @State private var appState = AppState()
     @State private var isHandlingForeground = false
     @Environment(\.scenePhase) private var scenePhase
+
+    init() {
+        // Route SDK log output through os.Logger via AppLogger.sdk so SDK
+        // info/warning lines surface in Console.app. Without this, every
+        // RidestrLogger call in the SDK is silently discarded.
+        RidestrLogger.handler = { level, message, _, _ in
+            switch level {
+            case .debug: AppLogger.sdk.debug("\(message)")
+            case .info: AppLogger.sdk.info("\(message)")
+            case .warning: AppLogger.sdk.warning("\(message)")
+            case .error: AppLogger.sdk.error("\(message)")
+            }
+        }
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/RoadFlare/RoadFlare/RoadFlareApp.swift
+++ b/RoadFlare/RoadFlare/RoadFlareApp.swift
@@ -1,6 +1,4 @@
 import SwiftUI
-import os
-import RidestrSDK
 
 @main
 struct RoadFlareApp: App {
@@ -9,17 +7,7 @@ struct RoadFlareApp: App {
     @Environment(\.scenePhase) private var scenePhase
 
     init() {
-        // Route SDK log output through os.Logger via AppLogger.sdk so SDK
-        // info/warning lines surface in Console.app. Without this, every
-        // RidestrLogger call in the SDK is silently discarded.
-        RidestrLogger.handler = { level, message, _, _ in
-            switch level {
-            case .debug: AppLogger.sdk.debug("\(message)")
-            case .info: AppLogger.sdk.info("\(message)")
-            case .warning: AppLogger.sdk.warning("\(message)")
-            case .error: AppLogger.sdk.error("\(message)")
-            }
-        }
+        AppLogger.bootstrapSDKLogging()
     }
 
     var body: some Scene {

--- a/RoadFlare/RoadFlare/Services/AppLogger.swift
+++ b/RoadFlare/RoadFlare/Services/AppLogger.swift
@@ -1,4 +1,5 @@
 import os
+import RidestrSDK
 
 /// Centralized logging for the RoadFlare app.
 /// Uses os.Logger for proper system integration — shows in Console.app,
@@ -12,4 +13,19 @@ enum AppLogger {
     static let location = Logger(subsystem: subsystem, category: "location")
     static let auth = Logger(subsystem: subsystem, category: "auth")
     static let sdk = Logger(subsystem: subsystem, category: "sdk")
+
+    /// Wire `RidestrLogger.handler` so SDK log output surfaces through
+    /// `AppLogger.sdk`. Without this, every `RidestrLogger.info/warning/error`
+    /// call in the SDK is silently discarded. Must be called at app launch
+    /// BEFORE any SDK code runs.
+    static func bootstrapSDKLogging() {
+        RidestrLogger.handler = { level, message, _, _ in
+            switch level {
+            case .debug: sdk.debug("\(message)")
+            case .info: sdk.info("\(message)")
+            case .warning: sdk.warning("\(message)")
+            case .error: sdk.error("\(message)")
+            }
+        }
+    }
 }

--- a/RoadFlare/RoadFlare/Services/AppLogger.swift
+++ b/RoadFlare/RoadFlare/Services/AppLogger.swift
@@ -11,4 +11,5 @@ enum AppLogger {
     static let ride = Logger(subsystem: subsystem, category: "ride")
     static let location = Logger(subsystem: subsystem, category: "location")
     static let auth = Logger(subsystem: subsystem, category: "auth")
+    static let sdk = Logger(subsystem: subsystem, category: "sdk")
 }

--- a/RoadFlare/RoadFlare/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlare/ViewModels/AppState.swift
@@ -138,7 +138,7 @@ final class AppState {
     func completeProfileSetup(name: String) async {
         settings.setProfileName(name)
         syncCoordinator?.markDirty(.profile)
-        await syncCoordinator?.publishProfile()
+        await publishProfile()
         authState = .paymentSetup
     }
 
@@ -146,23 +146,37 @@ final class AppState {
     func completePaymentSetup() async {
         settings.setProfileCompleted(true)
         syncCoordinator?.markDirty(.profileBackup)
-        await syncCoordinator?.saveAndPublishSettings()
+        await saveAndPublishSettings()
         authState = .ready
     }
 
-    // MARK: - Forwarding to SyncCoordinator
+    // MARK: - Forwarding to SDK (through SyncCoordinator)
 
-    func publishProfile() async { await syncCoordinator?.publishProfile() }
-    func publishProfileBackup() async { await syncCoordinator?.publishProfileBackup() }
-    func saveAndPublishSettings() async { await syncCoordinator?.saveAndPublishSettings() }
+    func publishProfile() async {
+        guard let service = roadflareDomainService,
+              let syncStore = syncCoordinator?.roadflareSyncStore else { return }
+        await service.publishProfileAndMark(from: settings, syncStore: syncStore)
+    }
+
+    func publishProfileBackup() async {
+        await syncCoordinator?.profileBackupCoordinator?.publishAndMark(
+            settings: settings, savedLocations: savedLocations
+        )
+    }
+
+    func saveAndPublishSettings() async {
+        await publishProfile()
+        await publishProfileBackup()
+    }
 
     func buildProfileBackupContent() -> ProfileBackupContent {
-        syncCoordinator?.buildProfileBackupContent()
-            ?? ProfileBackupContent(savedLocations: [], settings: SettingsBackupContent())
+        syncCoordinator?.profileBackupCoordinator?.buildContent(
+            settings: settings, savedLocations: savedLocations
+        ) ?? ProfileBackupContent(savedLocations: [], settings: SettingsBackupContent())
     }
 
     func preserveProfileBackupSettingsTemplate(_ s: SettingsBackupContent) {
-        syncCoordinator?.preserveProfileBackupSettingsTemplate(s)
+        syncCoordinator?.profileBackupCoordinator?.preserveSettingsTemplate(s)
     }
 
     // MARK: - Driver Key Management

--- a/RoadFlare/RoadFlare/ViewModels/SyncCoordinator.swift
+++ b/RoadFlare/RoadFlare/ViewModels/SyncCoordinator.swift
@@ -131,7 +131,7 @@ final class SyncCoordinator {
                 await MainActor.run {
                     let name = value.displayName ?? value.name ?? ""
                     settings.performWithoutChangeTracking {
-                        _ = settings.setProfileName(name, allowEmpty: true)
+                        _ = settings.setProfileName(name)
                     }
                     if !name.isEmpty {
                         AppLogger.auth.info("Restored profile name from Nostr: \(name)")

--- a/RoadFlare/RoadFlare/ViewModels/SyncCoordinator.swift
+++ b/RoadFlare/RoadFlare/ViewModels/SyncCoordinator.swift
@@ -10,21 +10,18 @@ enum SyncProgress {
     case locationsRestored(count: Int)
 }
 
-/// Owns Nostr sync orchestration: startup resolution, publish methods,
-/// dirty tracking callbacks, and flush-on-reconnect.
-///
-/// AppState creates and holds this privately. Views never access it directly.
-/// All sync-related state (roadflareSyncStore, publish flags, backup template)
-/// lives here instead of on AppState, reducing AppState's responsibility surface.
+/// Owns Nostr sync orchestration: startup resolution, callback wiring, and
+/// teardown. Publish wrappers and state machines live in the SDK (see
+/// `ProfileBackupCoordinator` and `RoadflareDomainService.publishXAndMark`
+/// helpers). This class is pure wiring between AppState-owned state and
+/// SDK-provided sync primitives.
 @MainActor
 final class SyncCoordinator {
     // MARK: - Owned State
 
     private(set) var roadflareSyncStore: RoadflareSyncStateStore?
     private(set) var roadflareDomainService: RoadflareDomainService?
-    private var isPublishingProfileBackup = false
-    private var profileBackupRepublishRequested = false
-    private var profileBackupSettingsTemplate = SettingsBackupContent()
+    private(set) var profileBackupCoordinator: ProfileBackupCoordinator?
 
     // MARK: - Injected References (owned by AppState)
 
@@ -48,6 +45,9 @@ final class SyncCoordinator {
     func configure(syncStore: RoadflareSyncStateStore, domainService: RoadflareDomainService) {
         self.roadflareSyncStore = syncStore
         self.roadflareDomainService = domainService
+        self.profileBackupCoordinator = ProfileBackupCoordinator(
+            domainService: domainService, syncStore: syncStore
+        )
     }
 
     /// Forward markDirty for AppState methods that need it (completeProfileSetup, etc.)
@@ -58,19 +58,14 @@ final class SyncCoordinator {
     // MARK: - Tracking Callbacks
 
     /// Wire ALL change-tracking callbacks: settings + repositories.
-    /// Replaces: configureDriversRepositoryTracking, configureRideHistoryTracking,
-    ///           configureSavedLocationsTracking, and settings callbacks from AppState.init().
     /// MUST be called after configure() so roadflareSyncStore is set.
     func wireTrackingCallbacks(driversRepo: FollowedDriversRepository) {
         let store = roadflareSyncStore
         trackedDriversRepo = driversRepo
 
-        // Settings callbacks (previously in AppState.init — safe to move since
-        // they no-op before setup via optional chaining anyway)
         settings.onProfileChanged = { store?.markDirty(.profile) }
         settings.onProfileBackupChanged = { store?.markDirty(.profileBackup) }
 
-        // Repository callbacks
         driversRepo.onDriversChanged = { source in
             guard source == .local else { return }
             store?.markDirty(.followedDrivers)
@@ -81,11 +76,11 @@ final class SyncCoordinator {
 
     // MARK: - Teardown
 
-    /// Detach ALL callbacks and clear sync state. Called during identity replacement.
-    /// MUST be called BEFORE any clearAll() calls on repositories to prevent
-    /// stale callbacks from writing dirty flags.
+    /// Detach ALL callbacks, clear sync state, and release the profile backup
+    /// coordinator. Called during identity replacement. MUST be called BEFORE
+    /// any clearAll() calls on repositories to prevent stale callbacks from
+    /// writing dirty flags.
     func teardown(clearPersistedState: Bool) {
-        // Detach all callbacks first
         settings.onProfileChanged = nil
         settings.onProfileBackupChanged = nil
         trackedDriversRepo?.onDriversChanged = nil
@@ -93,18 +88,19 @@ final class SyncCoordinator {
         savedLocations.onChange = nil
         savedLocations.onFavoritesChanged = nil
 
-        // Clear sync store
+        profileBackupCoordinator?.clearAll()
+        profileBackupCoordinator = nil
+
         if clearPersistedState {
             roadflareSyncStore?.clearAll()
         }
         roadflareSyncStore = nil
         roadflareDomainService = nil
-        profileBackupSettingsTemplate = SettingsBackupContent()
     }
 
     // MARK: - Startup Sync
 
-    /// Orchestrate startup sync across all 4 domains.
+    /// Orchestrate startup sync across all 4 domains using SyncDomainResolver.
     /// - Parameters:
     ///   - repo: The followed drivers repository (created by AppState during setup).
     ///   - importFlow: Whether to report progress for the sync UI screen.
@@ -114,24 +110,120 @@ final class SyncCoordinator {
         importFlow: Bool,
         onProgress: (@MainActor (SyncProgress) -> Void)? = nil
     ) async {
-        guard let service = roadflareDomainService else { return }
+        guard let service = roadflareDomainService,
+              let syncStore = roadflareSyncStore,
+              let backupCoordinator = profileBackupCoordinator else { return }
 
         let remote = await service.fetchStartupRemoteState()
 
+        // Strategy captures (non-isolated Sendable closures wrap @MainActor state)
+        let settings = self.settings
+        let savedLocations = self.savedLocations
+        let rideHistory = self.rideHistory
+
+        // Profile (Kind 0)
+        let profileStrategy = SyncDomainStrategy<UserProfileContent>(
+            domain: .profile,
+            hasLocalState: { @Sendable in
+                await MainActor.run { !settings.profileName.isEmpty }
+            },
+            applyRemote: { @Sendable value in
+                await MainActor.run {
+                    let name = value.displayName ?? value.name ?? ""
+                    settings.performWithoutChangeTracking {
+                        _ = settings.setProfileName(name, allowEmpty: true)
+                    }
+                    if !name.isEmpty {
+                        AppLogger.auth.info("Restored profile name from Nostr: \(name)")
+                    }
+                }
+            },
+            undecodableWarning: "Latest profile metadata is not decodable; preserving local profile state",
+            publishLocal: { @Sendable in
+                await service.publishProfileAndMark(from: settings, syncStore: syncStore)
+            }
+        )
+
         if importFlow { onProgress?(.status("Restoring your profile...")) }
-        await applyProfileResolution(remote: remote.profile)
+        await SyncDomainResolver.apply(strategy: profileStrategy, remote: remote.profile, syncStore: syncStore)
         if importFlow { onProgress?(.profileRestored(nameFound: !settings.profileName.isEmpty)) }
 
+        // Followed Drivers (Kind 30011)
+        let driversStrategy = SyncDomainStrategy<FollowedDriversContent>(
+            domain: .followedDrivers,
+            hasLocalState: { @Sendable [weak repo] in
+                await MainActor.run { repo?.hasDrivers ?? false }
+            },
+            applyRemote: { @Sendable [weak repo] value in
+                await MainActor.run {
+                    repo?.restoreFromNostr(content: value)
+                    if !value.drivers.isEmpty {
+                        AppLogger.auth.info("Restored \(value.drivers.count) drivers from Nostr")
+                    }
+                }
+            },
+            undecodableWarning: "Latest followed-drivers snapshot is not decodable; preserving local driver state",
+            publishLocal: { @Sendable [weak repo] in
+                guard let repo else { return }
+                await service.publishFollowedDriversListAndMark(from: repo, syncStore: syncStore)
+            }
+        )
+
         if importFlow { onProgress?(.status("Restoring your drivers...")) }
-        await applyFollowedDriversResolution(repo: repo, remote: remote.followedDrivers)
+        await SyncDomainResolver.apply(strategy: driversStrategy, remote: remote.followedDrivers, syncStore: syncStore)
         if importFlow { onProgress?(.driversRestored(count: repo.drivers.count)) }
 
+        // Profile Backup (Kind 30177)
+        let backupStrategy = SyncDomainStrategy<ProfileBackupContent>(
+            domain: .profileBackup,
+            hasLocalState: { @Sendable in
+                await MainActor.run {
+                    !settings.roadflarePaymentMethods.isEmpty || !savedLocations.locations.isEmpty
+                }
+            },
+            applyRemote: { @Sendable value in
+                await MainActor.run {
+                    backupCoordinator.applyRemote(value, settings: settings, savedLocations: savedLocations)
+                }
+            },
+            undecodableWarning: "Latest profile backup is not decodable; preserving local backup state",
+            publishLocal: { @Sendable in
+                await backupCoordinator.publishAndMark(settings: settings, savedLocations: savedLocations)
+            },
+            onSnapshotSeen: { @Sendable value in
+                backupCoordinator.preserveSettingsTemplate(value.settings)
+            }
+        )
+
         if importFlow { onProgress?(.status("Restoring settings...")) }
-        await applyProfileBackupResolution(remote: remote.profileBackup)
+        await SyncDomainResolver.apply(strategy: backupStrategy, remote: remote.profileBackup, syncStore: syncStore)
         if importFlow { onProgress?(.locationsRestored(count: savedLocations.locations.count)) }
 
+        // Ride History (Kind 30174)
+        let historyStrategy = SyncDomainStrategy<RideHistoryBackupContent>(
+            domain: .rideHistory,
+            hasLocalState: { @Sendable in
+                await MainActor.run { !rideHistory.rides.isEmpty }
+            },
+            applyRemote: { @Sendable value in
+                await MainActor.run {
+                    rideHistory.restoreFromBackup(value.rides)
+                    if !value.rides.isEmpty {
+                        AppLogger.auth.info("Restored \(value.rides.count) ride(s) from Nostr")
+                    }
+                }
+            },
+            undecodableWarning: "Latest ride history backup is not decodable; preserving local history state",
+            publishLocal: { @Sendable in
+                await service.publishRideHistoryAndMark(from: rideHistory, syncStore: syncStore)
+            },
+            shouldPublishGuard: { @Sendable in
+                await MainActor.run { !rideHistory.rides.isEmpty }
+            }
+        )
+
         if importFlow { onProgress?(.status("Restoring ride history...")) }
-        await applyRideHistoryResolution(remote: remote.rideHistory)
+        await SyncDomainResolver.apply(strategy: historyStrategy, remote: remote.rideHistory, syncStore: syncStore)
 
         if importFlow { onProgress?(.status("Loading driver info...")) }
         let driverProfiles = await service.fetchDriverProfiles(pubkeys: repo.allPubkeys)
@@ -148,265 +240,25 @@ final class SyncCoordinator {
         }
     }
 
-    // MARK: - Publish Methods
-
-    /// Publish Kind 0 metadata to Nostr.
-    func publishProfile() async {
-        guard let service = roadflareDomainService else { return }
-        let profile = UserProfileContent(
-            name: settings.profileName,
-            displayName: settings.profileName
-        )
-        do {
-            let event = try await service.publishProfile(profile)
-            roadflareSyncStore?.markPublished(.profile, at: event.createdAt)
-            AppLogger.auth.info("Published profile to Nostr")
-        } catch {
-            AppLogger.auth.info("Failed to publish profile: \(error)")
-        }
-    }
-
-    /// Publish Kind 30177 encrypted profile backup (settings + saved locations) to Nostr.
-    func publishProfileBackup() async {
-        guard let service = roadflareDomainService else { return }
-        if isPublishingProfileBackup {
-            profileBackupRepublishRequested = true
-            return
-        }
-
-        isPublishingProfileBackup = true
-        defer { isPublishingProfileBackup = false }
-
-        repeat {
-            profileBackupRepublishRequested = false
-            let backup = buildProfileBackupContent()
-            do {
-                let event = try await service.publishProfileBackup(backup)
-                roadflareSyncStore?.markPublished(.profileBackup, at: event.createdAt)
-                AppLogger.auth.info("Published profile backup to Nostr")
-            } catch {
-                AppLogger.auth.info("Failed to publish profile backup: \(error)")
-            }
-        } while profileBackupRepublishRequested
-    }
-
-    /// Publish both Kind 0 and Kind 30177.
-    func saveAndPublishSettings() async {
-        await publishProfile()
-        await publishProfileBackup()
-    }
-
-    func buildProfileBackupContent() -> ProfileBackupContent {
-        var settingsBackup = profileBackupSettingsTemplate
-        settingsBackup.roadflarePaymentMethods = settings.roadflarePaymentMethods
-
-        return ProfileBackupContent(
-            savedLocations: savedLocations.locations.map { loc in
-                SavedLocationBackup(
-                    displayName: loc.displayName, lat: loc.latitude, lon: loc.longitude,
-                    addressLine: loc.addressLine,
-                    isPinned: loc.isPinned,
-                    nickname: loc.nickname,
-                    timestampMs: loc.timestampMs
-                )
-            },
-            settings: settingsBackup
-        )
-    }
-
-    func preserveProfileBackupSettingsTemplate(_ settings: SettingsBackupContent) {
-        profileBackupSettingsTemplate = settings
-    }
-
     // MARK: - Flush on Reconnect
 
     /// Publish any dirty sync domains. Caller must verify relay connectivity first.
     func flushPendingSyncPublishes(rideCoordinator: RideCoordinator?) async {
-        guard let syncStore = roadflareSyncStore else { return }
+        guard let syncStore = roadflareSyncStore,
+              let service = roadflareDomainService,
+              let backupCoordinator = profileBackupCoordinator else { return }
 
         if syncStore.metadata(for: .profile).isDirty {
-            await publishProfile()
+            await service.publishProfileAndMark(from: settings, syncStore: syncStore)
         }
         if syncStore.metadata(for: .followedDrivers).isDirty {
             await rideCoordinator?.publishFollowedDriversList()
         }
         if syncStore.metadata(for: .profileBackup).isDirty {
-            await publishProfileBackup()
+            await backupCoordinator.publishAndMark(settings: settings, savedLocations: savedLocations)
         }
         if syncStore.metadata(for: .rideHistory).isDirty, !rideHistory.rides.isEmpty {
-            do {
-                let content = RideHistoryBackupContent(rides: rideHistory.rides)
-                if let service = roadflareDomainService {
-                    let event = try await service.publishRideHistoryBackup(content)
-                    syncStore.markPublished(.rideHistory, at: event.createdAt)
-                }
-            } catch {
-                // Will retry on next reconnect
-            }
-        }
-    }
-
-    // MARK: - Resolution Methods
-
-    private func applyProfileResolution(
-        remote: RoadflareDomainService.StartupRemoteDomain<UserProfileContent>
-    ) async {
-        guard let syncStore = roadflareSyncStore else { return }
-        let metadata = syncStore.metadata(for: .profile)
-        let resolution = RoadflareDomainService.resolve(
-            domain: .profile, metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt
-        )
-        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
-            metadata: metadata, remoteCreatedAt: remote.latestSeenCreatedAt,
-            hasLocalState: !settings.profileName.isEmpty
-        )
-
-        if resolution.source == .remote,
-           let snapshot = remote.snapshot,
-           snapshot.createdAt == remote.latestSeenCreatedAt {
-            let name = snapshot.value.displayName ?? snapshot.value.name ?? ""
-            settings.performWithoutChangeTracking {
-                _ = settings.setProfileName(name)
-            }
-            if !name.isEmpty {
-                AppLogger.auth.info("Restored profile name from Nostr: \(name)")
-            }
-            syncStore.markPublished(.profile, at: snapshot.createdAt)
-        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
-            AppLogger.auth.warning("Latest profile metadata is not decodable; preserving local profile state")
-        } else if resolution.shouldPublishLocal || shouldSeedLegacyLocal {
-            if shouldSeedLegacyLocal { syncStore.markDirty(.profile) }
-            await publishProfile()
-        }
-    }
-
-    private func applyFollowedDriversResolution(
-        repo: FollowedDriversRepository,
-        remote: RoadflareDomainService.StartupRemoteDomain<FollowedDriversContent>
-    ) async {
-        guard let service = roadflareDomainService else { return }
-        guard let syncStore = roadflareSyncStore else { return }
-        let metadata = syncStore.metadata(for: .followedDrivers)
-        let resolution = RoadflareDomainService.resolve(
-            domain: .followedDrivers, metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt
-        )
-        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
-            metadata: metadata, remoteCreatedAt: remote.latestSeenCreatedAt,
-            hasLocalState: repo.hasDrivers
-        )
-
-        if resolution.source == .remote,
-           let snapshot = remote.snapshot,
-           snapshot.createdAt == remote.latestSeenCreatedAt {
-            repo.restoreFromNostr(content: snapshot.value)
-            syncStore.markPublished(.followedDrivers, at: snapshot.createdAt)
-            if !snapshot.value.drivers.isEmpty {
-                AppLogger.auth.info("Restored \(snapshot.value.drivers.count) drivers from Nostr")
-            }
-        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
-            AppLogger.auth.warning("Latest followed-drivers snapshot is not decodable; preserving local driver state")
-        } else if resolution.shouldPublishLocal || shouldSeedLegacyLocal {
-            if shouldSeedLegacyLocal { syncStore.markDirty(.followedDrivers) }
-            do {
-                let event = try await service.publishFollowedDriversList(repo.drivers)
-                syncStore.markPublished(.followedDrivers, at: event.createdAt)
-                AppLogger.auth.info("Published followed drivers list to Nostr")
-            } catch {
-                AppLogger.auth.info("Failed to publish followed drivers list: \(error)")
-            }
-        }
-    }
-
-    private func applyProfileBackupResolution(
-        remote: RoadflareDomainService.StartupRemoteDomain<ProfileBackupContent>
-    ) async {
-        guard roadflareDomainService != nil else { return }
-        guard let syncStore = roadflareSyncStore else { return }
-        if let snapshot = remote.snapshot {
-            preserveProfileBackupSettingsTemplate(snapshot.value.settings)
-        }
-        let metadata = syncStore.metadata(for: .profileBackup)
-        let resolution = RoadflareDomainService.resolve(
-            domain: .profileBackup, metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt
-        )
-        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
-            metadata: metadata, remoteCreatedAt: remote.latestSeenCreatedAt,
-            hasLocalState: !settings.roadflarePaymentMethods.isEmpty
-                || !savedLocations.locations.isEmpty
-        )
-
-        if resolution.source == .remote,
-           let snapshot = remote.snapshot,
-           snapshot.createdAt == remote.latestSeenCreatedAt {
-            applyRemoteProfileBackup(snapshot.value)
-            syncStore.markPublished(.profileBackup, at: snapshot.createdAt)
-        } else if resolution.source == .remote, remote.latestSeenCreatedAt != nil {
-            AppLogger.auth.warning("Latest profile backup is not decodable; preserving local backup state")
-        } else if resolution.shouldPublishLocal || shouldSeedLegacyLocal {
-            if shouldSeedLegacyLocal { syncStore.markDirty(.profileBackup) }
-            await publishProfileBackup()
-        }
-    }
-
-    private func applyRemoteProfileBackup(_ backup: ProfileBackupContent) {
-        preserveProfileBackupSettingsTemplate(backup.settings)
-        settings.performWithoutChangeTracking {
-            settings.setRoadflarePaymentMethods(backup.settings.roadflarePaymentMethods)
-        }
-
-        savedLocations.restoreFromBackup(backup.savedLocations.map { loc in
-            SavedLocation(
-                latitude: loc.lat,
-                longitude: loc.lon,
-                displayName: loc.displayName,
-                addressLine: loc.addressLine ?? loc.displayName,
-                isPinned: loc.isPinned,
-                nickname: loc.nickname,
-                timestampMs: loc.timestampMs ?? Int(Date.now.timeIntervalSince1970 * 1000)
-            )
-        })
-
-        if !backup.savedLocations.isEmpty {
-            AppLogger.auth.info("Restored \(backup.savedLocations.count) saved locations")
-        }
-    }
-
-    private func applyRideHistoryResolution(
-        remote: RoadflareDomainService.StartupRemoteDomain<RideHistoryBackupContent>
-    ) async {
-        guard let service = roadflareDomainService else { return }
-        guard let syncStore = roadflareSyncStore else { return }
-        let metadata = syncStore.metadata(for: .rideHistory)
-        let resolution = RoadflareDomainService.resolve(
-            domain: .rideHistory, metadata: metadata,
-            remoteCreatedAt: remote.latestSeenCreatedAt
-        )
-        let shouldSeedLegacyLocal = RoadflareDomainService.shouldSeedLegacyLocalState(
-            metadata: metadata, remoteCreatedAt: remote.latestSeenCreatedAt,
-            hasLocalState: !rideHistory.rides.isEmpty
-        )
-
-        if resolution.source == .remote,
-           let snapshot = remote.snapshot,
-           snapshot.createdAt == remote.latestSeenCreatedAt {
-            rideHistory.restoreFromBackup(snapshot.value.rides)
-            syncStore.markPublished(.rideHistory, at: snapshot.createdAt)
-            if !snapshot.value.rides.isEmpty {
-                AppLogger.auth.info("Restored \(snapshot.value.rides.count) ride(s) from Nostr")
-            }
-        } else if (resolution.shouldPublishLocal || shouldSeedLegacyLocal), !rideHistory.rides.isEmpty {
-            if shouldSeedLegacyLocal { syncStore.markDirty(.rideHistory) }
-            do {
-                let content = RideHistoryBackupContent(rides: rideHistory.rides)
-                let event = try await service.publishRideHistoryBackup(content)
-                syncStore.markPublished(.rideHistory, at: event.createdAt)
-                AppLogger.auth.info("Published ride history backup to Nostr")
-            } catch {
-                AppLogger.auth.info("Failed to publish ride history backup: \(error)")
-            }
+            await service.publishRideHistoryAndMark(from: rideHistory, syncStore: syncStore)
         }
     }
 }

--- a/RoadFlare/RoadFlareTests/RoadFlareTests.swift
+++ b/RoadFlare/RoadFlareTests/RoadFlareTests.swift
@@ -179,74 +179,6 @@ struct AppStateTests {
     }
 
     @MainActor
-    @Test func profileBackupContentIncludesPinnedAndRecentLocations() {
-        // SyncCoordinator owns buildProfileBackupContent, so test it directly
-        let settings = UserSettingsRepository(persistence: InMemoryUserSettingsPersistence())
-        let savedLocations = SavedLocationsRepository(persistence: InMemorySavedLocationsPersistence())
-        let rideHistory = RideHistoryRepository(persistence: InMemoryRideHistoryPersistence())
-        let sync = SyncCoordinator(settings: settings, savedLocations: savedLocations, rideHistory: rideHistory)
-
-        settings.setRoadflarePaymentMethods(["zelle", "venmo-business"])
-        savedLocations.save(SavedLocation(
-            id: "fav", latitude: 36.17, longitude: -115.14,
-            displayName: "Home", addressLine: "123 Main St",
-            isPinned: true, nickname: "Home", timestampMs: 100
-        ))
-        savedLocations.save(SavedLocation(
-            id: "recent", latitude: 36.12, longitude: -115.17,
-            displayName: "Airport", addressLine: "Harry Reid Intl",
-            isPinned: false, timestampMs: 200
-        ))
-
-        let backup = sync.buildProfileBackupContent()
-
-        #expect(backup.savedLocations.count == 2)
-        #expect(backup.savedLocations.contains {
-            $0.displayName == "Home" && $0.isPinned && $0.nickname == "Home" && $0.timestampMs == 100
-        })
-        #expect(backup.savedLocations.contains {
-            $0.displayName == "Airport" && !$0.isPinned && $0.timestampMs == 200
-        })
-        #expect(backup.settings.roadflarePaymentMethods == ["zelle", "venmo-business"])
-        #expect(backup.settings.customPaymentMethods == ["venmo-business"])
-    }
-
-    @MainActor
-    @Test func profileBackupContentPreservesImportedAndroidSettingsTemplate() {
-        let settings = UserSettingsRepository(persistence: InMemoryUserSettingsPersistence())
-        let savedLocations = SavedLocationsRepository(persistence: InMemorySavedLocationsPersistence())
-        let rideHistory = RideHistoryRepository(persistence: InMemoryRideHistoryPersistence())
-        let sync = SyncCoordinator(settings: settings, savedLocations: savedLocations, rideHistory: rideHistory)
-
-        sync.preserveProfileBackupSettingsTemplate(
-            SettingsBackupContent(
-                roadflarePaymentMethods: ["cash"],
-                notificationSoundEnabled: false,
-                notificationVibrationEnabled: false,
-                autoOpenNavigation: false,
-                alwaysAskVehicle: false,
-                customRelays: ["wss://relay.example"],
-                paymentMethods: ["cashu", "lightning"],
-                defaultPaymentMethod: "cashu",
-                mintUrl: "https://mint.example"
-            )
-        )
-        settings.setRoadflarePaymentMethods(["zelle", "venmo-business"])
-
-        let backup = sync.buildProfileBackupContent()
-
-        #expect(backup.settings.roadflarePaymentMethods == ["zelle", "venmo-business"])
-        #expect(backup.settings.notificationSoundEnabled == false)
-        #expect(backup.settings.notificationVibrationEnabled == false)
-        #expect(backup.settings.autoOpenNavigation == false)
-        #expect(backup.settings.alwaysAskVehicle == false)
-        #expect(backup.settings.customRelays == ["wss://relay.example"])
-        #expect(backup.settings.paymentMethods == ["cashu", "lightning"])
-        #expect(backup.settings.defaultPaymentMethod == "cashu")
-        #expect(backup.settings.mintUrl == "https://mint.example")
-    }
-
-    @MainActor
     @Test func syncCoordinatorTeardownDetachesCallbacksBeforeClearAll() async {
         let settings = UserSettingsRepository(persistence: InMemoryUserSettingsPersistence())
         let savedLocations = SavedLocationsRepository(persistence: InMemorySavedLocationsPersistence())
@@ -291,6 +223,8 @@ struct AppStateTests {
         // Callbacks were nil'd before clearAll, so no dirty flags should be set
         #expect(syncStore.metadata(for: .rideHistory).isDirty == false)
         #expect(syncStore.metadata(for: .profileBackup).isDirty == false)
+        // profileBackupCoordinator should be released
+        #expect(sync.profileBackupCoordinator == nil)
     }
 }
 

--- a/RoadFlare/RoadFlareTests/RoadFlareTests.swift
+++ b/RoadFlare/RoadFlareTests/RoadFlareTests.swift
@@ -4,6 +4,24 @@ import Foundation
 @testable import RidestrSDK
 
 
+// MARK: - AppLogger Tests
+
+@Suite("AppLogger Tests")
+struct AppLoggerTests {
+    @Test func bootstrapSDKLoggingWiresRidestrLoggerHandler() {
+        // Save and restore the global handler so this test doesn't leak state.
+        let original = RidestrLogger.handler
+        defer { RidestrLogger.handler = original }
+
+        RidestrLogger.handler = nil
+        #expect(RidestrLogger.handler == nil)
+
+        AppLogger.bootstrapSDKLogging()
+
+        #expect(RidestrLogger.handler != nil)
+    }
+}
+
 // MARK: - RideHistoryRepository Tests
 
 @Suite("RideHistoryRepository Tests")


### PR DESCRIPTION
## Summary

- Introduces generic `SyncDomainResolver<T>` + `SyncDomainStrategy<Value>` in SDK
- Adds `publishAndMark` helpers to `RoadflareDomainService` for 3 domains
- Introduces `ProfileBackupCoordinator` (SDK) owning template + republish state machine
- Shrinks `SyncCoordinator` from 412 → 240 LOC by delegating all publish logic to SDK
- Closes two latent concurrency bugs in the publish state machine

## Why

Completes the SDK protocol surface for sync:
- Eliminates 4 copy-pasted `applyXResolution` methods (one had dropped a log line)
- Moves publish wrappers + state machines into SDK so any RoadFlare client gets them
- After this + #20, `SyncCoordinator` is pure wiring

## Commits

1. **Add SyncDomainResolver to SDK** — generic resolution pattern with 10 branch tests
2. **Add publishAndMark helpers + ProfileBackupCoordinator** — 3 service helpers + new coordinator with 9 tests covering template storage, build, apply, publish, republish loop, failure path, clearAll, and clearAll-during-in-flight invalidation
3. **Migrate SyncCoordinator to SDK resolver + publish helpers** — atomic refactor

## Intentional behavior changes

- rideHistory now logs undecodable-remote warning (observability fix — other 3 domains already did)
- rideHistory publish failure now logs (was silent)
- Profile backup log messages shift from `AppLogger.auth` to `RidestrLogger` subsystem
- **Concurrency bug fixes**: `publishAndMark` atomic loop-exit + generation counter close two latent races (lost-update between loop-check/defer, and `clearAll()` clobbering a new publish session). Current `SyncCoordinator.publishProfileBackup` has these races masked by `@MainActor` serialization; SDK version is strictly safer.

## End state

SyncCoordinator is 240 LOC of pure orchestration: init/configure, callback wiring, startup sync (strategy definitions + resolver calls), reconnect flush, teardown. All publish state machines, template preservation, content building, and remote-apply logic live in SDK.

## Test plan

- [x] 10 SyncDomainResolverTests pass
- [x] 9 ProfileBackupCoordinatorTests pass
- [x] 3 new publishAndMark tests in RoadflareDomainServiceTests pass
- [x] 719 SDK tests pass (+22 new)
- [x] RoadFlareTests pass (pre-push hook: ** TEST SUCCEEDED **)
- [ ] Manual: fresh install → onboarding → publish works
- [ ] Manual: logout → nsec import → all 4 domains restore
- [ ] Manual: background/foreground reconnect flushes dirty domains
- [ ] Manual: payment method edits trigger profileBackup republish

See \`.claude/plans/19-sync-domain-resolver.md\` for full design rationale, concurrency model, and scenario traces.