### PR TITLE
feat(sdk): extract RideHistorySyncCoordinator, remove passive rideHistory dirty wiring

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// SDK-owned coordinator for ride history backup sync.
+///
+/// Owns the fire-and-forget publish Task for any user-initiated ride history
+/// mutation (add ride after ride completion, remove ride from history).
+/// On publish failure, marks `.rideHistory` dirty so `flushPendingSyncPublishes`
+/// retries on the next relay reconnect.
+///
+/// Thread safety: NSLock-protected state. Generation counter invalidates
+/// in-flight publish Tasks that cross a `clearAll()` boundary (identity
+/// replacement). Parallel to `ProfileBackupCoordinator`.
+///
+// @unchecked Sendable: all mutable state protected by `lock`.
+public final class RideHistorySyncCoordinator: @unchecked Sendable {
+    private let domainService: RoadflareDomainService
+    private weak var syncStoreRef: RoadflareSyncStateStore?
+
+    private let lock = NSLock()
+    /// Bumped by `clearAll()` to invalidate in-flight publish Tasks.
+    private var generation: UInt64 = 0
+
+    public init(domainService: RoadflareDomainService, syncStore: RoadflareSyncStateStore) {
+        self.domainService = domainService
+        self.syncStoreRef = syncStore
+    }
+
+    // MARK: - Publish
+
+    /// Publish ride history immediately (fire-and-forget Task).
+    /// Marks `.rideHistory` dirty on failure so the reconnect flush retries.
+    ///
+    /// Call after any user-initiated ride history mutation:
+    /// - after `rideHistory.addRide(entry)` (ride completion)
+    /// - after `rideHistory.removeRide(id:)` (swipe-to-delete)
+    ///
+    /// Safe to call from any context — the Task captures the rides snapshot
+    /// at call time via `rideHistory.rides` (NSLock-protected, thread-safe read).
+    public func publishAndMark(from rideHistory: RideHistoryRepository) {
+        let rides = rideHistory.rides
+        let myGeneration: UInt64 = lock.withLock { generation }
+        Task {
+            let content = RideHistoryBackupContent(rides: rides)
+            do {
+                let event = try await domainService.publishRideHistoryBackup(content)
+                lock.withLock {
+                    guard generation == myGeneration else { return }
+                    syncStoreRef?.markPublished(.rideHistory, at: event.createdAt)
+                    RidestrLogger.info("[RideHistorySyncCoordinator] Published ride history backup")
+                }
+            } catch {
+                lock.withLock {
+                    guard generation == myGeneration else { return }
+                    syncStoreRef?.markDirty(.rideHistory)
+                    RidestrLogger.info("[RideHistorySyncCoordinator] Failed; marked dirty: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Cleanup
+
+    /// Bump generation to invalidate any in-flight publish Task.
+    /// Called by `SyncCoordinator.teardown()` on identity replacement.
+    public func clearAll() {
+        lock.withLock { generation &+= 1 }
+    }
+}

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift
@@ -67,6 +67,15 @@ public final class RideHistorySyncCoordinator: @unchecked Sendable {
 
     /// Bump generation to invalidate any in-flight publish Task.
     /// Called by `SyncCoordinator.teardown()` on identity replacement.
+    ///
+    /// The generation guard suppresses the local store update for any Task whose
+    /// generation no longer matches, but it does **not** cancel the in-flight
+    /// network request — if `relay.publish` is already awaiting, the Nostr event
+    /// is still delivered to relays. This matches `ProfileBackupCoordinator`
+    /// behavior: cancelling mid-flight would require cooperative cancellation
+    /// throughout `RoadflareDomainService` for a race window measured in
+    /// milliseconds. The stale event is harmless; it is overwritten by the next
+    /// successful publish from the new session.
     public func clearAll() {
         lock.withLock { generation &+= 1 }
     }

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift
@@ -34,11 +34,13 @@ public final class RideHistorySyncCoordinator: @unchecked Sendable {
     /// - after `rideHistory.addRide(entry)` (ride completion)
     /// - after `rideHistory.removeRide(id:)` (swipe-to-delete)
     ///
-    /// Callers must be `@MainActor`. Individual reads (`rideHistory.rides` and
-    /// `generation`) are each NSLock-protected, but the generation guard's
-    /// correctness requires callers and `clearAll()` to be serialized on the
-    /// same actor — in practice, all callers are `@MainActor` and
-    /// `SyncCoordinator.teardown()` is also `@MainActor`.
+    /// Callers must be `@MainActor`. `generation` is NSLock-protected;
+    /// `rideHistory.rides` is safe to read on `@MainActor` because all
+    /// mutations also run on `@MainActor` (no concurrent read/write is
+    /// possible). The generation guard's correctness requires callers and
+    /// `clearAll()` to be serialized on the same actor — in practice all
+    /// callers are `@MainActor` and `SyncCoordinator.teardown()` is also
+    /// `@MainActor`.
     public func publishAndMark(from rideHistory: RideHistoryRepository) {
         let rides = rideHistory.rides
         let myGeneration: UInt64 = lock.withLock { generation }

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift
@@ -34,8 +34,11 @@ public final class RideHistorySyncCoordinator: @unchecked Sendable {
     /// - after `rideHistory.addRide(entry)` (ride completion)
     /// - after `rideHistory.removeRide(id:)` (swipe-to-delete)
     ///
-    /// Safe to call from any context — the Task captures the rides snapshot
-    /// at call time via `rideHistory.rides` (NSLock-protected, thread-safe read).
+    /// Callers must be `@MainActor`. Individual reads (`rideHistory.rides` and
+    /// `generation`) are each NSLock-protected, but the generation guard's
+    /// correctness requires callers and `clearAll()` to be serialized on the
+    /// same actor — in practice, all callers are `@MainActor` and
+    /// `SyncCoordinator.teardown()` is also `@MainActor`.
     public func publishAndMark(from rideHistory: RideHistoryRepository) {
         let rides = rideHistory.rides
         let myGeneration: UInt64 = lock.withLock { generation }

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
@@ -38,7 +38,9 @@ public final class SyncDomainTracker: @unchecked Sendable {
     ///   - driversRepo: Followed drivers repository (stored weakly). Only
     ///     `.local` mutations dirty `.followedDrivers`; `.sync` mutations are
     ///     ignored — they originate from the relay, not from local edits.
-    ///   - rideHistory: Ride history repository (rideHistory domain).
+    ///   - rideHistory: Ride history repository — accepted so `detach()` can nil
+    ///     its `onRidesChanged` callback. `.rideHistory` dirty marking is handled
+    ///     by `RideHistorySyncCoordinator`, not this tracker (see class-level note).
     ///   - savedLocations: Saved locations repository (profileBackup domain).
     public init(
         store: RoadflareSyncStateStore,

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift
@@ -9,6 +9,10 @@ import Foundation
 /// `SyncCoordinator` always calls `detach()` before releasing the tracker,
 /// so callbacks are already nil by the time `deinit` fires.
 ///
+/// Note: `.rideHistory` is NOT wired here. `RideHistorySyncCoordinator`
+/// calls `markDirty(.rideHistory)` on publish failure; passive wiring via
+/// `onRidesChanged` caused a false-dirty on `restoreFromBackup` at startup.
+///
 /// `@unchecked Sendable`: all `let` properties are themselves `@unchecked
 /// Sendable`. `driversRepo` is `weak var` written only in `wireCallbacks()`
 /// and `_detachUnchecked()`, both called exclusively from `@MainActor`
@@ -93,9 +97,6 @@ public final class SyncDomainTracker: @unchecked Sendable {
         driversRepo?.onDriversChanged = { [weak store] source in
             guard source == .local else { return }
             store?.markDirty(.followedDrivers)
-        }
-        rideHistory.onRidesChanged = { [weak store] in
-            store?.markDirty(.rideHistory)
         }
         savedLocations.onChange = { [weak store] in
             store?.markDirty(.profileBackup)

--- a/RidestrSDK/Tests/RidestrSDKTests/Nostr/FakeRelayManager.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/Nostr/FakeRelayManager.swift
@@ -47,6 +47,22 @@ public final class FakeRelayManager: RelayManagerProtocol, @unchecked Sendable {
     public var publishDelay: Duration?
     private var _isConnected = false
 
+    // MARK: - Publish-started signaling
+
+    private var _publishStartedContinuation: CheckedContinuation<Void, Never>?
+    private let _publishStartedLock = NSLock()
+
+    /// Suspends the caller until the next `publish(_:)` call begins executing.
+    ///
+    /// Tests use this to replace fragile time-based sleeps with a deterministic
+    /// suspension point: after `waitForNextPublish()` returns, the publish Task has
+    /// definitely entered `relay.publish` and is suspended on its delay (if any).
+    public func waitForNextPublish() async {
+        await withCheckedContinuation { cont in
+            _publishStartedLock.withLock { _publishStartedContinuation = cont }
+        }
+    }
+
     /// Events to return immediately from subscribe calls, keyed by subscription ID.
     public var subscriptionEvents: [String: [NostrEvent]] = [:]
 
@@ -97,6 +113,14 @@ public final class FakeRelayManager: RelayManagerProtocol, @unchecked Sendable {
     }
 
     public func publish(_ event: NostrEvent) async throws -> String {
+        // Signal any waiting `waitForNextPublish()` caller before doing any work.
+        let pendingCont = _publishStartedLock.withLock { () -> CheckedContinuation<Void, Never>? in
+            let c = _publishStartedContinuation
+            _publishStartedContinuation = nil
+            return c
+        }
+        pendingCont?.resume()
+
         if shouldFailPublish {
             throw RidestrError.relay(.notConnected)
         }

--- a/RidestrSDK/Tests/RidestrSDKTests/Nostr/FakeRelayManager.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/Nostr/FakeRelayManager.swift
@@ -49,7 +49,8 @@ public final class FakeRelayManager: RelayManagerProtocol, @unchecked Sendable {
 
     // MARK: - Publish-started signaling
 
-    private var _publishStartedContinuation: CheckedContinuation<Void, Never>?
+    private var _publishStartedContinuations: [CheckedContinuation<Void, Never>] = []
+    private var _pendingPublishStartedSignals = 0
     private let _publishStartedLock = NSLock()
 
     /// Suspends the caller until the next `publish(_:)` call begins executing.
@@ -59,7 +60,17 @@ public final class FakeRelayManager: RelayManagerProtocol, @unchecked Sendable {
     /// definitely entered `relay.publish` and is suspended on its delay (if any).
     public func waitForNextPublish() async {
         await withCheckedContinuation { cont in
-            _publishStartedLock.withLock { _publishStartedContinuation = cont }
+            let shouldResumeImmediately = _publishStartedLock.withLock { () -> Bool in
+                if _pendingPublishStartedSignals > 0 {
+                    _pendingPublishStartedSignals -= 1
+                    return true
+                }
+                _publishStartedContinuations.append(cont)
+                return false
+            }
+            if shouldResumeImmediately {
+                cont.resume()
+            }
         }
     }
 
@@ -115,9 +126,11 @@ public final class FakeRelayManager: RelayManagerProtocol, @unchecked Sendable {
     public func publish(_ event: NostrEvent) async throws -> String {
         // Signal any waiting `waitForNextPublish()` caller before doing any work.
         let pendingCont = _publishStartedLock.withLock { () -> CheckedContinuation<Void, Never>? in
-            let c = _publishStartedContinuation
-            _publishStartedContinuation = nil
-            return c
+            if !_publishStartedContinuations.isEmpty {
+                return _publishStartedContinuations.removeFirst()
+            }
+            _pendingPublishStartedSignals += 1
+            return nil
         }
         pendingCont?.resume()
 

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift
@@ -81,9 +81,10 @@ struct RideHistorySyncCoordinatorTests {
         kit.relay.publishDelay = .milliseconds(150)
         kit.rideHistory.addRide(makeEntry())
 
-        kit.coordinator.publishAndMark(from: kit.rideHistory)  // Task is mid-await in relay
-        kit.coordinator.clearAll()                              // bumps generation before publish completes
-        try await Task.sleep(for: .milliseconds(400))           // let Task try to complete
+        kit.coordinator.publishAndMark(from: kit.rideHistory)
+        try await Task.sleep(for: .milliseconds(30))   // let Task start and suspend inside relay publishDelay
+        kit.coordinator.clearAll()                     // bumps generation while Task is mid-await
+        try await Task.sleep(for: .milliseconds(400))  // let Task try to complete after relay returns
 
         // Generation mismatch — Task exits without touching store
         #expect(kit.syncStore.metadata(for: .rideHistory).lastSuccessfulPublishAt == 0)

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift
@@ -110,12 +110,12 @@ struct RideHistorySyncCoordinatorTests {
 
     @Test func publishAndMark_snapshotsRidesAtCallTime() async throws {
         let kit = try await makeKit()
-        kit.relay.publishDelay = .milliseconds(150)
+        kit.relay.publishDelay = .milliseconds(50)
         kit.rideHistory.addRide(makeEntry(id: "ride1"))
 
         kit.coordinator.publishAndMark(from: kit.rideHistory)  // captures [ride1] at call time
         kit.rideHistory.addRide(makeEntry(id: "ride2"))         // added AFTER Task fires
-        try await Task.sleep(for: .milliseconds(400))
+        try await Task.sleep(for: .milliseconds(600))
 
         // Only one publish was fired (not a second one triggered by addRide)
         #expect(kit.relay.publishedEvents.count == 1)

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift
@@ -82,9 +82,12 @@ struct RideHistorySyncCoordinatorTests {
         kit.rideHistory.addRide(makeEntry())
 
         kit.coordinator.publishAndMark(from: kit.rideHistory)
-        try await Task.sleep(for: .milliseconds(30))   // let Task start and suspend inside relay publishDelay
+        // Deterministic suspension point: wait until the in-flight Task has actually
+        // entered relay.publish (and is suspended on publishDelay) before firing clearAll.
+        // Replaces the fragile 30ms sleep that could race on a loaded CI executor.
+        await kit.relay.waitForNextPublish()
         kit.coordinator.clearAll()                     // bumps generation while Task is mid-await
-        try await Task.sleep(for: .milliseconds(400))  // let Task try to complete after relay returns
+        try await Task.sleep(for: .milliseconds(300))  // let relay delay complete + Task exit
 
         // Generation mismatch — Task exits without touching store
         #expect(kit.syncStore.metadata(for: .rideHistory).lastSuccessfulPublishAt == 0)

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import RidestrSDK
+
+@Suite("RideHistorySyncCoordinator Tests")
+struct RideHistorySyncCoordinatorTests {
+
+    private struct TestKit {
+        let rideHistory: RideHistoryRepository
+        let syncStore: RoadflareSyncStateStore
+        let relay: FakeRelayManager
+        let coordinator: RideHistorySyncCoordinator
+    }
+
+    private func makeKit() async throws -> TestKit {
+        let kp = try NostrKeypair.generate()
+        let relay = FakeRelayManager()
+        try await relay.connect(to: [URL(string: "wss://fake")!])
+        let syncStore = RoadflareSyncStateStore(
+            defaults: UserDefaults(suiteName: "rhsc_test_\(UUID().uuidString)")!,
+            namespace: UUID().uuidString
+        )
+        let domainService = RoadflareDomainService(relayManager: relay, keypair: kp)
+        let rideHistory = RideHistoryRepository(persistence: InMemoryRideHistoryPersistence())
+        let coordinator = RideHistorySyncCoordinator(domainService: domainService, syncStore: syncStore)
+        return TestKit(rideHistory: rideHistory, syncStore: syncStore, relay: relay, coordinator: coordinator)
+    }
+
+    private func makeEntry(id: String = UUID().uuidString) -> RideHistoryEntry {
+        RideHistoryEntry(
+            id: id, date: .now, counterpartyPubkey: "driver",
+            pickupGeohash: "abc", dropoffGeohash: "def",
+            pickup: Location(latitude: 40, longitude: -74),
+            destination: Location(latitude: 41, longitude: -73),
+            fare: 12.50, paymentMethod: "zelle"
+        )
+    }
+
+    // MARK: - Happy path
+
+    @Test func publishAndMark_onSuccess_marksPublished() async throws {
+        let kit = try await makeKit()
+        kit.rideHistory.addRide(makeEntry())
+
+        kit.coordinator.publishAndMark(from: kit.rideHistory)
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(kit.syncStore.metadata(for: .rideHistory).isDirty == false)
+        #expect(kit.syncStore.metadata(for: .rideHistory).lastSuccessfulPublishAt > 0)
+    }
+
+    // MARK: - Failure path
+
+    @Test func publishAndMark_onFailure_marksDirty() async throws {
+        let kit = try await makeKit()
+        kit.relay.shouldFailPublish = true
+
+        kit.coordinator.publishAndMark(from: kit.rideHistory)
+        try await Task.sleep(for: .milliseconds(200))
+
+        #expect(kit.syncStore.metadata(for: .rideHistory).isDirty == true)
+    }
+
+    // MARK: - Empty history
+
+    @Test func publishAndMark_emptyHistory_succeeds() async throws {
+        let kit = try await makeKit()
+        // No rides added — empty history is valid after deletion
+
+        kit.coordinator.publishAndMark(from: kit.rideHistory)
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(!kit.relay.publishedEvents.isEmpty)
+        #expect(kit.syncStore.metadata(for: .rideHistory).lastSuccessfulPublishAt > 0)
+    }
+
+    // MARK: - Generation / clearAll
+
+    @Test func clearAll_invalidatesInFlightPublish_noMarkPublished() async throws {
+        let kit = try await makeKit()
+        kit.relay.publishDelay = .milliseconds(150)
+        kit.rideHistory.addRide(makeEntry())
+
+        kit.coordinator.publishAndMark(from: kit.rideHistory)  // Task is mid-await in relay
+        kit.coordinator.clearAll()                              // bumps generation before publish completes
+        try await Task.sleep(for: .milliseconds(400))           // let Task try to complete
+
+        // Generation mismatch — Task exits without touching store
+        #expect(kit.syncStore.metadata(for: .rideHistory).lastSuccessfulPublishAt == 0)
+        #expect(kit.syncStore.metadata(for: .rideHistory).isDirty == false)
+    }
+
+    @Test func clearAll_doesNotAffectCompletedPublish() async throws {
+        let kit = try await makeKit()
+        kit.rideHistory.addRide(makeEntry())
+
+        kit.coordinator.publishAndMark(from: kit.rideHistory)
+        try await Task.sleep(for: .milliseconds(300))  // let publish complete
+
+        let publishedAt = kit.syncStore.metadata(for: .rideHistory).lastSuccessfulPublishAt
+        #expect(publishedAt > 0)  // confirm publish succeeded
+
+        kit.coordinator.clearAll()  // bumps generation — must not undo store state
+
+        #expect(kit.syncStore.metadata(for: .rideHistory).lastSuccessfulPublishAt == publishedAt)
+    }
+
+    // MARK: - Content snapshot
+
+    @Test func publishAndMark_snapshotsRidesAtCallTime() async throws {
+        let kit = try await makeKit()
+        kit.relay.publishDelay = .milliseconds(150)
+        kit.rideHistory.addRide(makeEntry(id: "ride1"))
+
+        kit.coordinator.publishAndMark(from: kit.rideHistory)  // captures [ride1] at call time
+        kit.rideHistory.addRide(makeEntry(id: "ride2"))         // added AFTER Task fires
+        try await Task.sleep(for: .milliseconds(400))
+
+        // Only one publish was fired (not a second one triggered by addRide)
+        #expect(kit.relay.publishedEvents.count == 1)
+    }
+}

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainTrackerTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/SyncDomainTrackerTests.swift
@@ -119,7 +119,7 @@ struct SyncDomainTrackerTests {
         #expect(!store.metadata(for: .followedDrivers).isDirty)
     }
 
-    @Test func onRidesChanged_marksRideHistoryDirty() {
+    @Test func restoreFromBackup_doesNotMarkRideHistoryDirty() {
         let store = makeSyncStore()
         let rideHistory = makeRideHistory()
         let tracker = SyncDomainTracker(
@@ -129,11 +129,12 @@ struct SyncDomainTrackerTests {
             rideHistory: rideHistory,
             savedLocations: makeSavedLocations()
         )
-        _ = tracker
+        _ = tracker  // keep alive
 
+        // restoreFromBackup simulates startup sync — relay is authoritative, not a user action.
+        // After removing the onRidesChanged wiring, this must NOT mark .rideHistory dirty.
+        rideHistory.restoreFromBackup([makeEntry()])
         #expect(!store.metadata(for: .rideHistory).isDirty)
-        rideHistory.addRide(makeEntry())
-        #expect(store.metadata(for: .rideHistory).isDirty)
     }
 
     @Test func savedLocationsOnChange_marksProfileBackupDirty() {

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -312,6 +312,7 @@ public final class AppState {
             rideStatePersistence: rideStatePersistence
         )
         self.rideCoordinator = coordinator
+        coordinator.rideHistorySyncCoordinator = sync.rideHistorySyncCoordinator
         await coordinator.restoreLiveSubscriptions()
         connectionCoordinator.start(
             interval: Self.connectionWatchdogInterval,
@@ -360,6 +361,7 @@ public final class AppState {
             rideStatePersistence: rideStatePersistence
         )
         self.rideCoordinator = coordinator
+        coordinator.rideHistorySyncCoordinator = sync.rideHistorySyncCoordinator
         AppLogger.auth.info("Starting subscriptions... (\(repo.drivers.count) drivers loaded)")
         await coordinator.restoreLiveSubscriptions()
         connectionCoordinator.start(

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -337,7 +337,13 @@ public final class RideCoordinator {
 
     /// Publish the current ride history to Nostr as a backup event.
     /// Fire-and-forget — marks dirty on failure so the next flush retries.
+    /// No-op before AppState injects `rideHistorySyncCoordinator` via `setupServices`.
     public func backupRideHistory() {
+        #if DEBUG
+        if rideHistorySyncCoordinator == nil {
+            AppLogger.ride.warning("[RideCoordinator] backupRideHistory() called with no coordinator — ride history will not be backed up")
+        }
+        #endif
         rideHistorySyncCoordinator?.publishAndMark(from: rideHistory)
     }
 

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -28,6 +28,10 @@ public final class RideCoordinator {
     private let roadflareSyncStore: RoadflareSyncStateStore?
     let rideStateRepository: RideStateRepository
 
+    /// Injected by AppState after SyncCoordinator.configure(). Nil until identity
+    /// is configured; backupRideHistory() is a no-op when nil.
+    var rideHistorySyncCoordinator: RideHistorySyncCoordinator?
+
     public var currentFareEstimate: FareEstimate?
     public var selectedPaymentMethod: String?
     public var pickupLocation: Location?
@@ -334,17 +338,7 @@ public final class RideCoordinator {
     /// Publish the current ride history to Nostr as a backup event.
     /// Fire-and-forget — marks dirty on failure so the next flush retries.
     public func backupRideHistory() {
-        guard let service = roadflareDomainService,
-              let syncStore = roadflareSyncStore else { return }
-        Task {
-            do {
-                let content = RideHistoryBackupContent(rides: rideHistory.rides)
-                let event = try await service.publishRideHistoryBackup(content)
-                syncStore.markPublished(.rideHistory, at: event.createdAt)
-            } catch {
-                syncStore.markDirty(.rideHistory)
-            }
-        }
+        rideHistorySyncCoordinator?.publishAndMark(from: rideHistory)
     }
 
     private static func duration(seconds: TimeInterval) -> Duration {

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import RidestrSDK
 
 /// Thin app-layer adapter around `RiderRideSession`.

--- a/RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift
@@ -13,9 +13,9 @@ enum SyncProgress {
 /// Owns Nostr sync orchestration: startup resolution, change-tracking delegation,
 /// and teardown. Change-tracking callback wiring is delegated to `SyncDomainTracker`
 /// (SDK). Publish wrappers and state machines live in the SDK (see
-/// `ProfileBackupCoordinator` and `RoadflareDomainService.publishXAndMark`
-/// helpers). This class is pure wiring between AppState-owned state and
-/// SDK-provided sync primitives.
+/// `ProfileBackupCoordinator`, `RideHistorySyncCoordinator`, and
+/// `RoadflareDomainService.publishXAndMark` helpers). This class is pure wiring
+/// between AppState-owned state and SDK-provided sync primitives.
 @MainActor
 final class SyncCoordinator {
     // MARK: - Owned State

--- a/RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift
@@ -23,6 +23,7 @@ final class SyncCoordinator {
     private(set) var roadflareSyncStore: RoadflareSyncStateStore?
     private(set) var roadflareDomainService: RoadflareDomainService?
     private(set) var profileBackupCoordinator: ProfileBackupCoordinator?
+    private(set) var rideHistorySyncCoordinator: RideHistorySyncCoordinator?
     private(set) var syncDomainTracker: SyncDomainTracker?
 
     // MARK: - Injected References (owned by AppState)
@@ -45,6 +46,9 @@ final class SyncCoordinator {
         self.roadflareSyncStore = syncStore
         self.roadflareDomainService = domainService
         self.profileBackupCoordinator = ProfileBackupCoordinator(
+            domainService: domainService, syncStore: syncStore
+        )
+        self.rideHistorySyncCoordinator = RideHistorySyncCoordinator(
             domainService: domainService, syncStore: syncStore
         )
     }
@@ -86,6 +90,9 @@ final class SyncCoordinator {
 
         profileBackupCoordinator?.clearAll()
         profileBackupCoordinator = nil
+
+        rideHistorySyncCoordinator?.clearAll()
+        rideHistorySyncCoordinator = nil
 
         if clearPersistedState {
             roadflareSyncStore?.clearAll()

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -16,7 +16,8 @@ struct RideCoordinatorTests {
         clearRidePersistence: Bool = true,
         roadflarePaymentMethods: [String] = ["zelle"],
         rideStatePersistence: InMemoryRideStatePersistence? = nil,
-        stageTimeouts: RideCoordinator.StageTimeouts = .interopDefault
+        stageTimeouts: RideCoordinator.StageTimeouts = .interopDefault,
+        withRideHistorySync: Bool = false
     ) async throws -> (RideCoordinator, FakeRelayManager, NostrKeypair, RideHistoryRepository, InMemoryRideStatePersistence) {
         let persistence = rideStatePersistence ?? InMemoryRideStatePersistence()
         if clearRidePersistence {
@@ -44,6 +45,19 @@ struct RideCoordinatorTests {
             rideStatePersistence: persistence,
             stageTimeouts: stageTimeouts
         )
+
+        if withRideHistorySync {
+            let domainService = RoadflareDomainService(relayManager: fake, keypair: keypair)
+            let syncStore = RoadflareSyncStateStore(
+                defaults: UserDefaults(suiteName: "rctest_\(UUID().uuidString)")!,
+                namespace: UUID().uuidString
+            )
+            coordinator.rideHistorySyncCoordinator = RideHistorySyncCoordinator(
+                domainService: domainService,
+                syncStore: syncStore
+            )
+        }
+
         return (coordinator, fake, keypair, history, persistence)
     }
 
@@ -887,5 +901,18 @@ struct RideCoordinatorTests {
         #expect(recorded)
         #expect(cleared)
         await coordinator.stopAll()
+    }
+
+    // MARK: - Backup bridge
+
+    @MainActor
+    @Test func backupRideHistoryBridgeDelegatesToSyncCoordinator() async throws {
+        let (coordinator, fake, _, _, _) = try await makeCoordinator(withRideHistorySync: true)
+        let publishedBefore = fake.publishedEvents.count
+
+        coordinator.backupRideHistory()
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(fake.publishedEvents.count > publishedBefore)
     }
 }

--- a/decisions/0007-ride-history-sync-coordinator.md
+++ b/decisions/0007-ride-history-sync-coordinator.md
@@ -8,7 +8,7 @@
 
 Ride-history sync has two code paths that both touch `.rideHistory` dirty state, and they conflict in a subtle way.
 
-**Passive path (`SyncDomainTracker`):** wires a callback on the `RideHistoryRepository` mutation hook so that any `addRide`, `removeRide`, `restoreFromBackup`, or `clearAll` marks the domain dirty:
+**Passive path (`SyncDomainTracker`):** wires a callback on the `RideHistoryRepository` mutation hook so that any `addRide`, `removeRide`, `restoreFromBackup`, `mergeFromBackup`, or `clearAll` marks the domain dirty:
 
 ```swift
 rideHistory.onRidesChanged = { [weak store] in
@@ -16,7 +16,7 @@ rideHistory.onRidesChanged = { [weak store] in
 }
 ```
 
-This fires on relay-side restores during startup sync. When `restoreFromBackup` is called because the relay returned a newer backup, the passive path marks `.rideHistory` dirty — semantically wrong, because the local state was just *synchronised from* the relay, not changed in a way that needs publishing back.
+This fires on relay-side restores during startup sync. When `restoreFromBackup` is called because the relay returned a newer backup, or when `mergeFromBackup` adds relay-authoritative rides that do not already exist locally, the passive path marks `.rideHistory` dirty — semantically wrong, because the local state was just *synchronised from* the relay, not changed in a way that needs publishing back. Both `restoreFromBackup` and `mergeFromBackup` are relay-authoritative operations, not user actions.
 
 **Active path (`RideCoordinator.backupRideHistory()`):** publishes immediately and marks dirty only on failure:
 
@@ -40,7 +40,7 @@ The publish logic in `backupRideHistory()` also lives in the wrong layer: `RideC
 
 Introduce `RideHistorySyncCoordinator` (SDK, `public final class`) as the single owner of ride-history publish-and-mark logic:
 
-- **`RideHistorySyncCoordinator`** (SDK): accepts the `RideHistoryRepository`, `RidestrService`, and `SyncStore` dependencies; exposes a single `sync()` method that publishes, calls `markPublished` on success, and calls `markDirty` on failure; mirrors the structure of `ProfileBackupCoordinator`.
+- **`RideHistorySyncCoordinator`** (SDK): accepts the `RideHistoryRepository`, `RidestrService`, and `SyncStore` dependencies; exposes a single `sync()` method that publishes, calls `markPublished` on success, and calls `markDirty` on failure. It mirrors the publish-mark *responsibility* of `ProfileBackupCoordinator` (the same pattern applied to Kind 30078 instead of Kind 30177), but is a simplified subset: there is no republish-on-dirty loop (ride history has no concurrent republish requirement) and no template field. Reconnect-retry is handled by `flushPendingSyncPublishes`, not by a loop inside the coordinator.
 - **`SyncDomainTracker`** (SDK, MODIFY): remove the `rideHistory.onRidesChanged` callback wiring. The coordinator's `catch { markDirty }` is the only dirty-setter for this domain outside of `flushPendingSyncPublishes`.
 - **`RideCoordinator.backupRideHistory()`** (app, MODIFY): replace the inline `Task { publish… }` body with a call to `RideHistorySyncCoordinator.sync()`.
 - **`SyncCoordinator`** (app, MODIFY): construct and hold a `RideHistorySyncCoordinator` instance, passing it to `RideCoordinator`.
@@ -62,9 +62,11 @@ Making the coordinator the sole dirty-setter (outside of `flushPendingSyncPublis
 ## Consequences
 
 - `SyncDomainTracker` no longer holds a callback on `RideHistoryRepository`. The coordinator's `catch { markDirty }` is the only dirty-setter for `.rideHistory` outside of `flushPendingSyncPublishes`.
-- `restoreFromBackup` during startup sync no longer produces a spurious dirty flag.
+- `restoreFromBackup` and `mergeFromBackup` during startup sync no longer produce a spurious dirty flag.
 - `RideHistorySyncCoordinator` is SDK-testable without iOS dependencies, consistent with `ProfileBackupCoordinator`.
 - `RideCoordinator.backupRideHistory()` becomes a thin delegation stub — protocol-level logic is no longer duplicated in the app layer.
+- `RoadflareDomainService.publishRideHistoryAndMark(from:syncStore:)` is **NOT removed** and is **NOT changed**. It continues to be called by `SyncCoordinator.flushPendingSyncPublishes` and `performStartupSync` — those paths do not route through the coordinator. `RideHistorySyncCoordinator.sync()` calls `publishRideHistoryBackup(_:)` directly and handles `markPublished`/`markDirty` itself. `RoadflareDomainService.swift` is therefore not in Affected Files.
+- `SyncCoordinator.flushPendingSyncPublishes` is intentionally NOT changed to route through the coordinator. It continues to call `service.publishRideHistoryAndMark` directly for the reconnect-flush path. The coordinator's `markDirty`-on-failure sets the dirty flag that `flushPendingSyncPublishes` will eventually act on.
 
 ## Affected Files
 

--- a/decisions/0007-ride-history-sync-coordinator.md
+++ b/decisions/0007-ride-history-sync-coordinator.md
@@ -1,0 +1,77 @@
+# ADR-0007: Extract Ride-History Publish Logic to RideHistorySyncCoordinator
+
+**Status:** Active
+**Created:** 2026-04-13
+**Tags:** refactor, sdk, architecture, sync, coordinator
+
+## Context
+
+Ride-history sync has two code paths that both touch `.rideHistory` dirty state, and they conflict in a subtle way.
+
+**Passive path (`SyncDomainTracker`):** wires a callback on the `RideHistoryRepository` mutation hook so that any `addRide`, `removeRide`, `restoreFromBackup`, or `clearAll` marks the domain dirty:
+
+```swift
+rideHistory.onRidesChanged = { [weak store] in
+    store?.markDirty(.rideHistory)
+}
+```
+
+This fires on relay-side restores during startup sync. When `restoreFromBackup` is called because the relay returned a newer backup, the passive path marks `.rideHistory` dirty — semantically wrong, because the local state was just *synchronised from* the relay, not changed in a way that needs publishing back.
+
+**Active path (`RideCoordinator.backupRideHistory()`):** publishes immediately and marks dirty only on failure:
+
+```swift
+Task {
+    do {
+        let content = RideHistoryBackupContent(rides: rideHistory.rides)
+        let event = try await service.publishRideHistoryBackup(content)
+        syncStore.markPublished(.rideHistory, at: event.createdAt)
+    } catch {
+        syncStore.markDirty(.rideHistory)
+    }
+}
+```
+
+The active path already handles dirty-on-failure, so the passive path's `markDirty` is fully redundant for the mutation case. The only genuine passive safety net is the reconnect-retry path (`flushPendingSyncPublishes` checks `isDirty`), which is not wired through `SyncDomainTracker` and is not changed.
+
+The publish logic in `backupRideHistory()` also lives in the wrong layer: `RideCoordinator` is app-side view-model glue, but the decision of *how* to publish ride history and *when* to mark the domain dirty is protocol-level knowledge that belongs in the SDK alongside `ProfileBackupCoordinator`, which already owns the same pattern for Kind 30177.
+
+## Decision
+
+Introduce `RideHistorySyncCoordinator` (SDK, `public final class`) as the single owner of ride-history publish-and-mark logic:
+
+- **`RideHistorySyncCoordinator`** (SDK): accepts the `RideHistoryRepository`, `RidestrService`, and `SyncStore` dependencies; exposes a single `sync()` method that publishes, calls `markPublished` on success, and calls `markDirty` on failure; mirrors the structure of `ProfileBackupCoordinator`.
+- **`SyncDomainTracker`** (SDK, MODIFY): remove the `rideHistory.onRidesChanged` callback wiring. The coordinator's `catch { markDirty }` is the only dirty-setter for this domain outside of `flushPendingSyncPublishes`.
+- **`RideCoordinator.backupRideHistory()`** (app, MODIFY): replace the inline `Task { publish… }` body with a call to `RideHistorySyncCoordinator.sync()`.
+- **`SyncCoordinator`** (app, MODIFY): construct and hold a `RideHistorySyncCoordinator` instance, passing it to `RideCoordinator`.
+
+## Rationale
+
+Protocol-level publish logic belongs in the SDK. The "publish ride history backup then markPublished / markDirty" sequence is no different in kind from `ProfileBackupCoordinator`'s sequence for Kind 30177, and it carries the same requirement that any future Ridestr client implement it identically. Duplicating protocol semantics in the app layer repeats the mistake that ADR-0002 and ADR-0004 corrected for repositories.
+
+Removing the passive `onRidesChanged` wiring eliminates the false-dirty problem at startup: `restoreFromBackup` no longer triggers a dirty flag, so the reconnect-retry path will not attempt to re-publish content that was just restored from the relay.
+
+Making the coordinator the sole dirty-setter (outside of `flushPendingSyncPublishes`) creates a simple, auditable rule: `.rideHistory` becomes dirty if and only if a publish attempt fails. This is the correct semantics for an optimistic-publish-with-retry model.
+
+## Alternatives Considered
+
+- **Keep both paths, accept redundancy** — rejected. The passive path marks dirty during `restoreFromBackup` at startup, which is semantically wrong: it causes the next flush to re-publish content we just restored from the relay. Redundant dirty-setting also makes it harder to reason about when the domain is actually out of sync.
+- **Move publish into the `SyncDomainTracker` callback directly** — rejected. `SyncDomainTracker` is for `markDirty` wiring only; introducing `async` publish side-effects into a synchronous callback violates its single responsibility and creates a new class of re-entrancy risk.
+- **Make `backupRideHistory()` call `markDirty` instead of publishing** — rejected. Deferring to `flushPendingSyncPublishes` loses the immediate-publish guarantee for online sessions. A user adding a ride while connected should not have to wait for the next reconnect event to back it up.
+
+## Consequences
+
+- `SyncDomainTracker` no longer holds a callback on `RideHistoryRepository`. The coordinator's `catch { markDirty }` is the only dirty-setter for `.rideHistory` outside of `flushPendingSyncPublishes`.
+- `restoreFromBackup` during startup sync no longer produces a spurious dirty flag.
+- `RideHistorySyncCoordinator` is SDK-testable without iOS dependencies, consistent with `ProfileBackupCoordinator`.
+- `RideCoordinator.backupRideHistory()` becomes a thin delegation stub — protocol-level logic is no longer duplicated in the app layer.
+
+## Affected Files
+
+- `RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift` (CREATE)
+- `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift` (CREATE)
+- `decisions/0007-ride-history-sync-coordinator.md` (CREATE — this file)
+- `RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift` (MODIFY)
+- `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift` (MODIFY)
+- `RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift` (MODIFY)
+- `RoadFlare/RoadFlare/Views/History/HistoryTab.swift` (NO CHANGE)

--- a/decisions/0007-ride-history-sync-coordinator.md
+++ b/decisions/0007-ride-history-sync-coordinator.md
@@ -40,9 +40,9 @@ The publish logic in `backupRideHistory()` also lives in the wrong layer: `RideC
 
 Introduce `RideHistorySyncCoordinator` (SDK, `public final class`) as the single owner of ride-history publish-and-mark logic:
 
-- **`RideHistorySyncCoordinator`** (SDK): accepts the `RideHistoryRepository`, `RidestrService`, and `SyncStore` dependencies; exposes a single `sync()` method that publishes, calls `markPublished` on success, and calls `markDirty` on failure. It mirrors the publish-mark *responsibility* of `ProfileBackupCoordinator` (the same pattern applied to Kind 30078 instead of Kind 30177), but is a simplified subset: there is no republish-on-dirty loop (ride history has no concurrent republish requirement) and no template field. Reconnect-retry is handled by `flushPendingSyncPublishes`, not by a loop inside the coordinator.
+- **`RideHistorySyncCoordinator`** (SDK): accepts the `RideHistoryRepository`, `RidestrService`, and `SyncStore` dependencies; exposes a single `publishAndMark(from:)` method that publishes, calls `markPublished` on success, and calls `markDirty` on failure. It mirrors the publish-mark *responsibility* of `ProfileBackupCoordinator` (the same pattern applied to Kind 30078 instead of Kind 30177), but is a simplified subset: there is no republish-on-dirty loop (ride history has no concurrent republish requirement) and no template field. Reconnect-retry is handled by `flushPendingSyncPublishes`, not by a loop inside the coordinator.
 - **`SyncDomainTracker`** (SDK, MODIFY): remove the `rideHistory.onRidesChanged` callback wiring. The coordinator's `catch { markDirty }` is the only dirty-setter for this domain outside of `flushPendingSyncPublishes`.
-- **`RideCoordinator.backupRideHistory()`** (app, MODIFY): replace the inline `Task { publish… }` body with a call to `RideHistorySyncCoordinator.sync()`.
+- **`RideCoordinator.backupRideHistory()`** (app, MODIFY): replace the inline `Task { publish… }` body with a call to `RideHistorySyncCoordinator.publishAndMark(from:)`.
 - **`SyncCoordinator`** (app, MODIFY): construct and hold a `RideHistorySyncCoordinator` instance, passing it to `RideCoordinator`.
 
 ## Rationale
@@ -65,7 +65,7 @@ Making the coordinator the sole dirty-setter (outside of `flushPendingSyncPublis
 - `restoreFromBackup` and `mergeFromBackup` during startup sync no longer produce a spurious dirty flag.
 - `RideHistorySyncCoordinator` is SDK-testable without iOS dependencies, consistent with `ProfileBackupCoordinator`.
 - `RideCoordinator.backupRideHistory()` becomes a thin delegation stub — protocol-level logic is no longer duplicated in the app layer.
-- `RoadflareDomainService.publishRideHistoryAndMark(from:syncStore:)` is **NOT removed** and is **NOT changed**. It continues to be called by `SyncCoordinator.flushPendingSyncPublishes` and `performStartupSync` — those paths do not route through the coordinator. `RideHistorySyncCoordinator.sync()` calls `publishRideHistoryBackup(_:)` directly and handles `markPublished`/`markDirty` itself. `RoadflareDomainService.swift` is therefore not in Affected Files.
+- `RoadflareDomainService.publishRideHistoryAndMark(from:syncStore:)` is **NOT removed** and is **NOT changed**. It continues to be called by `SyncCoordinator.flushPendingSyncPublishes` and `performStartupSync` — those paths do not route through the coordinator. `RideHistorySyncCoordinator.publishAndMark(from:)` calls `publishRideHistoryBackup(_:)` directly and handles `markPublished`/`markDirty` itself. `RoadflareDomainService.swift` is therefore not in Affected Files.
 - `SyncCoordinator.flushPendingSyncPublishes` is intentionally NOT changed to route through the coordinator. It continues to call `service.publishRideHistoryAndMark` directly for the reconnect-flush path. The coordinator's `markDirty`-on-failure sets the dirty flag that `flushPendingSyncPublishes` will eventually act on.
 
 ## Affected Files

--- a/docs/superpowers/plans/2026-04-12-issue-39-ride-history-sync.md
+++ b/docs/superpowers/plans/2026-04-12-issue-39-ride-history-sync.md
@@ -4,7 +4,7 @@
 
 **Goal:** Unify the two ride-history sync paths (passive `onRidesChanged → markDirty` via `SyncDomainTracker`, and active fire-and-forget publish via `RideCoordinator.backupRideHistory()`) into a single SDK class `RideHistorySyncCoordinator`, parallel to `ProfileBackupCoordinator`. Eliminate the redundant `markDirty` wiring from `SyncDomainTracker` and give the publish logic an SDK home with tests.
 
-**Architecture:** `RideHistorySyncCoordinator` lives in `RidestrSDK/Sources/RidestrSDK/RoadFlare/` alongside `ProfileBackupCoordinator`. It owns the fire-and-forget publish Task (with `markDirty`-on-failure), a `clearAll()` for teardown, and a generation counter to safely handle identity replacement. `SyncCoordinator` owns the coordinator instance (created in `configure()`, cleared in `teardown()`). Call sites (`RideCoordinator.recordCompletedRide` / `HistoryTab.onDelete`) call `syncCoordinator.rideHistorySyncCoordinator?.publishAndMark(from: rideHistory)` instead of `rideCoordinator?.backupRideHistory()`. `SyncDomainTracker` drops the `rideHistory.onRidesChanged → markDirty(.rideHistory)` wiring (the coordinator's `markDirty`-on-failure covers offline).
+**Architecture:** `RideHistorySyncCoordinator` lives in `RidestrSDK/Sources/RidestrSDK/RoadFlare/` alongside `ProfileBackupCoordinator`. It owns the fire-and-forget publish Task (with `markDirty`-on-failure), a `clearAll()` for teardown, and a generation counter to safely handle identity replacement. `SyncCoordinator` owns the coordinator instance (created in `configure()`, cleared in `teardown()`). `RideCoordinator` gains a `var rideHistorySyncCoordinator: RideHistorySyncCoordinator?` property (injected by `AppState` after `configure()`); `backupRideHistory()` becomes a thin bridge that calls it. `HistoryTab` call site stays unchanged (`appState.rideCoordinator?.backupRideHistory()`). `SyncDomainTracker` drops the `rideHistory.onRidesChanged → markDirty(.rideHistory)` wiring (the coordinator's `markDirty`-on-failure covers offline).
 
 **Tech Stack:** Swift, RidestrSDK (SPM package), Swift Testing framework, `@unchecked Sendable` + `NSLock` pattern, `FakeRelayManager` + `InMemoryRideHistoryPersistence` for SDK tests.
 
@@ -74,7 +74,7 @@ appState.rideHistory.removeRide(id: ride.id)
 appState.rideCoordinator?.backupRideHistory()
 ```
 
-After the change: call the coordinator directly via `appState.syncCoordinator.rideHistorySyncCoordinator?.publishAndMark(from: appState.rideHistory)`, or expose a convenience through `AppState`.
+After the change: call stays as-is — `appState.rideCoordinator?.backupRideHistory()` — because `backupRideHistory()` becomes a thin bridge to `rideHistorySyncCoordinator`. `AppState.syncCoordinator` is `private`; HistoryTab cannot reach it directly and must go through the public RideCoordinator API.
 
 ### What the passive `onRidesChanged → markDirty` path was protecting against
 
@@ -123,8 +123,8 @@ public final class RideHistorySyncCoordinator: @unchecked Sendable {
     /// - after `rideHistory.addRide(entry)` (ride completion)
     /// - after `rideHistory.removeRide(id:)` (swipe-to-delete)
     ///
-    /// Safe to call from `@MainActor` — the Task captures the rides snapshot
-    /// at call time via `rideHistory.rides` (main-actor isolated read).
+    /// Safe to call from any context — the Task captures the rides snapshot
+    /// at call time via `rideHistory.rides` (NSLock-protected, thread-safe read).
     public func publishAndMark(from rideHistory: RideHistoryRepository) {
         let rides = rideHistory.rides
         let myGeneration: UInt64 = lock.withLock { generation }
@@ -175,7 +175,7 @@ public final class RideHistorySyncCoordinator: @unchecked Sendable {
 | `RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift` | MODIFY | Add `rideHistorySyncCoordinator`; wire in `configure()`; release in `teardown()` |
 | `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift` | MODIFY | Replace `backupRideHistory()` body with coordinator delegation |
 | `RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift` | MODIFY | Remove `rideHistory.onRidesChanged` wiring |
-| `RoadFlare/RoadFlare/Views/History/HistoryTab.swift` | MODIFY | Replace `rideCoordinator?.backupRideHistory()` with coordinator call |
+| `RoadFlare/RoadFlare/Views/History/HistoryTab.swift` | NO CHANGE | Call site stays as `rideCoordinator?.backupRideHistory()` — thin bridge handles delegation |
 
 **Not changed:** `RoadflareDomainService.swift` (existing `publishRideHistoryBackup` is reused), `Package.swift` (auto-discovers sources), `RideHistoryRepository.swift` (no changes needed — `onRidesChanged` callback stays in the struct for future use by other callers).
 
@@ -300,50 +300,51 @@ The `onRidesChanged → markDirty(.rideHistory)` callback is now redundant. The 
       store?.markDirty(.rideHistory)
   }
   ```
-- [ ] In `_detachUnchecked()`, remove the `rideHistory.onRidesChanged = nil` line (it is now a no-op since `wireCallbacks` no longer sets it, but removing it keeps the code clean)
+- [ ] In `_detachUnchecked()`, **keep** the `rideHistory.onRidesChanged = nil` line — it becomes a defensive no-op (the callback was never wired, so nil-assignment is harmless) but preserves the invariant that all repos passed to `init` have their callbacks nil'd in `detach()`. Removing it would also require removing `rideHistory` from `init`, which breaks callers by position.
 - [ ] Update the `SyncDomainTracker` class-level doc comment to reflect that `.rideHistory` is no longer wired here
 
-**Important:** `SyncDomainTracker` still holds the `rideHistory: RideHistoryRepository` property — it is passed in `init` for the `detach()` nil-assignment defensive cleanup. Whether to keep or remove the property from `init` is a judgment call:
-  - Keep it (and just stop setting `onRidesChanged`): minimal change, still nils the callback in `detach()` as a defensive no-op.
-  - Remove it from `init`: cleaner but breaks any callers that already pass it by position. Removing it requires updating `SyncCoordinator.wireTrackingCallbacks()` call site.
-  
-  **Recommended:** keep the `rideHistory` parameter in `init` for now to avoid a breaking change to the `SyncDomainTracker` public API. Just stop wiring `onRidesChanged`. If the property becomes truly unused after detach cleanup is updated, remove it in a follow-up.
+**Important:** Keep the `rideHistory` parameter in `init` and the `rideHistory.onRidesChanged = nil` in `_detachUnchecked()`. The property is still used in teardown as a defensive nil-assignment. If a future change removes the parameter too, that's a separate cleanup PR.
 
 ---
 
-### Step 6: Update `RideCoordinator.swift` — replace `backupRideHistory()`
+### Step 6: Update `RideCoordinator.swift` — thin bridge + inject coordinator
 
-The `backupRideHistory()` method currently holds the active-publish logic. After this change, it becomes a thin bridge to the coordinator (or is removed entirely if the call sites are updated directly).
+**Approach: thin bridge (Option A).** Keep `backupRideHistory()` as the public API — its body delegates to the coordinator. HistoryTab's call site is unchanged. This is lower-risk and avoids exposing AppState-private internals to views.
 
-Option A (thin bridge — lower risk, easier to search/replace later):
-- [ ] Replace `backupRideHistory()` body with:
+`RideCoordinator` currently holds `roadflareDomainService` and `roadflareSyncStore` but has NO reference to `SyncCoordinator` or `RideHistorySyncCoordinator`. The coordinator must be injected by `AppState`.
+
+**6a — Add property to `RideCoordinator`:**
+- [ ] Add to `RideCoordinator`:
+  ```swift
+  /// Injected by AppState after SyncCoordinator.configure(). Nil until identity
+  /// is configured; thin bridge backupRideHistory() is a no-op when nil.
+  var rideHistorySyncCoordinator: RideHistorySyncCoordinator?
+  ```
+  (Internal visibility — `AppState` and `RideCoordinator` are both in `RoadFlareCore`.)
+
+**6b — Replace `backupRideHistory()` body:**
+- [ ] Replace the body of `backupRideHistory()` with:
   ```swift
   public func backupRideHistory() {
-      syncCoordinator?.rideHistorySyncCoordinator?.publishAndMark(from: rideHistory)
+      rideHistorySyncCoordinator?.publishAndMark(from: rideHistory)
   }
   ```
-  This requires `RideCoordinator` to hold a reference to `SyncCoordinator`. Check if it already does; if not, inject it.
+  The guard on `roadflareDomainService`/`roadflareSyncStore` is removed — the coordinator owns those dependencies now.
 
-Option B (remove method, update call sites directly):
-- [ ] Remove `backupRideHistory()` entirely
-- [ ] In `recordRideHistory()`, replace `backupRideHistory()` with the coordinator call directly
-- [ ] In `HistoryTab.swift`, replace `appState.rideCoordinator?.backupRideHistory()` with the coordinator call
-
-**Recommended:** Option B for cleaner deletion of the old path. The call sites are well-known (2 locations).
-
-**If Option B:**
-- [ ] In `recordRideHistory()` (RideCoordinator.swift, after `rideHistory.addRide(entry)`):
+**6c — Inject in `AppState.setupServices()` and `setupServicesWithSync()`:**
+- [ ] In both `setupServices()` and `setupServicesWithSync()`, after `self.rideCoordinator = coordinator`, add:
   ```swift
-  // Previously: backupRideHistory()
-  // Now call via SyncCoordinator — need access to it here.
+  coordinator.rideHistorySyncCoordinator = sync.rideHistorySyncCoordinator
   ```
-  Note: `RideCoordinator` does not currently hold a `SyncCoordinator` reference. It holds `roadflareDomainService` and `roadflareSyncStore` directly. One approach: keep `backupRideHistory()` as a public method that takes an explicit coordinator parameter, or have `AppState` call the coordinator after `rideHistory.addRide`. Review `AppState.swift` to determine the cleanest injection path before coding.
+  `sync.configure()` runs before `RideCoordinator` is created, so `rideHistorySyncCoordinator` is already populated.
 
-- [ ] In `HistoryTab.swift` (`onDelete` closure):
-  ```swift
-  appState.rideHistory.removeRide(id: ride.id)
-  appState.syncCoordinator.rideHistorySyncCoordinator?.publishAndMark(from: appState.rideHistory)
-  ```
+**6d — Teardown is handled automatically:**
+- No explicit nil needed in `prepareForIdentityReplacement()`. `syncCoordinator?.teardown()` calls `rideHistorySyncCoordinator?.clearAll()` (bumps generation) before `rideCoordinator = nil` releases the ref. Because `syncStoreRef` is `weak` and generation is bumped, any in-flight Task exits cleanly without touching the new session's state.
+
+**Call sites after this change:**
+- `RideCoordinator.recordRideHistory()` → `backupRideHistory()` → coordinator (unchanged call chain)
+- `HistoryTab.onDelete` → `appState.rideCoordinator?.backupRideHistory()` (unchanged)
+- Both correctly no-op when not configured (coordinator is nil before `AppState.setupServices()` runs).
 
 ---
 
@@ -390,16 +391,24 @@ After tests pass:
 
 Model after `SyncDomainTrackerTests.swift` (simple, synchronous-style tests using `@MainActor @Suite`) and `LocationSyncCoordinatorTests.swift` (async tests using `FakeRelayManager`).
 
-Tests to write (6 minimum, ordered by TDD priority):
+Tests to write (6 minimum for new coordinator, plus 1 regression in SyncDomainTrackerTests, ordered by TDD priority):
+
+**RideHistorySyncCoordinatorTests.swift (6 tests):**
 
 | # | Test name | What it verifies |
 |---|-----------|-----------------|
 | 1 | `publishAndMark_onSuccess_marksPublished` | Happy path: relay succeeds → `markPublished` called |
 | 2 | `publishAndMark_onFailure_marksDirty` | Offline path: relay throws → `markDirty` called |
 | 3 | `publishAndMark_emptyHistory_succeeds` | Deletion case: empty rides array is published (not skipped) |
-| 4 | `clearAll_invalidatesInFlightPublish_noMarkPublished` | Generation guard: `clearAll` before Task completes → no store mutation |
+| 4 | `clearAll_invalidatesInFlightPublish_noMarkPublished` | Generation guard: `clearAll` before Task completes → no store mutation. **Use `FakeRelayManager` with a configurable delay/continuation** to ensure `clearAll()` fires while the Task is mid-await — a simple `Task.yield()` is inherently racy. Study the suspension-point pattern in `LocationSyncCoordinatorTests.swift`. |
 | 5 | `publishAndMark_snapshotsRidesAtCallTime` | Content isolation: late `addRide` does not affect in-flight publish content |
 | 6 | `clearAll_doesNotAffectCompletedPublish` | Regression: completed publish is not undone by subsequent `clearAll` |
+
+**SyncDomainTrackerTests.swift (1 additional test):**
+
+| # | Test name | File | What it verifies |
+|---|-----------|------|-----------------|
+| 7 | `restoreFromBackup_doesNotMarkRideHistoryDirty` | `SyncDomainTrackerTests.swift` | Regression: after removing the `onRidesChanged` wiring, `rideHistory.restoreFromBackup([entry])` must NOT mark `.rideHistory` dirty. This directly verifies the primary motivation (false-dirty during startup sync). |
 
 ### Existing tests to update
 
@@ -416,8 +425,8 @@ Per CLAUDE.md conventions:
 - The publish Task is fire-and-forget (no `await` at the call site). This matches the current `backupRideHistory()` pattern — callers are `@MainActor` and should not block on publish.
 - The generation counter uses `&+=` (wrapping addition) to prevent overflow, matching `ProfileBackupCoordinator`.
 - `syncStoreRef` is `weak var` — same as `ProfileBackupCoordinator` — to prevent the coordinator retaining the store after `teardown()` releases it.
-- Rides are snapshot from `rideHistory.rides` at call time on `@MainActor`, so the Task closure captures a value type snapshot (`[RideHistoryEntry]`) — no shared mutable state crossing the Task boundary.
-- `RideHistoryRepository.rides` is an `@Observable` `@MainActor`-isolated property; reading it from a `@MainActor` caller before spawning the Task is safe.
+- Rides are snapshot from `rideHistory.rides` at call time, so the Task closure captures a value type snapshot (`[RideHistoryEntry]`) — no shared mutable state crossing the Task boundary.
+- `RideHistoryRepository` is `@Observable @unchecked Sendable` with NSLock protection — `rides` is NOT `@MainActor`-isolated; it is thread-safe from any context. The snapshot (`let rides = rideHistory.rides`) can be taken from any caller context.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-12-issue-39-ride-history-sync.md
+++ b/docs/superpowers/plans/2026-04-12-issue-39-ride-history-sync.md
@@ -1,0 +1,426 @@
+# RideHistorySyncCoordinator SDK Extraction — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify the two ride-history sync paths (passive `onRidesChanged → markDirty` via `SyncDomainTracker`, and active fire-and-forget publish via `RideCoordinator.backupRideHistory()`) into a single SDK class `RideHistorySyncCoordinator`, parallel to `ProfileBackupCoordinator`. Eliminate the redundant `markDirty` wiring from `SyncDomainTracker` and give the publish logic an SDK home with tests.
+
+**Architecture:** `RideHistorySyncCoordinator` lives in `RidestrSDK/Sources/RidestrSDK/RoadFlare/` alongside `ProfileBackupCoordinator`. It owns the fire-and-forget publish Task (with `markDirty`-on-failure), a `clearAll()` for teardown, and a generation counter to safely handle identity replacement. `SyncCoordinator` owns the coordinator instance (created in `configure()`, cleared in `teardown()`). Call sites (`RideCoordinator.recordCompletedRide` / `HistoryTab.onDelete`) call `syncCoordinator.rideHistorySyncCoordinator?.publishAndMark(from: rideHistory)` instead of `rideCoordinator?.backupRideHistory()`. `SyncDomainTracker` drops the `rideHistory.onRidesChanged → markDirty(.rideHistory)` wiring (the coordinator's `markDirty`-on-failure covers offline).
+
+**Tech Stack:** Swift, RidestrSDK (SPM package), Swift Testing framework, `@unchecked Sendable` + `NSLock` pattern, `FakeRelayManager` + `InMemoryRideHistoryPersistence` for SDK tests.
+
+---
+
+## ADR Note
+
+**An ADR is required.** This creates a new public SDK type (`RideHistorySyncCoordinator`) and removes an existing wiring from `SyncDomainTracker` — both are new public API surface and a change to established callback-wiring conventions. The next available number is **ADR-0007**.
+
+The ADR should cover:
+- **Context:** two-path problem (passive `markDirty` via `SyncDomainTracker` + active `backupRideHistory()` in `RideCoordinator`), and why the passive path is redundant once the coordinator handles `markDirty`-on-failure
+- **Decision:** `RideHistorySyncCoordinator` as the single owner of ride-history publish-and-mark, removal of `onRidesChanged` from `SyncDomainTracker`, `backupRideHistory()` body replaced by coordinator call
+- **Rationale:** protocol-level publish logic belongs in the SDK, parallels `ProfileBackupCoordinator` pattern, removes accidental complexity, makes the "offline retry via reconnect flush" path the only passive safety net
+- **Alternatives Considered:** (a) keep both paths, accept redundancy; (b) move publish into `SyncDomainTracker` callback directly (rejected — `SyncDomainTracker` is for markDirty only, not async publish); (c) make `backupRideHistory()` call `markDirty` instead of publishing (rejected — loses the immediate-publish guarantee in online sessions)
+- **Consequences:** `SyncDomainTracker` no longer marks `.rideHistory` dirty on mutation — the coordinator's `catch { markDirty }` is the only dirty-setter for this domain outside of `flushPendingSyncPublishes`
+
+---
+
+## Research Findings
+
+### Current ride-history sync logic in SyncCoordinator.swift
+
+`SyncCoordinator` touches ride history in three places:
+
+1. **`configure()`** — does not wire ride history (no coordinator yet). The `rideHistory` repository is held as a property but only passed to `SyncDomainTracker`.
+
+2. **`wireTrackingCallbacks()` (via `SyncDomainTracker`)** — `SyncDomainTracker.init` wires:
+   ```swift
+   rideHistory.onRidesChanged = { [weak store] in
+       store?.markDirty(.rideHistory)
+   }
+   ```
+   This is the **passive path**: any `addRide`, `removeRide`, `restoreFromBackup`, or `clearAll` call marks `.rideHistory` dirty. It fires on relay-side restores too (via `restoreFromBackup`), which creates unnecessary dirty churn during startup sync.
+
+3. **`flushPendingSyncPublishes()`** — checks `syncStore.metadata(for: .rideHistory).isDirty` and calls `service.publishRideHistoryAndMark(from: rideHistory, syncStore: syncStore)`. This is the **reconnect-retry path** and is the correct passive safety net for the offline case. This path must remain unchanged.
+
+4. **`performStartupSync()` (ride history strategy)** — uses `SyncDomainStrategy<RideHistoryBackupContent>` with a `shouldPublishGuard: { true }` override (empty history is valid after deletion). Calls `service.publishRideHistoryAndMark(from: rideHistory, syncStore: syncStore)` when local state should be published. This is a startup-time path; it is not affected by this issue.
+
+### Current ride-history sync logic in RideCoordinator.swift
+
+`RideCoordinator` has two ride-history sync touch points:
+
+1. **`backupRideHistory()`** (lines 336–348) — the **active publish path**:
+   ```swift
+   public func backupRideHistory() {
+       guard let service = roadflareDomainService,
+             let syncStore = roadflareSyncStore else { return }
+       Task {
+           do {
+               let content = RideHistoryBackupContent(rides: rideHistory.rides)
+               let event = try await service.publishRideHistoryBackup(content)
+               syncStore.markPublished(.rideHistory, at: event.createdAt)
+           } catch {
+               syncStore.markDirty(.rideHistory)
+           }
+       }
+   }
+   ```
+   Called from: `recordRideHistory()` (after a completed ride) and `HistoryTab.onDelete`.
+
+2. **`recordRideHistory()`** (lines 308–332) — builds a `RideHistoryEntry`, calls `rideHistory.addRide(entry)`, then immediately calls `backupRideHistory()`. After this change, it will call `rideHistorySyncCoordinator?.publishAndMark(from: rideHistory)` instead.
+
+### HistoryTab.swift call site
+
+```swift
+appState.rideHistory.removeRide(id: ride.id)
+appState.rideCoordinator?.backupRideHistory()
+```
+
+After the change: call the coordinator directly via `appState.syncCoordinator.rideHistorySyncCoordinator?.publishAndMark(from: appState.rideHistory)`, or expose a convenience through `AppState`.
+
+### What the passive `onRidesChanged → markDirty` path was protecting against
+
+The passive path exists because `flushPendingSyncPublishes` only runs on relay reconnect — in a continuous online session, a deletion or new ride might never get flushed. The active `backupRideHistory()` publish fills this gap by publishing immediately. If the active publish succeeds, it calls `markPublished`, which clears the dirty flag. If it fails, it calls `markDirty`, which ensures the reconnect flush will retry.
+
+Therefore the `onRidesChanged → markDirty(.rideHistory)` wiring in `SyncDomainTracker` is logically redundant when `backupRideHistory()` is called at every mutation site. The redundancy is safe (the two paths do not conflict) but adds accidental complexity — particularly, it marks dirty during `restoreFromBackup` during startup sync, which is semantically wrong (we just restored from the relay; there is nothing to sync back).
+
+---
+
+## New SDK Type: RideHistorySyncCoordinator
+
+File: `RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift`
+
+```swift
+/// SDK-owned coordinator for ride history backup sync.
+///
+/// Owns the fire-and-forget publish Task for any user-initiated ride history
+/// mutation (add ride after ride completion, remove ride from history).
+/// On publish failure, marks `.rideHistory` dirty so `flushPendingSyncPublishes`
+/// retries on the next relay reconnect.
+///
+/// Thread safety: NSLock-protected state. Generation counter invalidates
+/// in-flight publish Tasks that cross a `clearAll()` boundary (identity
+/// replacement). Parallel to `ProfileBackupCoordinator`.
+///
+// @unchecked Sendable: all mutable state protected by `lock`.
+public final class RideHistorySyncCoordinator: @unchecked Sendable {
+    private let domainService: RoadflareDomainService
+    private weak var syncStoreRef: RoadflareSyncStateStore?
+
+    private let lock = NSLock()
+    /// Bumped by `clearAll()` to invalidate in-flight publish Tasks.
+    private var generation: UInt64 = 0
+
+    public init(domainService: RoadflareDomainService, syncStore: RoadflareSyncStateStore) {
+        self.domainService = domainService
+        self.syncStoreRef = syncStore
+    }
+
+    // MARK: - Publish
+
+    /// Publish ride history immediately (fire-and-forget Task).
+    /// Marks `.rideHistory` dirty on failure so the reconnect flush retries.
+    ///
+    /// Call after any user-initiated ride history mutation:
+    /// - after `rideHistory.addRide(entry)` (ride completion)
+    /// - after `rideHistory.removeRide(id:)` (swipe-to-delete)
+    ///
+    /// Safe to call from `@MainActor` — the Task captures the rides snapshot
+    /// at call time via `rideHistory.rides` (main-actor isolated read).
+    public func publishAndMark(from rideHistory: RideHistoryRepository) {
+        let rides = rideHistory.rides
+        let myGeneration: UInt64 = lock.withLock { generation }
+        Task {
+            let content = RideHistoryBackupContent(rides: rides)
+            do {
+                let event = try await domainService.publishRideHistoryBackup(content)
+                lock.withLock {
+                    guard generation == myGeneration else { return }
+                    syncStoreRef?.markPublished(.rideHistory, at: event.createdAt)
+                    RidestrLogger.info("[RideHistorySyncCoordinator] Published ride history backup")
+                }
+            } catch {
+                lock.withLock {
+                    guard generation == myGeneration else { return }
+                    syncStoreRef?.markDirty(.rideHistory)
+                    RidestrLogger.info("[RideHistorySyncCoordinator] Failed; marked dirty: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Cleanup
+
+    /// Bump generation to invalidate any in-flight publish Task.
+    /// Called by `SyncCoordinator.teardown()` on identity replacement.
+    public func clearAll() {
+        lock.withLock { generation &+= 1 }
+    }
+}
+```
+
+**Design notes:**
+- No `isPublishing`/`republishRequested` loop (unlike `ProfileBackupCoordinator`) — ride history publish is not expected to be concurrent-heavy; a simple fire-and-forget Task per mutation is sufficient. If a mutation races with an in-flight publish, the later publish wins at the relay (Kind 30174 is replaced by `created_at`).
+- Generation counter protects against `clearAll()` crossing a Task boundary — if identity changes while a publish is awaiting, the Task exits without touching the new session's sync store.
+- `syncStoreRef` is `weak` — same pattern as `ProfileBackupCoordinator`, protects against the teardown race where the store is released before the Task completes.
+- The rides snapshot is captured at call time (`rideHistory.rides`) from `@MainActor` context, so no concurrent access occurs.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|---------------|
+| `RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift` | CREATE | New coordinator class |
+| `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift` | CREATE | SDK tests (TDD — write first) |
+| `decisions/0007-ride-history-sync-coordinator.md` | CREATE | ADR for new public API |
+| `RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift` | MODIFY | Add `rideHistorySyncCoordinator`; wire in `configure()`; release in `teardown()` |
+| `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift` | MODIFY | Replace `backupRideHistory()` body with coordinator delegation |
+| `RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift` | MODIFY | Remove `rideHistory.onRidesChanged` wiring |
+| `RoadFlare/RoadFlare/Views/History/HistoryTab.swift` | MODIFY | Replace `rideCoordinator?.backupRideHistory()` with coordinator call |
+
+**Not changed:** `RoadflareDomainService.swift` (existing `publishRideHistoryBackup` is reused), `Package.swift` (auto-discovers sources), `RideHistoryRepository.swift` (no changes needed — `onRidesChanged` callback stays in the struct for future use by other callers).
+
+---
+
+## Implementation Steps
+
+### Step 1: Write the ADR
+
+- [ ] Create `decisions/0007-ride-history-sync-coordinator.md`
+- Follow the structure from ADR-0006 (SyncDomainTracker)
+- Cover: Context (two-path redundancy + startup-sync false-dirty), Decision, Rationale, Alternatives, Consequences, Affected Files
+- ADR must be written BEFORE implementation (it clarifies the design boundary)
+
+---
+
+### Step 2: TDD — Write failing tests for `RideHistorySyncCoordinator`
+
+Create `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/RideHistorySyncCoordinatorTests.swift` before the implementation file exists. All tests should fail to compile initially.
+
+**Test cases to cover:**
+
+#### Happy-path publish
+
+- [ ] `publishAndMark_onSuccess_marksPublished` — create coordinator with a `FakeRelayManager` wired to succeed; call `publishAndMark(from: rideHistory)` with one ride; assert `syncStore.metadata(for: .rideHistory).isDirty == false` and `lastSuccessfulPublishAt > 0` after awaiting
+
+#### Offline / failure path
+
+- [ ] `publishAndMark_onFailure_marksDirty` — configure relay to throw; call `publishAndMark`; assert `syncStore.metadata(for: .rideHistory).isDirty == true`
+
+#### Generation / clearAll
+
+- [ ] `clearAll_invalidatesInFlightPublish` — start a publish Task, call `clearAll()` before it completes, assert that `markPublished` is NOT called on the store (generation mismatch causes Task to exit silently)
+- [ ] `clearAll_afterPublish_doesNotDirtyStore` — full publish succeeds; call `clearAll()`; assert store is untouched (no regression)
+
+#### Empty history
+
+- [ ] `publishAndMark_emptyHistory_succeeds` — valid after deletion; assert publish is attempted even when `rideHistory.rides` is empty; on success, marks published
+
+#### Content snapshot
+
+- [ ] `publishAndMark_snapshotsRidesAtCallTime` — add a ride; call `publishAndMark`; add another ride before the Task completes; assert only the first ride's content was published (snapshot isolation)
+
+**Test helper pattern** (model after `SyncDomainTrackerTests.swift` and `LocationSyncCoordinatorTests.swift`):
+
+```swift
+@Suite("RideHistorySyncCoordinator Tests")
+struct RideHistorySyncCoordinatorTests {
+
+    private struct TestKit {
+        let rideHistory: RideHistoryRepository
+        let syncStore: RoadflareSyncStateStore
+        let relay: FakeRelayManager
+        let coordinator: RideHistorySyncCoordinator
+    }
+
+    private func makeKit(keypair: NostrKeypair? = nil) async throws -> TestKit {
+        let kp = try keypair ?? NostrKeypair.generate()
+        let relay = FakeRelayManager()
+        try await relay.connect(to: [URL(string: "wss://fake")!])
+        let syncStore = RoadflareSyncStateStore(
+            defaults: UserDefaults(suiteName: "rhsc_test_\(UUID().uuidString)")!,
+            namespace: UUID().uuidString
+        )
+        let domainService = RoadflareDomainService(relayManager: relay, keypair: kp)
+        let rideHistory = RideHistoryRepository(persistence: InMemoryRideHistoryPersistence())
+        let coordinator = RideHistorySyncCoordinator(domainService: domainService, syncStore: syncStore)
+        return TestKit(rideHistory: rideHistory, syncStore: syncStore, relay: relay, coordinator: coordinator)
+    }
+
+    private func makeEntry(id: String = UUID().uuidString) -> RideHistoryEntry {
+        RideHistoryEntry(
+            id: id, date: .now, counterpartyPubkey: "driver",
+            pickupGeohash: "abc", dropoffGeohash: "def",
+            pickup: Location(latitude: 40, longitude: -74),
+            destination: Location(latitude: 41, longitude: -73),
+            fare: 12.50, paymentMethod: "zelle"
+        )
+    }
+}
+```
+
+Note: Tests that need to wait for async Task completion should either use `FakeRelayManager` with a controlled continuation or use `Task.yield()` + a small `Task.sleep`. Check how `LocationSyncCoordinatorTests` handles async Task completion in the existing test suite.
+
+---
+
+### Step 3: Implement `RideHistorySyncCoordinator` in the SDK
+
+- [ ] Create `RidestrSDK/Sources/RidestrSDK/RoadFlare/RideHistorySyncCoordinator.swift` with the interface defined above
+- All tests from Step 2 should now pass
+- The class uses `@unchecked Sendable` + `NSLock` per CLAUDE.md concurrency conventions
+- Generation counter uses wrapping addition (`&+=`) to match `ProfileBackupCoordinator`
+
+---
+
+### Step 4: Update `SyncCoordinator.swift` to delegate to the coordinator
+
+- [ ] Add `private(set) var rideHistorySyncCoordinator: RideHistorySyncCoordinator?` to the owned state section
+- [ ] In `configure(syncStore:domainService:)`, after creating `profileBackupCoordinator`, add:
+  ```swift
+  self.rideHistorySyncCoordinator = RideHistorySyncCoordinator(
+      domainService: domainService, syncStore: syncStore
+  )
+  ```
+- [ ] In `teardown(clearPersistedState:)`, after `profileBackupCoordinator?.clearAll()`, add:
+  ```swift
+  rideHistorySyncCoordinator?.clearAll()
+  rideHistorySyncCoordinator = nil
+  ```
+
+No change is needed to `performStartupSync()` or `flushPendingSyncPublishes()` — they use `service.publishRideHistoryAndMark(from: rideHistory, syncStore: syncStore)` directly, which is correct for those paths.
+
+---
+
+### Step 5: Update `SyncDomainTracker.swift` — remove `rideHistory.onRidesChanged` wiring
+
+The `onRidesChanged → markDirty(.rideHistory)` callback is now redundant. The coordinator's `catch { markDirty }` is the sole dirty-setter for mutation-triggered publish failures.
+
+- [ ] In `wireCallbacks()`, remove:
+  ```swift
+  rideHistory.onRidesChanged = { [weak store] in
+      store?.markDirty(.rideHistory)
+  }
+  ```
+- [ ] In `_detachUnchecked()`, remove the `rideHistory.onRidesChanged = nil` line (it is now a no-op since `wireCallbacks` no longer sets it, but removing it keeps the code clean)
+- [ ] Update the `SyncDomainTracker` class-level doc comment to reflect that `.rideHistory` is no longer wired here
+
+**Important:** `SyncDomainTracker` still holds the `rideHistory: RideHistoryRepository` property — it is passed in `init` for the `detach()` nil-assignment defensive cleanup. Whether to keep or remove the property from `init` is a judgment call:
+  - Keep it (and just stop setting `onRidesChanged`): minimal change, still nils the callback in `detach()` as a defensive no-op.
+  - Remove it from `init`: cleaner but breaks any callers that already pass it by position. Removing it requires updating `SyncCoordinator.wireTrackingCallbacks()` call site.
+  
+  **Recommended:** keep the `rideHistory` parameter in `init` for now to avoid a breaking change to the `SyncDomainTracker` public API. Just stop wiring `onRidesChanged`. If the property becomes truly unused after detach cleanup is updated, remove it in a follow-up.
+
+---
+
+### Step 6: Update `RideCoordinator.swift` — replace `backupRideHistory()`
+
+The `backupRideHistory()` method currently holds the active-publish logic. After this change, it becomes a thin bridge to the coordinator (or is removed entirely if the call sites are updated directly).
+
+Option A (thin bridge — lower risk, easier to search/replace later):
+- [ ] Replace `backupRideHistory()` body with:
+  ```swift
+  public func backupRideHistory() {
+      syncCoordinator?.rideHistorySyncCoordinator?.publishAndMark(from: rideHistory)
+  }
+  ```
+  This requires `RideCoordinator` to hold a reference to `SyncCoordinator`. Check if it already does; if not, inject it.
+
+Option B (remove method, update call sites directly):
+- [ ] Remove `backupRideHistory()` entirely
+- [ ] In `recordRideHistory()`, replace `backupRideHistory()` with the coordinator call directly
+- [ ] In `HistoryTab.swift`, replace `appState.rideCoordinator?.backupRideHistory()` with the coordinator call
+
+**Recommended:** Option B for cleaner deletion of the old path. The call sites are well-known (2 locations).
+
+**If Option B:**
+- [ ] In `recordRideHistory()` (RideCoordinator.swift, after `rideHistory.addRide(entry)`):
+  ```swift
+  // Previously: backupRideHistory()
+  // Now call via SyncCoordinator — need access to it here.
+  ```
+  Note: `RideCoordinator` does not currently hold a `SyncCoordinator` reference. It holds `roadflareDomainService` and `roadflareSyncStore` directly. One approach: keep `backupRideHistory()` as a public method that takes an explicit coordinator parameter, or have `AppState` call the coordinator after `rideHistory.addRide`. Review `AppState.swift` to determine the cleanest injection path before coding.
+
+- [ ] In `HistoryTab.swift` (`onDelete` closure):
+  ```swift
+  appState.rideHistory.removeRide(id: ride.id)
+  appState.syncCoordinator.rideHistorySyncCoordinator?.publishAndMark(from: appState.rideHistory)
+  ```
+
+---
+
+### Step 7: Verify build and tests
+
+- [ ] Run `xcodebuild` on the full Xcode project (not `swift test` alone):
+  ```bash
+  xcodebuild -project RoadFlare/RoadFlare.xcodeproj \
+    -scheme RoadFlare \
+    -destination 'platform=iOS Simulator,name=iPhone 16' \
+    build 2>&1 | tail -20
+  ```
+  (Per CLAUDE.md: "Always use xcodebuild on the full Xcode project, not just swift test in the SDK package. The SDK's SPM tests miss concurrency errors that only surface in the app target.")
+- [ ] Run SDK tests:
+  ```bash
+  xcodebuild test \
+    -scheme RidestrSDK \
+    -destination 'platform=iOS Simulator,name=iPhone 16' 2>&1 | tail -30
+  ```
+- [ ] Run app tests:
+  ```bash
+  xcodebuild test \
+    -project RoadFlare/RoadFlare.xcodeproj \
+    -scheme RoadFlareTests \
+    -destination 'platform=iOS Simulator,name=iPhone 16' 2>&1 | tail -30
+  ```
+
+---
+
+### Step 8: Clean up dead code in SyncCoordinator and RideCoordinator
+
+After tests pass:
+
+- [ ] Confirm `rideHistory` property in `SyncCoordinator.init` is still needed (it is, for `performStartupSync` and `flushPendingSyncPublishes` — no change needed here)
+- [ ] If `backupRideHistory()` was removed from `RideCoordinator`, verify no callers remain (`grep -r backupRideHistory`)
+- [ ] Remove `roadflareDomainService` and `roadflareSyncStore` from `RideCoordinator.init` if they are no longer used after moving publish logic to the coordinator. Verify all usages before removing — `LocationCoordinator` also receives these as pass-through parameters.
+- [ ] Update `SyncDomainTracker` doc comment if the rideHistory parameter is still in `init` but no longer wired
+
+---
+
+## Test Strategy
+
+### New SDK tests (`RideHistorySyncCoordinatorTests.swift`)
+
+Model after `SyncDomainTrackerTests.swift` (simple, synchronous-style tests using `@MainActor @Suite`) and `LocationSyncCoordinatorTests.swift` (async tests using `FakeRelayManager`).
+
+Tests to write (6 minimum, ordered by TDD priority):
+
+| # | Test name | What it verifies |
+|---|-----------|-----------------|
+| 1 | `publishAndMark_onSuccess_marksPublished` | Happy path: relay succeeds → `markPublished` called |
+| 2 | `publishAndMark_onFailure_marksDirty` | Offline path: relay throws → `markDirty` called |
+| 3 | `publishAndMark_emptyHistory_succeeds` | Deletion case: empty rides array is published (not skipped) |
+| 4 | `clearAll_invalidatesInFlightPublish_noMarkPublished` | Generation guard: `clearAll` before Task completes → no store mutation |
+| 5 | `publishAndMark_snapshotsRidesAtCallTime` | Content isolation: late `addRide` does not affect in-flight publish content |
+| 6 | `clearAll_doesNotAffectCompletedPublish` | Regression: completed publish is not undone by subsequent `clearAll` |
+
+### Existing tests to update
+
+- `SyncDomainTrackerTests.swift` — the `onRidesChanged_marksRideHistoryDirty` test verifies the wiring being removed. This test must be **deleted** (not just skipped) since it tests behavior that is intentionally removed. Note the deletion in the PR.
+- `RoadFlareTests` (app test target) — check for any tests that call `backupRideHistory()` directly; update to call through the coordinator.
+
+---
+
+## Concurrency Notes
+
+Per CLAUDE.md conventions:
+
+- `RideHistorySyncCoordinator` uses `@unchecked Sendable` + `NSLock` (not actors), matching `ProfileBackupCoordinator` and `SyncDomainTracker`.
+- The publish Task is fire-and-forget (no `await` at the call site). This matches the current `backupRideHistory()` pattern — callers are `@MainActor` and should not block on publish.
+- The generation counter uses `&+=` (wrapping addition) to prevent overflow, matching `ProfileBackupCoordinator`.
+- `syncStoreRef` is `weak var` — same as `ProfileBackupCoordinator` — to prevent the coordinator retaining the store after `teardown()` releases it.
+- Rides are snapshot from `rideHistory.rides` at call time on `@MainActor`, so the Task closure captures a value type snapshot (`[RideHistoryEntry]`) — no shared mutable state crossing the Task boundary.
+- `RideHistoryRepository.rides` is an `@Observable` `@MainActor`-isolated property; reading it from a `@MainActor` caller before spawning the Task is safe.
+
+---
+
+## Prerequisite Check
+
+Issue #29 (SyncDomainTracker extraction) is listed as a prerequisite in the issue. As of main at `09f70bf`, `SyncDomainTracker.swift` already exists in `RidestrSDK/Sources/RidestrSDK/RoadFlare/SyncDomainTracker.swift` — the prerequisite is satisfied. Verify with `git log --oneline main | head -5` before starting.

--- a/docs/superpowers/reviews/plan39-deep-review.txt
+++ b/docs/superpowers/reviews/plan39-deep-review.txt
@@ -1,0 +1,198 @@
+Plan39 Deep Review — 2026-04-12
+Reviewer: Claude Sonnet 4.6
+Branch: claude/issue-39-ride-history-sync
+Plan: docs/superpowers/plans/2026-04-12-issue-39-ride-history-sync.md
+
+=== VERDICT ===
+
+5 findings (2 critical, 1 medium, 2 minor). Two issues would cause compilation
+failures if implemented as written. One test gap leaves the primary motivation
+unverified. Fixes applied directly to plan; ready after review of those changes.
+
+=== CLAIMS VERIFIED AGAINST SOURCE ===
+
+✓ RideCoordinator.backupRideHistory() body (lines 336–348): confirmed exactly
+  as described. Holds roadflareDomainService + roadflareSyncStore; fire-and-
+  forget Task; markPublished on success, markDirty on failure.
+
+✓ SyncDomainTracker.wireCallbacks(): confirmed wires
+  rideHistory.onRidesChanged → markDirty(.rideHistory) at line 102.
+
+✓ RideHistoryRepository.restoreFromBackup(): calls onRidesChanged?() at
+  line 94 — passive path fires during startup restore. Claim confirmed.
+
+✓ SyncCoordinator.configure() / teardown(): structure matches plan's proposed
+  changes. profileBackupCoordinator pattern confirmed; insertion points valid.
+
+✓ HistoryTab call site (line 41): appState.rideCoordinator?.backupRideHistory()
+  confirmed.
+
+✓ SyncDomainTrackerTests.onRidesChanged_marksRideHistoryDirty test: confirmed
+  exists; must be deleted (not skipped) when wiring is removed. Plan says this.
+
+✓ ARC detach/nil/create pattern in wireTrackingCallbacks(): confirmed correct —
+  plan's description of why detach+nil must precede the new init is accurate.
+
+✓ profileBackupCoordinator pattern: confirmed as reference. Generation counter,
+  weak syncStoreRef, clearAll() bumps generation — plan's RideHistorySyncCoordinator
+  matches this pattern correctly (with simpler fire-and-forget vs. loop).
+
+✓ flushPendingSyncPublishes(): confirmed uses service.publishRideHistoryAndMark
+  directly; not affected by this change.
+
+✓ performStartupSync() rideHistory strategy: confirmed uses service directly;
+  not affected by this change.
+
+=== FINDINGS ===
+
+FINDING 1 — CRITICAL
+Title: HistoryTab call site won't compile — appState.syncCoordinator is private
+File: Step 6 (Option B), HistoryTab.swift proposed change
+
+AppState declares:
+    private var syncCoordinator: SyncCoordinator?
+
+HistoryTab accesses AppState via @Environment and cannot reach syncCoordinator.
+The plan's Option B code:
+    appState.syncCoordinator.rideHistorySyncCoordinator?.publishAndMark(...)
+will not compile. This is a real compilation failure, not a style issue.
+
+Resolution (applied to plan): Option B's HistoryTab call site must use one of:
+  (a) appState.rideCoordinator?.backupRideHistory() — unchanged from today, if
+      backupRideHistory() is the thin bridge (Option A). This is the recommended
+      path: keep Option A for HistoryTab's call site, keep backupRideHistory()
+      as the public API, but change its body to delegate to the coordinator.
+  (b) A new AppState convenience method publishRideHistoryBackup() similar to
+      publishProfileBackup() — exposes the coordinator call to views without
+      making syncCoordinator itself accessible.
+
+The recommended fix (applied to plan): use thin bridge (Option A) for the
+HistoryTab call site. HistoryTab's code stays as-is. Only backupRideHistory()'s
+body changes.
+
+FINDING 2 — CRITICAL
+Title: RideCoordinator injection path not resolved — no reference to coordinator
+File: Step 6 (both options), Step 4
+
+RideCoordinator holds roadflareDomainService and roadflareSyncStore directly.
+It has NO reference to SyncCoordinator or RideHistorySyncCoordinator. The plan
+flags this as an open design decision but does not specify how to inject the
+coordinator into RideCoordinator.
+
+AppState.setupServices() creates SyncCoordinator first (calls configure(), which
+creates rideHistorySyncCoordinator), then creates RideCoordinator. The injection
+point exists naturally.
+
+Resolution (applied to plan):
+1. Add `var rideHistorySyncCoordinator: RideHistorySyncCoordinator?` to
+   RideCoordinator (internal visibility; AppState is in the same module).
+2. In AppState.setupServices() and setupServicesWithSync(), after creating
+   coordinator (RideCoordinator), add:
+     coordinator.rideHistorySyncCoordinator = sync.rideHistorySyncCoordinator
+3. In prepareForIdentityReplacement(), teardown() bumps the generation and
+   clears the coordinator from SyncCoordinator. When rideCoordinator = nil
+   fires, the ref is released. Because syncStoreRef is weak and generation
+   was bumped, any in-flight Task exits cleanly. No explicit nil needed in
+   prepareForIdentityReplacement — the teardown order handles it.
+4. backupRideHistory() body becomes:
+     rideHistorySyncCoordinator?.publishAndMark(from: rideHistory)
+   This is Option A (thin bridge) — the cleanest change with lowest risk.
+
+FINDING 3 — MEDIUM
+Title: Missing regression test — restoreFromBackup no longer marks dirty
+File: Step 2 test cases; SyncDomainTrackerTests
+
+The primary motivation for removing onRidesChanged → markDirty is that
+restoreFromBackup fires onRidesChanged?() (confirmed at RideHistoryRepository
+line 94), causing a false-dirty during startup sync. No test verifies this
+behavior is fixed.
+
+After removing the wiring, a test should confirm:
+  rideHistory.restoreFromBackup([entry])
+  → store.metadata(for: .rideHistory).isDirty == false
+
+This should live in SyncDomainTrackerTests (same file where onRidesChanged
+wiring tests live), as a companion to the deleted onRidesChanged_marksRideHistoryDirty.
+
+Resolution (applied to plan): Added test 7:
+  restoreFromBackup_doesNotMarkRideHistoryDirty
+to SyncDomainTrackerTests section in the plan.
+
+FINDING 4 — MINOR
+Title: `rides` read described as "main-actor isolated" — incorrect
+File: publishAndMark docstring in the New SDK Type section
+
+The plan says:
+  "Safe to call from @MainActor — the Task captures the rides snapshot at call
+   time via rideHistory.rides (main-actor isolated read)."
+
+RideHistoryRepository is @unchecked Sendable + NSLock, not @MainActor-isolated.
+reads of .rides are thread-safe from any context, not "main-actor isolated."
+The docstring is technically misleading — `rides` could be read from a background
+thread just as safely.
+
+Resolution (applied to plan): Changed to "NSLock-protected read — thread-safe
+from any context."
+
+FINDING 5 — MINOR
+Title: Step 5 self-contradiction on _detachUnchecked() rideHistory.onRidesChanged = nil
+File: Step 5 "Update SyncDomainTracker"
+
+The plan says in one bullet:
+  "remove the `rideHistory.onRidesChanged = nil` line"
+And in the next bullet:
+  "still nils the callback in detach() as a defensive no-op"
+
+These contradict. Removing the nil assignment IS removing the defensive no-op.
+
+Resolution (applied to plan): Keep `rideHistory.onRidesChanged = nil` in
+_detachUnchecked(). Rationale: after the wiring is removed from wireCallbacks(),
+the nil assignment in detach becomes a harmless no-op — but keeping it is
+defensive and consistent (all repos that are passed to init get their callbacks
+nil'd in detach, whether or not the callbacks were set). Removing the nil would
+require also removing the rideHistory property from init, which the plan
+recommends against.
+
+=== CODE ACCURACY ===
+
+- RideCoordinator.recordRideHistory() line numbers: plan says 308–332 for
+  recordRideHistory and 336–348 for backupRideHistory. Verified approximately
+  correct from the read (addRide at line ~324, backupRideHistory() call at ~331,
+  method definition at ~336).
+
+- The plan correctly says forceEndRide() calls recordRideHistory() (it does).
+  The delegate's sessionDidReachTerminal(.completed) also calls recordRideHistory().
+  Both are covered by the proposed thin bridge.
+
+- SyncCoordinator.wireTrackingCallbacks() uses the detach/nil/create pattern
+  correctly as described. The plan's ARC safety analysis is correct.
+
+- ProfileBackupCoordinator pattern: plan's proposed RideHistorySyncCoordinator
+  correctly simplifies (no isPublishing loop) since ride history publishes are
+  not expected to be concurrent-heavy. Rationale is sound.
+
+=== ENTROPY CHECK ===
+
+Genuine simplification: yes. Two paths (onRidesChanged → markDirty and
+backupRideHistory → publish) are unified into one (coordinator → publish, with
+markDirty only on failure). SyncDomainTracker sheds one domain. The reconnect
+flush path (flushPendingSyncPublishes) remains as the correct passive safety net.
+The false-dirty during restoreFromBackup is eliminated.
+
+The new class (RideHistorySyncCoordinator ~80 lines) replaces ~15 lines of
+scattered logic across RideCoordinator + SyncDomainTracker. Net complexity is
+positive: test coverage + explicit SDK boundary outweigh the new file.
+
+=== CHANGES MADE TO PLAN ===
+
+1. Step 6: Removed the ambiguous Option A/B framing. Prescribed explicit path:
+   - Option A (thin bridge) is the recommended approach.
+   - Added injection requirement: RideCoordinator gets var rideHistorySyncCoordinator.
+   - AppState injection points specified for both setupServices() paths.
+   - HistoryTab call site stays as-is (appState.rideCoordinator?.backupRideHistory()).
+
+2. Step 5: Clarified that rideHistory.onRidesChanged = nil stays in _detachUnchecked().
+
+3. Test cases: Added test 7 to SyncDomainTrackerTests section.
+
+4. publishAndMark docstring: Corrected "main-actor isolated read" → "NSLock-protected read".


### PR DESCRIPTION
## Summary

- Introduces `RideHistorySyncCoordinator` (SDK) — owns the fire-and-forget publish Task for ride-history backups, parallel to `ProfileBackupCoordinator`. Marks `.rideHistory` dirty on failure so `flushPendingSyncPublishes` retries on reconnect.
- Removes `onRidesChanged → markDirty(.rideHistory)` from `SyncDomainTracker` — this wiring was redundant (coordinator's `catch { markDirty }` covers it) and caused a false-dirty bug during startup sync (`restoreFromBackup` fired the callback immediately after restoring from relay).
- `RideCoordinator.backupRideHistory()` becomes a thin one-line bridge to the coordinator; `HistoryTab` call site is unchanged.

ADR: `decisions/0007-ride-history-sync-coordinator.md`

Closes #39

## Test Plan

- [x] 6 new SDK unit tests in `RideHistorySyncCoordinatorTests.swift` (TDD): happy path, failure/dirty, empty history, generation guard via `clearAll`, snapshot isolation, clearAll-after-success regression
- [x] 1 new `SyncDomainTrackerTests` regression: `restoreFromBackup_doesNotMarkRideHistoryDirty`
- [x] Deleted `onRidesChanged_marksRideHistoryDirty` (tests removed wiring)
- [x] 799 SDK tests pass (`swift test --package-path RidestrSDK`)
- [x] Full Xcode build clean (no concurrency errors)
- [x] 69 app tests pass (`RoadFlareTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)