### PR TITLE
refactor(sdk): move driver ping preflight into repository

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/DriverPingResult.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/DriverPingResult.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Result of a Kind 3189 driver ping attempt.
+public enum DriverPingResult: Sendable, Equatable {
+    case sent
+    case rateLimited(retryAfter: Date)
+    case missingKey
+    case ineligible
+    case publishFailed(String)
+}

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
@@ -158,12 +158,16 @@ public final class FollowedDriversRepository: @unchecked Sendable {
     ///
     /// Independent of any sender-side cooldown — that layer lives in the app.
     public func canPingDriver(_ driver: FollowedDriver) -> Bool {
-        guard driver.hasKey else { return false }
-        return lock.withLock {
-            guard !staleKeyPubkeys.contains(driver.pubkey) else { return false }
-            let status = driverLocations[driver.pubkey]?.status
-            return status != "online" && status != "on_ride"
-        }
+        lock.withLock { driverPingPreflightLocked(driverPubkey: driver.pubkey) == nil }
+    }
+
+    /// Shared send-time validation for Kind 3189 driver pings.
+    ///
+    /// Returns `nil` when the ping may proceed. The lookup and eligibility check share the
+    /// same lock so a background sync cannot race the caller into observing different driver,
+    /// key-staleness, or location snapshots across separate reads.
+    public func driverPingPreflight(driverPubkey: String) -> DriverPingResult? {
+        lock.withLock { driverPingPreflightLocked(driverPubkey: driverPubkey) }
     }
 
     // MARK: - Driver Names
@@ -425,6 +429,17 @@ public final class FollowedDriversRepository: @unchecked Sendable {
             return incoming.version > existing.version ? .appliedNewer : .ignoredOlder
         }
         return .ignoredOlder
+    }
+
+    private func driverPingPreflightLocked(driverPubkey: String) -> DriverPingResult? {
+        guard let driver = drivers.first(where: { $0.pubkey == driverPubkey }) else {
+            return .ineligible
+        }
+        guard driver.hasKey else { return .missingKey }
+        guard !staleKeyPubkeys.contains(driver.pubkey) else { return .ineligible }
+        let status = driverLocations[driver.pubkey]?.status
+        guard status != "online" && status != "on_ride" else { return .ineligible }
+        return nil
     }
 }
 

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -12,15 +12,6 @@ public enum AuthState {
     case ready
 }
 
-/// Result of a driver ping attempt.
-public enum DriverPingResult: Sendable, Equatable {
-    case sent
-    case rateLimited(retryAfter: Date)
-    case missingKey          // Driver hasn't approved the follow yet
-    case ineligible          // Driver exists, but ping is currently not allowed
-    case publishFailed(String)
-}
-
 /// Central app state coordinator. Owns SDK services and manages auth lifecycle.
 ///
 /// Views access this via `@Environment(AppState.self)`. All sync orchestration
