### PR TITLE
feat(sdk): move sync change-tracking callback wiring to SyncDomainTracker (#29)

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Wires repository change callbacks to `RoadflareSyncStateStore.markDirty()`
+/// so the protocol-level mapping of "which local mutation dirties which sync
+/// domain" lives in the SDK rather than in the app layer.
+///
+/// Callbacks are wired in `init` and nil'd in `detach()`. `deinit` calls
+/// `detach()` as a safety net so repositories are never left pointing at a
+/// deallocated tracker.
+///
+/// `@unchecked Sendable`: all `let` properties are themselves `@unchecked
+/// Sendable`; `driversRepo` is `weak var` accessed only from `@Sendable`
+/// closures. `markDirty` inside `RoadflareSyncStateStore` is NSLock-protected.
+public final class SyncDomainTracker: @unchecked Sendable {
+
+    // MARK: - Stored References
+
+    private let store: RoadflareSyncStateStore
+    private let settings: UserSettingsRepository
+    private weak var driversRepo: FollowedDriversRepository?
+    private let rideHistory: RideHistoryRepository
+    private let savedLocations: SavedLocationsRepository
+
+    // MARK: - Init
+
+    /// Wire all change-tracking callbacks immediately.
+    ///
+    /// - Parameters:
+    ///   - store: The sync state store that receives `markDirty` calls.
+    ///   - settings: User settings repository (profile + profileBackup domains).
+    ///   - driversRepo: Followed drivers repository (stored weakly). Only
+    ///     `.local` mutations dirty `.followedDrivers`; `.sync` mutations are
+    ///     ignored — they originate from the relay, not from local edits.
+    ///   - rideHistory: Ride history repository (rideHistory domain).
+    ///   - savedLocations: Saved locations repository (profileBackup domain).
+    public init(
+        store: RoadflareSyncStateStore,
+        settings: UserSettingsRepository,
+        driversRepo: FollowedDriversRepository,
+        rideHistory: RideHistoryRepository,
+        savedLocations: SavedLocationsRepository
+    ) {
+        self.store = store
+        self.settings = settings
+        self.driversRepo = driversRepo
+        self.rideHistory = rideHistory
+        self.savedLocations = savedLocations
+        wireCallbacks()
+    }
+
+    // MARK: - Detach
+
+    /// Nil out all repository callbacks. Call before any `clearAll()` on the
+    /// repositories to prevent stale dirty flags after logout.
+    /// `deinit` also calls `detach()` as a safety net.
+    public func detach() {
+        settings.onProfileChanged = nil
+        settings.onProfileBackupChanged = nil
+        driversRepo?.onDriversChanged = nil
+        rideHistory.onRidesChanged = nil
+        savedLocations.onChange = nil
+        // onFavoritesChanged is intentionally NOT wired (onChange already fires
+        // for all location mutations including favorites, making a separate
+        // onFavoritesChanged → profileBackup mapping redundant). It is nil'd
+        // here for safety to match pre-refactor SyncCoordinator.teardown().
+        savedLocations.onFavoritesChanged = nil
+    }
+
+    deinit { detach() }
+
+    // MARK: - Private
+
+    private func wireCallbacks() {
+        let store = self.store
+
+        settings.onProfileChanged = { [weak store] in
+            store?.markDirty(.profile)
+        }
+        settings.onProfileBackupChanged = { [weak store] in
+            store?.markDirty(.profileBackup)
+        }
+        driversRepo?.onDriversChanged = { [weak store] source in
+            guard source == .local else { return }
+            store?.markDirty(.followedDrivers)
+        }
+        rideHistory.onRidesChanged = { [weak store] in
+            store?.markDirty(.rideHistory)
+        }
+        savedLocations.onChange = { [weak store] in
+            store?.markDirty(.profileBackup)
+        }
+    }
+}

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
@@ -5,14 +5,15 @@ import Foundation
 /// domain" lives in the SDK rather than in the app layer.
 ///
 /// Callbacks are wired in `init` and nil'd in `detach()`. `deinit` calls
-/// `detach()` as a safety net so repositories are never left pointing at a
-/// deallocated tracker.
+/// the same nil-assignments directly as a thread-safe defensive no-op:
+/// `SyncCoordinator` always calls `detach()` before releasing the tracker,
+/// so callbacks are already nil by the time `deinit` fires.
 ///
 /// `@unchecked Sendable`: all `let` properties are themselves `@unchecked
 /// Sendable`. `driversRepo` is `weak var` written only in `wireCallbacks()`
-/// and `detach()`, both called exclusively through `SyncCoordinator`
-/// (`@MainActor`), so access is always main-actor-serialized. `markDirty`
-/// inside `RoadflareSyncStateStore` is NSLock-protected.
+/// and `_detachUnchecked()`, both called exclusively from `@MainActor`
+/// context (via `SyncCoordinator`), so access is always main-actor-serialized.
+/// `markDirty` inside `RoadflareSyncStateStore` is NSLock-protected.
 public final class SyncDomainTracker: @unchecked Sendable {
 
     // MARK: - Stored References
@@ -53,9 +54,26 @@ public final class SyncDomainTracker: @unchecked Sendable {
     // MARK: - Detach
 
     /// Nil out all repository callbacks. Call before any `clearAll()` on the
-    /// repositories to prevent stale dirty flags after logout.
-    /// `deinit` also calls `detach()` as a safety net.
+    /// repositories to prevent stale dirty flags after logout. `SyncCoordinator`
+    /// always calls this before releasing the tracker, so `deinit`'s own call
+    /// to `_detachUnchecked()` is a defensive no-op by the time it fires.
     @MainActor public func detach() {
+        _detachUnchecked()
+    }
+
+    deinit {
+        // `_detachUnchecked()` has no actor isolation and is safe to call from
+        // any thread. SyncCoordinator (@MainActor) always calls detach() before
+        // releasing this tracker, so callbacks are already nil here — this is
+        // purely a defensive safety net against programmer error.
+        _detachUnchecked()
+    }
+
+    // MARK: - Private
+
+    /// Nil-assignment implementation with no actor isolation so it is safe to
+    /// call from `deinit` on any thread. External callers must use `detach()`.
+    private func _detachUnchecked() {
         settings.onProfileChanged = nil
         settings.onProfileBackupChanged = nil
         driversRepo?.onDriversChanged = nil
@@ -67,15 +85,6 @@ public final class SyncDomainTracker: @unchecked Sendable {
         // here for safety to match pre-refactor SyncCoordinator.teardown().
         savedLocations.onFavoritesChanged = nil
     }
-
-    deinit {
-        // detach() is @MainActor. SyncCoordinator (@MainActor) always calls
-        // detach() explicitly before releasing this tracker, so by deinit time
-        // all callbacks are already nil. assumeIsolated asserts the invariant.
-        MainActor.assumeIsolated { detach() }
-    }
-
-    // MARK: - Private
 
     private func wireCallbacks() {
         let store = self.store

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
@@ -9,8 +9,10 @@ import Foundation
 /// deallocated tracker.
 ///
 /// `@unchecked Sendable`: all `let` properties are themselves `@unchecked
-/// Sendable`; `driversRepo` is `weak var` accessed only from `@Sendable`
-/// closures. `markDirty` inside `RoadflareSyncStateStore` is NSLock-protected.
+/// Sendable`. `driversRepo` is `weak var` written only in `wireCallbacks()`
+/// and `detach()`, both called exclusively through `SyncCoordinator`
+/// (`@MainActor`), so access is always main-actor-serialized. `markDirty`
+/// inside `RoadflareSyncStateStore` is NSLock-protected.
 public final class SyncDomainTracker: @unchecked Sendable {
 
     // MARK: - Stored References
@@ -53,7 +55,7 @@ public final class SyncDomainTracker: @unchecked Sendable {
     /// Nil out all repository callbacks. Call before any `clearAll()` on the
     /// repositories to prevent stale dirty flags after logout.
     /// `deinit` also calls `detach()` as a safety net.
-    public func detach() {
+    @MainActor public func detach() {
         settings.onProfileChanged = nil
         settings.onProfileBackupChanged = nil
         driversRepo?.onDriversChanged = nil
@@ -66,7 +68,12 @@ public final class SyncDomainTracker: @unchecked Sendable {
         savedLocations.onFavoritesChanged = nil
     }
 
-    deinit { detach() }
+    deinit {
+        // detach() is @MainActor. SyncCoordinator (@MainActor) always calls
+        // detach() explicitly before releasing this tracker, so by deinit time
+        // all callbacks are already nil. assumeIsolated asserts the invariant.
+        MainActor.assumeIsolated { detach() }
+    }
 
     // MARK: - Private
 

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainTrackerTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainTrackerTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import Testing
+@testable import RidestrSDK
+
+@Suite("SyncDomainTracker Tests")
+struct SyncDomainTrackerTests {
+
+    // MARK: - Helpers
+
+    private func makeSyncStore() -> RoadflareSyncStateStore {
+        RoadflareSyncStateStore(
+            defaults: UserDefaults(suiteName: "tracker_test_\(UUID().uuidString)")!,
+            namespace: UUID().uuidString
+        )
+    }
+
+    private func makeSettings() -> UserSettingsRepository {
+        UserSettingsRepository(persistence: InMemoryUserSettingsPersistence())
+    }
+
+    private func makeDriversRepo() -> FollowedDriversRepository {
+        FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+    }
+
+    private func makeRideHistory() -> RideHistoryRepository {
+        RideHistoryRepository(persistence: InMemoryRideHistoryPersistence())
+    }
+
+    private func makeSavedLocations() -> SavedLocationsRepository {
+        SavedLocationsRepository(persistence: InMemorySavedLocationsPersistence())
+    }
+
+    private func makeEntry(id: String = UUID().uuidString) -> RideHistoryEntry {
+        RideHistoryEntry(
+            id: id, date: .now, counterpartyPubkey: "driver",
+            pickupGeohash: "abc", dropoffGeohash: "def",
+            pickup: Location(latitude: 40, longitude: -74),
+            destination: Location(latitude: 41, longitude: -73),
+            fare: 10.0, paymentMethod: "zelle"
+        )
+    }
+
+    private func makeSavedLocation(id: String = UUID().uuidString) -> SavedLocation {
+        SavedLocation(
+            id: id, latitude: 36.17, longitude: -115.14,
+            displayName: "Home", addressLine: "123 Main St",
+            isPinned: true, nickname: "Home"
+        )
+    }
+
+    // MARK: - Wiring Tests
+
+    @Test func onProfileChanged_marksProfileDirty() {
+        let store = makeSyncStore()
+        let settings = makeSettings()
+        let tracker = SyncDomainTracker(
+            store: store,
+            settings: settings,
+            driversRepo: makeDriversRepo(),
+            rideHistory: makeRideHistory(),
+            savedLocations: makeSavedLocations()
+        )
+        _ = tracker  // keep alive
+
+        #expect(!store.metadata(for: .profile).isDirty)
+        _ = settings.setProfileName("Alice")
+        #expect(store.metadata(for: .profile).isDirty)
+    }
+
+    @Test func onProfileBackupChanged_marksProfileBackupDirty_viaSettings() {
+        let store = makeSyncStore()
+        let settings = makeSettings()
+        let tracker = SyncDomainTracker(
+            store: store,
+            settings: settings,
+            driversRepo: makeDriversRepo(),
+            rideHistory: makeRideHistory(),
+            savedLocations: makeSavedLocations()
+        )
+        _ = tracker
+
+        #expect(!store.metadata(for: .profileBackup).isDirty)
+        settings.setRoadflarePaymentMethods(["cash", "zelle"])
+        #expect(store.metadata(for: .profileBackup).isDirty)
+    }
+
+    @Test func onDriversChanged_local_marksFollowedDriversDirty() {
+        let store = makeSyncStore()
+        let driversRepo = makeDriversRepo()
+        let tracker = SyncDomainTracker(
+            store: store,
+            settings: makeSettings(),
+            driversRepo: driversRepo,
+            rideHistory: makeRideHistory(),
+            savedLocations: makeSavedLocations()
+        )
+        _ = tracker
+
+        #expect(!store.metadata(for: .followedDrivers).isDirty)
+        driversRepo.addDriver(FollowedDriver(pubkey: "pk1"), source: .local)
+        #expect(store.metadata(for: .followedDrivers).isDirty)
+    }
+
+    @Test func onDriversChanged_sync_doesNotMarkFollowedDriversDirty() {
+        let store = makeSyncStore()
+        let driversRepo = makeDriversRepo()
+        let tracker = SyncDomainTracker(
+            store: store,
+            settings: makeSettings(),
+            driversRepo: driversRepo,
+            rideHistory: makeRideHistory(),
+            savedLocations: makeSavedLocations()
+        )
+        _ = tracker
+
+        #expect(!store.metadata(for: .followedDrivers).isDirty)
+        driversRepo.addDriver(FollowedDriver(pubkey: "pk1"), source: .sync)
+        #expect(!store.metadata(for: .followedDrivers).isDirty)
+    }
+
+    @Test func onRidesChanged_marksRideHistoryDirty() {
+        let store = makeSyncStore()
+        let rideHistory = makeRideHistory()
+        let tracker = SyncDomainTracker(
+            store: store,
+            settings: makeSettings(),
+            driversRepo: makeDriversRepo(),
+            rideHistory: rideHistory,
+            savedLocations: makeSavedLocations()
+        )
+        _ = tracker
+
+        #expect(!store.metadata(for: .rideHistory).isDirty)
+        rideHistory.addRide(makeEntry())
+        #expect(store.metadata(for: .rideHistory).isDirty)
+    }
+
+    @Test func savedLocationsOnChange_marksProfileBackupDirty() {
+        let store = makeSyncStore()
+        let savedLocations = makeSavedLocations()
+        let tracker = SyncDomainTracker(
+            store: store,
+            settings: makeSettings(),
+            driversRepo: makeDriversRepo(),
+            rideHistory: makeRideHistory(),
+            savedLocations: savedLocations
+        )
+        _ = tracker
+
+        #expect(!store.metadata(for: .profileBackup).isDirty)
+        savedLocations.save(makeSavedLocation())
+        #expect(store.metadata(for: .profileBackup).isDirty)
+    }
+
+    // MARK: - Detach Tests
+
+    @Test func detach_nilsAllCallbacksSoSubsequentMutationsDoNotDirtyStore() {
+        let store = makeSyncStore()
+        let settings = makeSettings()
+        let driversRepo = makeDriversRepo()
+        let rideHistory = makeRideHistory()
+        let savedLocations = makeSavedLocations()
+
+        let tracker = SyncDomainTracker(
+            store: store,
+            settings: settings,
+            driversRepo: driversRepo,
+            rideHistory: rideHistory,
+            savedLocations: savedLocations
+        )
+
+        tracker.detach()
+
+        // After detach, mutations must not dirty the store
+        _ = settings.setProfileName("Bob")
+        settings.setRoadflarePaymentMethods(["cash"])
+        driversRepo.addDriver(FollowedDriver(pubkey: "pk2"), source: .local)
+        rideHistory.addRide(makeEntry())
+        savedLocations.save(makeSavedLocation())
+
+        #expect(!store.metadata(for: .profile).isDirty)
+        #expect(!store.metadata(for: .profileBackup).isDirty)
+        #expect(!store.metadata(for: .followedDrivers).isDirty)
+        #expect(!store.metadata(for: .rideHistory).isDirty)
+    }
+
+    @Test func deinit_nilsCallbacksWhenTrackerGoesOutOfScope() {
+        let store = makeSyncStore()
+        let settings = makeSettings()
+        let driversRepo = makeDriversRepo()
+        let rideHistory = makeRideHistory()
+        let savedLocations = makeSavedLocations()
+
+        do {
+            let tracker = SyncDomainTracker(
+                store: store,
+                settings: settings,
+                driversRepo: driversRepo,
+                rideHistory: rideHistory,
+                savedLocations: savedLocations
+            )
+            _ = tracker
+            // tracker goes out of scope here
+        }
+
+        // After deinit, mutations must not dirty the store
+        _ = settings.setProfileName("Carol")
+        driversRepo.addDriver(FollowedDriver(pubkey: "pk3"), source: .local)
+        rideHistory.addRide(makeEntry())
+        savedLocations.save(makeSavedLocation())
+
+        #expect(!store.metadata(for: .profile).isDirty)
+        #expect(!store.metadata(for: .followedDrivers).isDirty)
+        #expect(!store.metadata(for: .rideHistory).isDirty)
+        #expect(!store.metadata(for: .profileBackup).isDirty)
+    }
+}

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainTrackerTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainTrackerTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import RidestrSDK
 
 @Suite("SyncDomainTracker Tests")
+@MainActor
 struct SyncDomainTrackerTests {
 
     // MARK: - Helpers
@@ -182,6 +183,33 @@ struct SyncDomainTrackerTests {
         #expect(!store.metadata(for: .profileBackup).isDirty)
         #expect(!store.metadata(for: .followedDrivers).isDirty)
         #expect(!store.metadata(for: .rideHistory).isDirty)
+    }
+
+    /// Regression: commit bef926b fixed a bug where `clearAll()` fired repository
+    /// callbacks that still held a reference to the old sync store, writing stale
+    /// dirty flags after logout. Detach must nil callbacks before `clearAll()`.
+    @Test func detach_preventsStaleCallbacksWhenRepositoriesAreClearedAll() {
+        let store = makeSyncStore()
+        let rideHistory = makeRideHistory()
+        let savedLocations = makeSavedLocations()
+
+        let tracker = SyncDomainTracker(
+            store: store,
+            settings: makeSettings(),
+            driversRepo: makeDriversRepo(),
+            rideHistory: rideHistory,
+            savedLocations: savedLocations
+        )
+
+        tracker.detach()
+
+        // clearAll() fires onRidesChanged?() and onChange?() internally —
+        // these must be nil after detach so no dirty flags are written.
+        rideHistory.clearAll()
+        savedLocations.clearAll()
+
+        #expect(!store.metadata(for: .rideHistory).isDirty)
+        #expect(!store.metadata(for: .profileBackup).isDirty)
     }
 
     @Test func deinit_nilsCallbacksWhenTrackerGoesOutOfScope() {

--- a/RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift
@@ -10,8 +10,9 @@ enum SyncProgress {
     case locationsRestored(count: Int)
 }
 
-/// Owns Nostr sync orchestration: startup resolution, callback wiring, and
-/// teardown. Publish wrappers and state machines live in the SDK (see
+/// Owns Nostr sync orchestration: startup resolution, change-tracking delegation,
+/// and teardown. Change-tracking callback wiring is delegated to `SyncDomainTracker`
+/// (SDK). Publish wrappers and state machines live in the SDK (see
 /// `ProfileBackupCoordinator` and `RoadflareDomainService.publishXAndMark`
 /// helpers). This class is pure wiring between AppState-owned state and
 /// SDK-provided sync primitives.
@@ -55,7 +56,7 @@ final class SyncCoordinator {
 
     // MARK: - Tracking Callbacks
 
-    /// Wire ALL change-tracking callbacks: settings + repositories.
+    /// Delegate change-tracking callback wiring to a fresh `SyncDomainTracker`.
     /// MUST be called after configure() so roadflareSyncStore is set.
     func wireTrackingCallbacks(driversRepo: FollowedDriversRepository) {
         guard let store = roadflareSyncStore else { return }

--- a/RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift
@@ -22,15 +22,13 @@ final class SyncCoordinator {
     private(set) var roadflareSyncStore: RoadflareSyncStateStore?
     private(set) var roadflareDomainService: RoadflareDomainService?
     private(set) var profileBackupCoordinator: ProfileBackupCoordinator?
+    private(set) var syncDomainTracker: SyncDomainTracker?
 
     // MARK: - Injected References (owned by AppState)
 
     private let settings: UserSettingsRepository
     private let savedLocations: SavedLocationsRepository
     private let rideHistory: RideHistoryRepository
-
-    // Weak ref for callback teardown
-    private weak var trackedDriversRepo: FollowedDriversRepository?
 
     // MARK: - Init
 
@@ -60,33 +58,30 @@ final class SyncCoordinator {
     /// Wire ALL change-tracking callbacks: settings + repositories.
     /// MUST be called after configure() so roadflareSyncStore is set.
     func wireTrackingCallbacks(driversRepo: FollowedDriversRepository) {
-        let store = roadflareSyncStore
-        trackedDriversRepo = driversRepo
-
-        settings.onProfileChanged = { store?.markDirty(.profile) }
-        settings.onProfileBackupChanged = { store?.markDirty(.profileBackup) }
-
-        driversRepo.onDriversChanged = { source in
-            guard source == .local else { return }
-            store?.markDirty(.followedDrivers)
-        }
-        rideHistory.onRidesChanged = { store?.markDirty(.rideHistory) }
-        savedLocations.onChange = { store?.markDirty(.profileBackup) }
+        guard let store = roadflareSyncStore else { return }
+        // Explicit detach+nil before creating the new tracker: ARC releases the old
+        // tracker's deinit AFTER the new tracker's init wires callbacks, which would
+        // immediately nil them. Nil first so deinit fires while callbacks are still
+        // nil, then wire fresh.
+        syncDomainTracker?.detach()
+        syncDomainTracker = nil
+        syncDomainTracker = SyncDomainTracker(
+            store: store,
+            settings: settings,
+            driversRepo: driversRepo,
+            rideHistory: rideHistory,
+            savedLocations: savedLocations
+        )
     }
 
     // MARK: - Teardown
 
-    /// Detach ALL callbacks, clear sync state, and release the profile backup
-    /// coordinator. Called during identity replacement. MUST be called BEFORE
-    /// any clearAll() calls on repositories to prevent stale callbacks from
-    /// writing dirty flags.
+    /// Detach ALL callbacks, clear sync state, and release owned coordinators.
+    /// Called during identity replacement. MUST be called BEFORE any clearAll()
+    /// calls on repositories to prevent stale callbacks from writing dirty flags.
     func teardown(clearPersistedState: Bool) {
-        settings.onProfileChanged = nil
-        settings.onProfileBackupChanged = nil
-        trackedDriversRepo?.onDriversChanged = nil
-        rideHistory.onRidesChanged = nil
-        savedLocations.onChange = nil
-        savedLocations.onFavoritesChanged = nil
+        syncDomainTracker?.detach()
+        syncDomainTracker = nil
 
         profileBackupCoordinator?.clearAll()
         profileBackupCoordinator = nil

--- a/RoadFlare/RoadFlareTests/RoadFlareTests.swift
+++ b/RoadFlare/RoadFlareTests/RoadFlareTests.swift
@@ -241,8 +241,9 @@ struct AppStateTests {
         // Callbacks were nil'd before clearAll, so no dirty flags should be set
         #expect(syncStore.metadata(for: .rideHistory).isDirty == false)
         #expect(syncStore.metadata(for: .profileBackup).isDirty == false)
-        // profileBackupCoordinator should be released
+        // Both coordinators/tracker should be released
         #expect(sync.profileBackupCoordinator == nil)
+        #expect(sync.syncDomainTracker == nil)
     }
 }
 

--- a/decisions/0006-sync-domain-tracker.md
+++ b/decisions/0006-sync-domain-tracker.md
@@ -1,0 +1,49 @@
+# ADR-0006: Extract Sync Change-Tracking Callback Wiring to SyncDomainTracker
+
+**Status:** Active
+**Created:** 2026-04-12
+**Tags:** refactor, sdk, architecture, sync, callback-wiring
+
+## Context
+
+`SyncCoordinator` (app layer) owned five callback→domain mappings that encode protocol-level knowledge: which repository mutations dirty which Nostr sync domain. These mappings are not iOS-specific — they reflect Ridestr protocol semantics (e.g., `.sync`-sourced driver mutations must not dirty `.followedDrivers` because they originate from the relay, not from local edits; `savedLocations.onChange` maps to `.profileBackup` because location data is included in Kind 30177).
+
+A prior regression (`bef926b`) established that callback teardown must happen before any `clearAll()` on repositories to prevent stale dirty flags after logout. `SyncCoordinator.teardown()` serialised this requirement correctly, but the five individual `nil` assignments were fragile — any future callback addition could miss teardown, and the protocol-level mapping logic was hidden in app wiring code.
+
+Additionally, `wireTrackingCallbacks` was called repeatedly on identity replacement (logout/login), which required careful ARC ordering: without explicit detach, the old tracker's `deinit` fires after the new tracker's `init` wires callbacks, immediately nil-ing the fresh callbacks.
+
+## Decision
+
+Extract all change-tracking callback wiring into a new SDK class `SyncDomainTracker`:
+
+- **`SyncDomainTracker`** (SDK, `public final class`): owns all five callback wirings in `init`, exposes a single `@MainActor detach()` method that nils them all, and calls `detach()` from `deinit` as a safety net.
+- **`SyncCoordinator.wireTrackingCallbacks`** (app): delegates to a fresh tracker using explicit detach+nil+create sequence so the old tracker's `deinit` fires with nil callbacks.
+- **`SyncCoordinator.teardown`** (app): calls `tracker.detach()` then `tracker = nil` before any `clearAll()`.
+
+## Rationale
+
+The "which mutation dirties which domain" mapping is protocol-level knowledge — identical to why `UserSettingsRepository` (ADR-0002) and `RideStateRepository` (ADR-0004) moved to the SDK. Any future Ridestr client must implement the same filtering logic (e.g., `.sync` mutations must not mark `.followedDrivers` dirty). Centralising it in the SDK makes the contract explicit and testable without iOS dependencies.
+
+The single-object lifecycle (`detach()` nils all five callbacks atomically from the caller's perspective) eliminates the class of bug where a future callback addition forgets teardown. `SyncCoordinator.teardown()` reduces to two lines regardless of how many callbacks `SyncDomainTracker` manages.
+
+`@MainActor` on `detach()` enforces at compile time the invariant that teardown is always main-actor-serialised (matching `SyncCoordinator`'s own isolation), preventing the data-race window where `deinit` fires off-actor while a background callback fires concurrently.
+
+## Alternatives Considered
+
+- **Keep wiring in SyncCoordinator, extract only the domain mapping as a constant** — rejected because it doesn't move the protocol knowledge to the SDK, and teardown still requires per-callback nil assignments.
+- **Protocol with default implementation rather than a concrete class** — rejected because there is exactly one implementation; a protocol adds indirection without benefit.
+- **Weak reference to `SyncDomainTracker` in `SyncCoordinator`** — rejected because the app must keep the tracker alive for callbacks to fire; `SyncCoordinator` owns the tracker's lifetime exactly.
+
+## Consequences
+
+- Protocol-level callback→domain mappings are SDK-tested without iOS dependencies (8 new tests + 1 clearAll regression test).
+- `SyncCoordinator.teardown()` is 2 lines regardless of future callback additions.
+- `detach()` is `@MainActor`, so callers get a compile-time guarantee that teardown is always serialised on the main actor.
+- `SyncDomainTracker.init` is not `@MainActor` — construction can happen synchronously in `@MainActor` callers (as now) without requiring async.
+
+## Affected Files
+
+- `RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift` (NEW)
+- `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainTrackerTests.swift` (NEW)
+- `RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift` (MODIFIED)
+- `RoadFlare/RoadFlareTests/RoadFlareTests.swift` (MODIFIED)


### PR DESCRIPTION
## Summary
- Extract sync change-tracking callback wiring from SyncCoordinator to SDK SyncDomainTracker
- 5 callback→domain mappings now owned by SDK, app layer delegates via 3-line ARC-safe pattern
- Dead field `trackedDriversRepo` removed, teardown simplified

## Test plan
- 8 new SDK tests (5 callback wirings + source filter negative + detach + deinit lifecycle)
- All 792 SDK tests pass
- App test suite passes
- Teardown assertion added for syncDomainTracker cleanup

Closes #29