### PR TITLE
refactor(sdk): remove unused onFavoritesChanged callback

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/SavedLocationsRepository.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/SavedLocationsRepository.swift
@@ -25,9 +25,6 @@ public final class SavedLocationsRepository: @unchecked Sendable {
     /// Called after location mutations so app code can persist sync metadata.
     public var onChange: (@Sendable () -> Void)?
 
-    /// Called when the set of pinned favorites changes (add/remove/rename).
-    public var onFavoritesChanged: (@Sendable () -> Void)?
-
     public init(persistence: SavedLocationsPersistence) {
         self.persistence = persistence
         self.locations = persistence.loadLocations()
@@ -67,7 +64,6 @@ public final class SavedLocationsRepository: @unchecked Sendable {
 
     /// Add or update a saved location. Deduplicates by proximity (~50m).
     public func save(_ location: SavedLocation) {
-        let previousFavorites = favoriteSignaturesLocked()
         lock.withLock {
             if let existingIndex = locations.firstIndex(where: { existing in
                 let dist = sqrt(
@@ -83,7 +79,7 @@ public final class SavedLocationsRepository: @unchecked Sendable {
             }
             enforceMaxRecentsLocked()
         }
-        persistAndNotify(previousFavorites: previousFavorites)
+        persistAndNotify()
     }
 
     /// Add a recent location (convenience for ride completions).
@@ -97,55 +93,49 @@ public final class SavedLocationsRepository: @unchecked Sendable {
 
     /// Pin a location as a favorite with a nickname.
     public func pin(id: String, nickname: String) {
-        let previousFavorites = favoriteSignaturesLocked()
         lock.withLock {
             guard let index = locations.firstIndex(where: { $0.id == id }) else { return }
             locations[index].isPinned = true
             locations[index].nickname = nickname
         }
-        persistAndNotify(previousFavorites: previousFavorites)
+        persistAndNotify()
     }
 
     /// Unpin a favorite back to recents.
     public func unpin(id: String) {
-        let previousFavorites = favoriteSignaturesLocked()
         lock.withLock {
             guard let index = locations.firstIndex(where: { $0.id == id }) else { return }
             locations[index].isPinned = false
             locations[index].nickname = nil
         }
-        persistAndNotify(previousFavorites: previousFavorites)
+        persistAndNotify()
     }
 
     /// Remove a location.
     public func remove(id: String) {
-        let previousFavorites = favoriteSignaturesLocked()
         lock.withLock {
             locations.removeAll { $0.id == id }
         }
-        persistAndNotify(previousFavorites: previousFavorites)
+        persistAndNotify()
     }
 
     // MARK: - Sync
 
     /// Replace all locations with a Nostr backup (full restore).
     public func restoreFromBackup(_ incoming: [SavedLocation]) {
-        let previousFavorites = favoriteSignaturesLocked()
         lock.withLock {
             locations = incoming
         }
-        persistAndNotify(previousFavorites: previousFavorites)
+        persistAndNotify()
     }
 
     // MARK: - Cleanup
 
     /// Clear all locations.
     public func clearAll() {
-        let previousFavorites = favoriteSignaturesLocked()
         lock.withLock { locations = [] }
         persistence.saveLocations([])
         notifyChanged()
-        notifyFavoritesChangedIfNeeded(previousFavorites)
     }
 
     // MARK: - Private Helpers
@@ -161,48 +151,16 @@ public final class SavedLocationsRepository: @unchecked Sendable {
         }
     }
 
-    private func persistAndNotify(previousFavorites: [FavoriteSignature]) {
+    private func persistAndNotify() {
         let snapshot = lock.withLock { locations }
         persistence.saveLocations(snapshot)
         notifyChanged()
-        notifyFavoritesChangedIfNeeded(previousFavorites)
     }
 
     private func notifyChanged() {
         guard !suppressChangeNotifications else { return }
         onChange?()
     }
-
-    private func notifyFavoritesChangedIfNeeded(_ previousFavorites: [FavoriteSignature]) {
-        guard !suppressChangeNotifications else { return }
-        guard previousFavorites != favoriteSignaturesLocked() else { return }
-        onFavoritesChanged?()
-    }
-
-    private func favoriteSignaturesLocked() -> [FavoriteSignature] {
-        lock.withLock {
-            locations
-                .filter(\.isPinned)
-                .map {
-                    FavoriteSignature(
-                        id: $0.id, latitude: $0.latitude, longitude: $0.longitude,
-                        displayName: $0.displayName, addressLine: $0.addressLine,
-                        nickname: $0.nickname, timestampMs: $0.timestampMs
-                    )
-                }
-                .sorted { $0.id < $1.id }
-        }
-    }
-}
-
-private struct FavoriteSignature: Equatable {
-    let id: String
-    let latitude: Double
-    let longitude: Double
-    let displayName: String
-    let addressLine: String
-    let nickname: String?
-    let timestampMs: Int
 }
 
 // MARK: - Persistence Protocol

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
@@ -79,11 +79,6 @@ public final class SyncDomainTracker: @unchecked Sendable {
         driversRepo?.onDriversChanged = nil
         rideHistory.onRidesChanged = nil
         savedLocations.onChange = nil
-        // onFavoritesChanged is intentionally NOT wired (onChange already fires
-        // for all location mutations including favorites, making a separate
-        // onFavoritesChanged → profileBackup mapping redundant). It is nil'd
-        // here for safety to match pre-refactor SyncCoordinator.teardown().
-        savedLocations.onFavoritesChanged = nil
     }
 
     private func wireCallbacks() {

--- a/RoadFlare/RoadFlareTests/RoadFlareTests.swift
+++ b/RoadFlare/RoadFlareTests/RoadFlareTests.swift
@@ -122,46 +122,6 @@ struct SavedLocationsRepositoryTests {
         SavedLocationsRepository(persistence: InMemorySavedLocationsPersistence())
     }
 
-    @Test func recentsDoNotTriggerFavoritesChanged() {
-        let repo = makeRepo()
-        var changeCount = 0
-        var favoritesChangeCount = 0
-
-        repo.onChange = { changeCount += 1 }
-        repo.onFavoritesChanged = { favoritesChangeCount += 1 }
-
-        repo.addRecent(
-            latitude: 36.17,
-            longitude: -115.14,
-            displayName: "Airport",
-            addressLine: "Harry Reid Intl"
-        )
-
-        #expect(changeCount == 1)
-        #expect(favoritesChangeCount == 0)
-    }
-
-    @Test func pinningFavoriteTriggersFavoritesChanged() {
-        let repo = makeRepo()
-        var favoritesChangeCount = 0
-
-        repo.onFavoritesChanged = { favoritesChangeCount += 1 }
-
-        let recent = SavedLocation(
-            id: "home",
-            latitude: 36.17,
-            longitude: -115.14,
-            displayName: "Home",
-            addressLine: "123 Main St",
-            isPinned: false
-        )
-        repo.save(recent)
-        repo.pin(id: "home", nickname: "Home")
-
-        #expect(favoritesChangeCount == 1)
-        #expect(repo.favorites.count == 1)
-    }
-
     @Test func restoreFromBackupReplacesAll() {
         let repo = makeRepo()
         repo.addRecent(latitude: 1, longitude: 2, displayName: "Old", addressLine: "Old St")

--- a/docs/superpowers/plans/2026-04-12-issue-38-favorites-audit.md
+++ b/docs/superpowers/plans/2026-04-12-issue-38-favorites-audit.md
@@ -14,11 +14,13 @@
 
 ## Research Findings
 
-### All references to `onFavoritesChanged` in the codebase (main tree only, excluding worktrees and docs)
+### All references to `onFavoritesChanged` and its supporting infrastructure (main tree only, excluding worktrees and docs)
 
 | File | Line | Role |
 |------|------|------|
 | `RidestrSDK/Sources/RidestrSDK/RoadFlare/SavedLocationsRepository.swift` | 29 | Declaration (`public var`) |
+| `RidestrSDK/Sources/RidestrSDK/RoadFlare/SavedLocationsRepository.swift` | 164 | `persistAndNotify(previousFavorites:)` signature — takes `[FavoriteSignature]` param (must change to no-arg) |
+| `RidestrSDK/Sources/RidestrSDK/RoadFlare/SavedLocationsRepository.swift` | 168 | `notifyFavoritesChangedIfNeeded` call inside `persistAndNotify` (must be removed) |
 | `RidestrSDK/Sources/RidestrSDK/RoadFlare/SavedLocationsRepository.swift` | 179 | Called inside `notifyFavoritesChangedIfNeeded` |
 | `RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift` | 86 | Nil'd in `_detachUnchecked()` (with explanatory comment) |
 | `RoadFlare/RoadFlareTests/RoadFlareTests.swift` | 131 | Test: `recentsDoNotTriggerFavoritesChanged` |

--- a/docs/superpowers/plans/2026-04-12-issue-38-favorites-audit.md
+++ b/docs/superpowers/plans/2026-04-12-issue-38-favorites-audit.md
@@ -1,0 +1,116 @@
+# Issue #38 — Audit & Remove `onFavoritesChanged`
+
+**Date:** 2026-04-12
+**Issue:** #38
+**Branch:** `claude/issue-38-favorites-audit`
+
+---
+
+## Summary
+
+`SavedLocationsRepository.onFavoritesChanged` is a public callback that fires when the pinned-favorites set changes (add/remove/rename/clear). It has a supporting private helper (`notifyFavoritesChangedIfNeeded`) and a private struct (`FavoriteSignature`) that exist solely to compute whether favorites actually changed. Despite being fully implemented and covered by two tests, **no production code ever assigns a closure to it**. The fix is to remove the property, its supporting infrastructure, the nil-out in `SyncDomainTracker._detachUnchecked()`, and the two tests that cover it.
+
+---
+
+## Research Findings
+
+### All references to `onFavoritesChanged` in the codebase (main tree only, excluding worktrees and docs)
+
+| File | Line | Role |
+|------|------|------|
+| `RidestrSDK/Sources/RidestrSDK/RoadFlare/SavedLocationsRepository.swift` | 29 | Declaration (`public var`) |
+| `RidestrSDK/Sources/RidestrSDK/RoadFlare/SavedLocationsRepository.swift` | 179 | Called inside `notifyFavoritesChangedIfNeeded` |
+| `RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift` | 86 | Nil'd in `_detachUnchecked()` (with explanatory comment) |
+| `RoadFlare/RoadFlareTests/RoadFlareTests.swift` | 131 | Test: `recentsDoNotTriggerFavoritesChanged` |
+| `RoadFlare/RoadFlareTests/RoadFlareTests.swift` | 148 | Test: `pinningFavoriteTriggersFavoritesChanged` |
+
+There are no references in `RoadFlare/RoadFlareCore/` production source (the main-tree `SyncCoordinator.swift` has zero hits — the old teardown nil-out was already migrated to `SyncDomainTracker` when PR #37 landed).
+
+### Supporting dead code pulled in by the property
+
+`onFavoritesChanged` is the sole reason three other private items exist:
+
+- `notifyFavoritesChangedIfNeeded(_:)` — private method, only calls `onFavoritesChanged?()`
+- `favoriteSignaturesLocked()` — private method, builds `[FavoriteSignature]` for diffing; called only from `notifyFavoritesChangedIfNeeded` and the mutation methods that pass snapshots to it
+- `FavoriteSignature` — private `Equatable` struct, exists solely for the diff comparison
+
+Removing `onFavoritesChanged` makes all four of these unreachable and eligible for deletion.
+
+### `previousFavorites` snapshot captures in mutation methods
+
+Every public mutation method (`save`, `pin`, `unpin`, `remove`, `restoreFromBackup`, `clearAll`) captures a `previousFavorites` snapshot via `favoriteSignaturesLocked()` before mutating, then passes it to `persistAndNotify(previousFavorites:)` or `notifyFavoritesChangedIfNeeded`. All of these call sites must be cleaned up when the helper is removed.
+
+### Why it is truly dead code
+
+- `onChange` already fires for every location mutation including favorites changes. `SyncDomainTracker.wireCallbacks()` wires `onChange → markDirty(.profileBackup)`. A separate `onFavoritesChanged → profileBackup` mapping would double-fire `markDirty` on favorites mutations.
+- All favorites-aware UI uses SwiftUI's `@Observable` auto-refresh; no imperative callback is needed.
+- The nil-out in `_detachUnchecked()` is documented in-code as a guard against a callback that is "intentionally NOT wired."
+- `onFavoritesChanged` was present from the first commit of `SavedLocationsRepository` (65ef4a3, 2026-03-31) and has never had a production caller assigned to it.
+
+### Is this prerequisite on #29?
+
+The issue notes #29 as a prerequisite ("SyncDomainTracker adds a new nil-out"). PR #37 (merged, now on main) already moved the nil-out from `SyncCoordinator.teardown()` into `SyncDomainTracker._detachUnchecked()`. The main tree at `09f70bf` reflects that state. There is no additional nil-out pending from #29 that would affect this cleanup.
+
+---
+
+## Decision
+
+**Remove it.** YAGNI applies: zero production callers, UI is `@Observable`-driven, sync already covered by `onChange`. The `FavoriteSignature` diff machinery is non-trivial complexity (snapshot before every mutation + `Equatable` struct) to support a callback that does nothing. Removing it reduces public API surface and eliminates dead code paths exercised on every location mutation.
+
+No ADR needed — this is an internal property removal with no public API consumers and no module-boundary or concurrency-model change.
+
+---
+
+## Implementation Steps
+
+### 1. `RidestrSDK/Sources/RidestrSDK/RoadFlare/SavedLocationsRepository.swift`
+
+a. Remove the `onFavoritesChanged` property declaration (line 28–29).
+
+b. Remove the `notifyFavoritesChangedIfNeeded(_:)` private method (lines 176–180).
+
+c. Remove the `FavoriteSignature` private struct (lines 198–206).
+
+d. Remove the `favoriteSignaturesLocked()` private method (lines 182–195).
+
+e. In each public mutation method, remove the `previousFavorites` snapshot capture and update the call to `persistAndNotify` / `clearAll` helper:
+   - `save(_:)`: remove `let previousFavorites = favoriteSignaturesLocked()` and change `persistAndNotify(previousFavorites:)` to a no-arg call (or inline `persistAndNotify`)
+   - `pin(id:nickname:)`: same
+   - `unpin(id:)`: same
+   - `remove(id:)`: same
+   - `restoreFromBackup(_:)`: same
+   - `clearAll()`: remove snapshot + `notifyFavoritesChangedIfNeeded(previousFavorites)` call
+
+f. Update `persistAndNotify` to remove its `previousFavorites` parameter (it will just call `persistence.saveLocations` + `notifyChanged()`).
+
+### 2. `RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift`
+
+Remove lines 82–86 in `_detachUnchecked()` — the explanatory comment block and the `savedLocations.onFavoritesChanged = nil` assignment.
+
+### 3. `RoadFlare/RoadFlareTests/RoadFlareTests.swift`
+
+Remove the two test functions that exercise `onFavoritesChanged`:
+- `recentsDoNotTriggerFavoritesChanged()` (lines 125–142)
+- `pinningFavoriteTriggersFavoritesChanged()` (lines 144–163)
+
+---
+
+## Test Strategy
+
+1. After edits, verify no remaining references: `grep -r "onFavoritesChanged\|favoriteSignaturesLocked\|FavoriteSignature\|notifyFavoritesChangedIfNeeded" RidestrSDK/ RoadFlare/`
+
+2. Build the full Xcode project (not just SPM) to catch any concurrency or compile errors:
+   ```
+   xcodebuild -project RoadFlare/RoadFlare.xcodeproj \
+     -scheme RoadFlare \
+     -destination 'platform=iOS Simulator,name=iPhone 16' \
+     build test
+   ```
+
+3. Confirm the remaining `SavedLocationsRepositoryTests` still pass (`restoreFromBackupReplacesAll`, `persistsViaPersistence`, and any others that do not touch `onFavoritesChanged`).
+
+---
+
+## No ADR Required
+
+Per CLAUDE.md: ADRs are not needed for bug fixes, internal single-file refactors, test additions, or doc updates. Removing an unwired internal callback across two source files and one test file qualifies as internal cleanup — no new public API, no concurrency model change, no module boundary shift.

--- a/docs/superpowers/reviews/plan38-deep-review.txt
+++ b/docs/superpowers/reviews/plan38-deep-review.txt
@@ -1,0 +1,187 @@
+PLAN DEEP REVIEW — Issue #38: Remove onFavoritesChanged
+Reviewer: Claude (claude-sonnet-4-6)
+Date: 2026-04-12
+Branch: claude/issue-38-favorites-audit
+Plan: docs/superpowers/plans/2026-04-12-issue-38-favorites-audit.md
+
+================================================================
+VERDICT: APPROVED — 1 low-severity finding (documentation gap fixed)
+================================================================
+
+FINDINGS SUMMARY
+----------------
+Total findings: 1
+Highest severity: LOW
+Verdict: Plan is accurate and safe to execute. One documentation gap in the
+references table was fixed inline (see Finding #1).
+
+================================================================
+DETAILED ANALYSIS BY QUESTION
+================================================================
+
+Q1. Is onFavoritesChanged truly never wired/called in production?
+STATUS: CONFIRMED — plan claim is accurate
+
+Grep across all .swift files (excluding worktrees/docs) shows exactly 5 direct
+references to onFavoritesChanged:
+  - SavedLocationsRepository.swift:29  (declaration)
+  - SavedLocationsRepository.swift:179 (called inside notifyFavoritesChangedIfNeeded)
+  - SyncDomainTracker.swift:86         (nil'd defensively, NOT wired)
+  - RoadFlareTests.swift:131           (test assignment)
+  - RoadFlareTests.swift:148           (test assignment)
+
+Verified nil (not wired) in all production callers:
+  - SyncDomainTracker.wireCallbacks(): no assignment to onFavoritesChanged
+  - AppState.swift: zero hits
+  - SyncCoordinator.swift: zero hits
+  - ProfileBackupCoordinator.swift: zero hits
+  - SyncDomainTrackerTests.swift: zero hits
+
+The SyncDomainTracker._detachUnchecked() nil-out is purely defensive (comment
+says "intentionally NOT wired"). No production code ever assigns a closure.
+
+Q2. Are the 3 private helpers truly only used by onFavoritesChanged?
+STATUS: CONFIRMED — plan claim is accurate
+
+notifyFavoritesChangedIfNeeded(_:):
+  - Called from persistAndNotify (line 168) and clearAll (line 148)
+  - Both call sites exist solely to drive the onFavoritesChanged callback
+  - No other callers
+
+favoriteSignaturesLocked():
+  - Called at 6 snapshot-capture sites (lines 70, 100, 111, 122, 133, 144)
+  - Called inside notifyFavoritesChangedIfNeeded (line 178)
+  - All call sites feed the callback chain exclusively
+
+FavoriteSignature struct:
+  - Constructed only inside favoriteSignaturesLocked (lines 187-193)
+  - Used only for the Equatable comparison inside notifyFavoritesChangedIfNeeded
+  - No other uses
+
+All three are exclusively in service of onFavoritesChanged.
+
+Q3. Are previousFavorites snapshot captures truly only for this callback?
+STATUS: CONFIRMED — plan claim is accurate
+
+6 snapshot captures confirmed:
+  SavedLocationsRepository.swift:70   save(_:)
+  SavedLocationsRepository.swift:100  pin(id:nickname:)
+  SavedLocationsRepository.swift:111  unpin(id:)
+  SavedLocationsRepository.swift:122  remove(id:)
+  SavedLocationsRepository.swift:133  restoreFromBackup(_:)
+  SavedLocationsRepository.swift:144  clearAll()
+
+Every capture feeds directly into persistAndNotify(previousFavorites:) or
+notifyFavoritesChangedIfNeeded(_:). No other use of these snapshots.
+
+Q4. Does removing the nil-out in SyncDomainTracker._detachUnchecked() leave
+    any stale references?
+STATUS: SAFE — confirmed
+
+After removing onFavoritesChanged from SavedLocationsRepository, the line
+  savedLocations.onFavoritesChanged = nil
+becomes a compile error (accessing removed property). It must be removed.
+
+No stale references result from this removal because:
+  - No closure is ever assigned in production code
+  - The property is removed, not just unset
+  - wireCallbacks() never referenced onFavoritesChanged
+
+The comment block (lines 82-84) and nil-assignment (line 86) must both be
+removed. The plan correctly identifies this at Step 2.
+
+Q5. Which tests reference onFavoritesChanged? Are they safe to remove?
+STATUS: CONFIRMED — plan identifies exactly the right tests
+
+Tests in RoadFlare/RoadFlareTests/RoadFlareTests.swift:
+  - recentsDoNotTriggerFavoritesChanged (assigns repo.onFavoritesChanged at line 131)
+  - pinningFavoriteTriggersFavoritesChanged (assigns repo.onFavoritesChanged at line 148)
+
+SDK-level tests (RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainTrackerTests.swift)
+have ZERO references to onFavoritesChanged — confirmed via grep.
+
+Both identified tests exist solely to exercise the callback. Safe to remove.
+
+Q6. Is there any Android/protocol dependency on this callback?
+STATUS: N/A — no cross-platform concerns
+
+onFavoritesChanged is a public var on a Swift final class. SavedLocationsRepository
+conforms to no protocol that includes this property. No protocol definition for the
+repository class was found. This is iOS-only; no Android layer exists.
+
+Q7. Completeness — does the plan cover ALL references that need cleanup?
+STATUS: 1 LOW-SEVERITY FINDING (fixed)
+
+FINDING #1 (Low — documentation gap, fixed inline):
+  The references table is titled "All references to onFavoritesChanged in the
+  codebase" and lists 5 rows. However, persistAndNotify(previousFavorites:) at
+  line 164 is an indirect but mechanically-important part of the cleanup: its
+  signature must change (remove the parameter), and it also contains the call to
+  notifyFavoritesChangedIfNeeded at line 168 that must be deleted.
+
+  persistAndNotify does not directly reference onFavoritesChanged (it references
+  notifyFavoritesChangedIfNeeded), so it is technically outside the table's stated
+  scope. But as the bridge between the 6 snapshot-capture call sites and the
+  callback, it belongs in a complete delete-checklist.
+
+  FIX APPLIED: Extended the references table to include lines 164 and 168, and
+  updated the table title to "All references to onFavoritesChanged and its
+  supporting infrastructure" so it serves as a comprehensive checklist.
+
+  Implementation step 1.f already covers the persistAndNotify change correctly —
+  this is a documentation gap only, not a missing step.
+
+All other items are fully covered:
+  - 6 snapshot captures: covered by step 1.e (all 6 methods listed)
+  - persistAndNotify refactor: covered by step 1.f
+  - 3 private helpers + struct: covered by steps 1.b/c/d
+  - SyncDomainTracker nil-out + comment: covered by step 2
+  - 2 tests: covered by step 3
+
+Q8. Ordering — is the deletion order safe?
+STATUS: CONFIRMED — ordering is safe
+
+The plan orders: (1) SavedLocationsRepository → (2) SyncDomainTracker → (3) Tests
+This is logical. All changes are compile-time transformations with no runtime
+ordering requirements (no schema migration, no data migration). The code will not
+compile until all three files are updated consistently, which is fine for a single
+PR. No dangling references mid-task.
+
+Q9. Entropy — does this genuinely simplify without removing anything needed?
+STATUS: YES — genuine simplification
+
+Items removed:
+  - 6 snapshot captures (one before every location mutation)
+  - persistAndNotify parameter (FavoriteSignature array allocation per call)
+  - notifyFavoritesChangedIfNeeded method
+  - favoriteSignaturesLocked method
+  - FavoriteSignature private struct (Equatable, 7 fields)
+  - SyncDomainTracker comment block + nil-assignment
+  - 2 test functions
+
+The FavoriteSignature diff machinery allocates a sorted array of structs on every
+location mutation (save, pin, unpin, remove, restoreFromBackup, clearAll) even
+though no code ever fires the callback. This is non-trivial overhead. Removing it
+is a clear win.
+
+suppressChangeNotifications is correctly retained — it is used by notifyChanged()
+which remains in place.
+
+Nothing currently used or useful is being removed. YAGNI applies cleanly.
+
+================================================================
+CHANGES MADE TO PLAN FILE
+================================================================
+
+1. References table: title changed from "All references to `onFavoritesChanged`
+   in the codebase (main tree only, excluding worktrees and docs)" to "All
+   references to `onFavoritesChanged` and its supporting infrastructure (main
+   tree only, excluding worktrees and docs)"
+
+2. References table: added 2 rows for persistAndNotify:
+   - SavedLocationsRepository.swift | 164 | persistAndNotify signature (takes [FavoriteSignature] param — must change to no-arg)
+   - SavedLocationsRepository.swift | 168 | notifyFavoritesChangedIfNeeded call inside persistAndNotify (must be removed)
+
+================================================================
+END OF REVIEW
+================================================================


### PR DESCRIPTION
## Summary
- Remove unused `onFavoritesChanged` callback from `SavedLocationsRepository` — zero production callers have ever assigned a closure to it
- Delete 3 supporting private helpers (`notifyFavoritesChangedIfNeeded`, `favoriteSignaturesLocked`, `FavoriteSignature`) and all `previousFavorites` snapshot captures in the 6 mutation methods
- Simplify `persistAndNotify` to a no-arg call; clean up `clearAll` similarly
- Remove defensive nil-out of `onFavoritesChanged` in `SyncDomainTracker._detachUnchecked()`

## Test plan
- [x] SDK tests pass: 793 tests in 51 suites (`swift test --package-path RidestrSDK`)
- [x] App tests pass: 69 tests (`xcodebuild -scheme RoadFlareTests`)
- [x] Verified zero production callers before removal (`grep` across all source files)
- [x] Removed the 2 `onFavoritesChanged`-specific tests (`recentsDoNotTriggerFavoritesChanged`, `pinningFavoriteTriggersFavoritesChanged`)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)