@@ -252,40 +243,9 @@ public final class AppState {
     /// Checks: has a current RoadFlare key, key is not stale, driver is not online,
     /// driver is not on a ride. Independent of the per-driver cooldown — use
     /// `sendDriverPing` for the full send-with-cooldown flow.
-    /// Delegates to the `nonisolated static` overload, which tests can call synchronously
-    /// without `await` or MainActor context.
     public func canPingDriver(_ driver: FollowedDriver) -> Bool {
         guard let repo = driversRepository else { return false }
-        return AppState.canPingDriver(driver, using: repo)
-    }
-
-    /// Thin wrapper kept for test ergonomics. The actual eligibility check lives in
-    /// `FollowedDriversRepository.canPingDriver(_:)` so composite reads across
-    /// `staleKeyPubkeys` and `driverLocations` take the repo lock atomically instead of
-    /// two unlocked property reads from an `@unchecked Sendable` type.
-    nonisolated static func canPingDriver(_ driver: FollowedDriver, using repo: FollowedDriversRepository) -> Bool {
-        repo.canPingDriver(driver)
-    }
-
-    /// Shared preflight for send-time validation. Returns nil when the ping may proceed.
-    ///
-    /// This rechecks the same structural eligibility as the UI so a stale-key or presence
-    /// update that lands after the bell renders cannot still burn the rider's cooldown.
-    nonisolated static func driverPingPreflight(
-        driverPubkey: String,
-        using repo: FollowedDriversRepository
-    ) -> DriverPingResult? {
-        guard let driver = repo.getDriver(pubkey: driverPubkey) else { return .ineligible }
-        return driverPingPreflight(driver, using: repo)
-    }
-
-    nonisolated private static func driverPingPreflight(
-        _ driver: FollowedDriver,
-        using repo: FollowedDriversRepository
-    ) -> DriverPingResult? {
-        guard driver.hasKey else { return .missingKey }
-        guard canPingDriver(driver, using: repo) else { return .ineligible }
-        return nil
+        return repo.canPingDriver(driver)
     }
 
     /// Send Kind 3189 driver ping request to an offline driver.
@@ -314,13 +274,12 @@ public final class AppState {
         guard let repo = driversRepository else {
             return .ineligible
         }
-        guard let driver = repo.getDriver(pubkey: driverPubkey) else {
-            return .ineligible
-        }
-        if let preflightFailure = Self.driverPingPreflight(driver, using: repo) {
+        if let preflightFailure = repo.driverPingPreflight(driverPubkey: driverPubkey) {
             return preflightFailure
         }
-        let roadflareKey = driver.roadflareKey!
+        guard let roadflareKey = repo.getRoadflareKey(driverPubkey: driverPubkey) else {
+            return .ineligible
+        }
 
         // 3. Require rider identity
         guard let kp = keypair, let rm = relayManager,

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -493,3 +493,22 @@ public final class AppState {
         bitcoinPrice.stop()
     }
 }
+
+#if DEBUG
+extension AppState {
+    /// Test seam for unit tests that exercise ping behavior without running full service setup.
+    func installDriverPingTestContext(
+        keypair: NostrKeypair? = nil,
+        relayManager: RelayManager? = nil,
+        driversRepository: FollowedDriversRepository? = nil
+    ) {
+        self.keypair = keypair
+        self.relayManager = relayManager
+        self.driversRepository = driversRepository
+    }
+
+    func primePingCooldownForTesting(driverPubkey: String, lastPing: Date) {
+        pingCooldowns[driverPubkey] = lastPing
+    }
+}
+#endif

--- a/RoadFlare/RoadFlareTests/AppState/CanPingDriverTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/CanPingDriverTests.swift
@@ -1,5 +1,4 @@
 import Testing
-@testable import RoadFlareCore
 import RidestrSDK
 
 // Use the SDK's own InMemoryFollowedDriversPersistence (FollowedDriversRepository.swift:459)
@@ -17,20 +16,20 @@ private func makeRepo(driver: FollowedDriver) -> FollowedDriversRepository {
     return repo
 }
 
-@Suite("AppState.canPingDriver")
+@Suite("FollowedDriversRepository.canPingDriver")
 struct CanPingDriverTests {
 
     @Test func noKey_returnsFalse() {
         let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: nil)
         let repo = makeRepo(driver: driver)
-        #expect(AppState.canPingDriver(driver, using: repo) == false)
+        #expect(repo.canPingDriver(driver) == false)
     }
 
     @Test func staleKey_returnsFalse() {
         let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
         let repo = makeRepo(driver: driver)
         repo.markKeyStale(pubkey: testPubkey)
-        #expect(AppState.canPingDriver(driver, using: repo) == false)
+        #expect(repo.canPingDriver(driver) == false)
     }
 
     @Test func online_returnsFalse() {
@@ -38,7 +37,7 @@ struct CanPingDriverTests {
         let repo = makeRepo(driver: driver)
         _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
                                       status: "online", timestamp: 1_000_000, keyVersion: 1)
-        #expect(AppState.canPingDriver(driver, using: repo) == false)
+        #expect(repo.canPingDriver(driver) == false)
     }
 
     @Test func onRide_returnsFalse() {
@@ -46,36 +45,50 @@ struct CanPingDriverTests {
         let repo = makeRepo(driver: driver)
         _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
                                       status: "on_ride", timestamp: 1_000_000, keyVersion: 1)
-        #expect(AppState.canPingDriver(driver, using: repo) == false)
+        #expect(repo.canPingDriver(driver) == false)
     }
 
     @Test func offlineWithCurrentKey_returnsTrue() {
         let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
         let repo = makeRepo(driver: driver)
         // No location update → driver is offline (nil status)
-        #expect(AppState.canPingDriver(driver, using: repo) == true)
+        #expect(repo.canPingDriver(driver) == true)
+    }
+
+    @Test func staleCallerSnapshot_missingKeyButRepoHasCurrentKey_returnsTrue() {
+        let repoDriver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let staleSnapshot = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: nil)
+        let repo = makeRepo(driver: repoDriver)
+        #expect(repo.canPingDriver(staleSnapshot) == true)
+    }
+
+    @Test func staleCallerSnapshot_hasKeyButRepoMissingKey_returnsFalse() {
+        let repoDriver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: nil)
+        let staleSnapshot = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: repoDriver)
+        #expect(repo.canPingDriver(staleSnapshot) == false)
     }
 }
 
-@Suite("AppState.driverPingPreflight")
+@Suite("FollowedDriversRepository.driverPingPreflight")
 struct DriverPingPreflightTests {
 
     @Test func unknownDriver_returnsIneligible() {
         let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
-        #expect(AppState.driverPingPreflight(driverPubkey: testPubkey, using: repo) == .ineligible)
+        #expect(repo.driverPingPreflight(driverPubkey: testPubkey) == .ineligible)
     }
 
     @Test func missingKey_returnsMissingKey() {
         let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: nil)
         let repo = makeRepo(driver: driver)
-        #expect(AppState.driverPingPreflight(driverPubkey: testPubkey, using: repo) == .missingKey)
+        #expect(repo.driverPingPreflight(driverPubkey: testPubkey) == .missingKey)
     }
 
     @Test func staleKey_returnsIneligible() {
         let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
         let repo = makeRepo(driver: driver)
         repo.markKeyStale(pubkey: testPubkey)
-        #expect(AppState.driverPingPreflight(driverPubkey: testPubkey, using: repo) == .ineligible)
+        #expect(repo.driverPingPreflight(driverPubkey: testPubkey) == .ineligible)
     }
 
     @Test func online_returnsIneligible() {
@@ -83,12 +96,12 @@ struct DriverPingPreflightTests {
         let repo = makeRepo(driver: driver)
         _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
                                       status: "online", timestamp: 1_000_000, keyVersion: 1)
-        #expect(AppState.driverPingPreflight(driverPubkey: testPubkey, using: repo) == .ineligible)
+        #expect(repo.driverPingPreflight(driverPubkey: testPubkey) == .ineligible)
     }
 
     @Test func offlineWithCurrentKey_returnsNil() {
         let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
         let repo = makeRepo(driver: driver)
-        #expect(AppState.driverPingPreflight(driverPubkey: testPubkey, using: repo) == nil)
+        #expect(repo.driverPingPreflight(driverPubkey: testPubkey) == nil)
     }
 }

--- a/RoadFlare/RoadFlareTests/RoadFlareTests.swift
+++ b/RoadFlare/RoadFlareTests/RoadFlareTests.swift
@@ -146,6 +146,16 @@ struct SavedLocationsRepositoryTests {
 
 @Suite("AppState Tests")
 struct AppStateTests {
+    private func makeRoadflareKey(version: Int = 1) throws -> RoadflareKey {
+        let keypair = try NostrKeypair.generate()
+        return RoadflareKey(
+            privateKeyHex: keypair.privateKeyHex,
+            publicKeyHex: keypair.publicKeyHex,
+            version: version,
+            keyUpdatedAt: version
+        )
+    }
+
     @MainActor
     @Test func localAuthStateRequiresRoadflareMethodsBeforeReady() {
         let appState = AppState()
@@ -204,6 +214,77 @@ struct AppStateTests {
         // Both coordinators/tracker should be released
         #expect(sync.profileBackupCoordinator == nil)
         #expect(sync.syncDomainTracker == nil)
+    }
+
+    @MainActor
+    @Test func sendDriverPing_returnsRateLimitedWhenCooldownActive() async {
+        let appState = AppState()
+        let driverPubkey = String(repeating: "a", count: 64)
+
+        appState.primePingCooldownForTesting(
+            driverPubkey: driverPubkey,
+            lastPing: Date.now.addingTimeInterval(-60)
+        )
+
+        let result = await appState.sendDriverPing(driverPubkey: driverPubkey)
+        switch result {
+        case .rateLimited(let retryAfter):
+            #expect(retryAfter.timeIntervalSinceNow > 0)
+        default:
+            #expect(Bool(false))
+        }
+    }
+
+    @MainActor
+    @Test func sendDriverPing_passthroughsRepoPreflightFailures() async throws {
+        let appState = AppState()
+        let driverPubkey = String(repeating: "b", count: 64)
+        let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+        repo.addDriver(FollowedDriver(pubkey: driverPubkey, name: "Bob", roadflareKey: nil))
+
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        let result = await appState.sendDriverPing(driverPubkey: driverPubkey)
+        #expect(result == .missingKey)
+    }
+
+    @MainActor
+    @Test func sendDriverPing_publishFailureRollsBackCooldown() async throws {
+        let appState = AppState()
+        let riderKeypair = try NostrKeypair.generate()
+        let driverIdentity = try NostrKeypair.generate()
+        let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+        let relayManager = RelayManager(keypair: riderKeypair)
+        repo.addDriver(
+            FollowedDriver(
+                pubkey: driverIdentity.publicKeyHex,
+                name: "Bob",
+                roadflareKey: try makeRoadflareKey()
+            )
+        )
+
+        appState.settings.setProfileName("Alice")
+        appState.installDriverPingTestContext(
+            keypair: riderKeypair,
+            relayManager: relayManager,
+            driversRepository: repo
+        )
+
+        let first = await appState.sendDriverPing(driverPubkey: driverIdentity.publicKeyHex)
+        switch first {
+        case .publishFailed:
+            break
+        default:
+            #expect(Bool(false))
+        }
+
+        let second = await appState.sendDriverPing(driverPubkey: driverIdentity.publicKeyHex)
+        switch second {
+        case .publishFailed:
+            break
+        default:
+            #expect(Bool(false))
+        }
     }
 }
 

--- a/decisions/0009-driver-ping-kind-3189.md
+++ b/decisions/0009-driver-ping-kind-3189.md
@@ -53,6 +53,7 @@ Prevents replay attacks — a captured ping event cannot be replayed outside the
 - `RidestrSDK/Sources/RidestrSDK/Nostr/EventKind.swift`
 - `RidestrSDK/Sources/RidestrSDK/Nostr/Constants.swift`
 - `RidestrSDK/Sources/RidestrSDK/Nostr/RideshareEventBuilder.swift`
+- `RidestrSDK/Sources/RidestrSDK/RoadFlare/DriverPingResult.swift`
 - `RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift`
 - `RoadFlare/RoadFlareCore/ViewModels/AppState.swift`
 - `RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift`


### PR DESCRIPTION
## Summary
- move DriverPingResult from AppState into RidestrSDK
- move send-time driver ping preflight into FollowedDriversRepository and simplify AppState.sendDriverPing
- update driver-ping tests to target the SDK repo directly and add stale-snapshot regression coverage

## Verification
- xcodebuild -project RoadFlare/RoadFlare.xcodeproj -scheme RoadFlareTests -destination 'platform=iOS Simulator,id=84EB3743-25F7-41AD-94E6-3C833BE4BB29' test
- swift test

Closes #45