### PR TITLE
fix(qr): parse driver share URLs

### DIFF
--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -277,18 +277,24 @@ struct AddDriverSheet: View {
         let trimmed = pubkeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
+        guard let parsed = DriverQRCodeParser.parse(trimmed) else {
+            errorMessage = "Enter a valid npub, hex key, or driver share URL"
+            return
+        }
+
+        if scannedName == nil {
+            scannedName = parsed.scannedName
+        }
+
         let hexPubkey: String
-        if trimmed.hasPrefix("npub1") {
-            guard let decoded = try? NIP19.npubDecode(trimmed) else {
+        if parsed.pubkeyInput.hasPrefix("npub1") {
+            guard let decoded = try? NIP19.npubDecode(parsed.pubkeyInput) else {
                 errorMessage = "Invalid npub format"
                 return
             }
             hexPubkey = decoded
-        } else if trimmed.count == 64 && trimmed.allSatisfy(\.isHexDigit) {
-            hexPubkey = trimmed
         } else {
-            errorMessage = "Enter a valid npub or 64-character hex key"
-            return
+            hexPubkey = parsed.pubkeyInput
         }
 
         errorMessage = nil

--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -261,49 +261,14 @@ struct AddDriverSheet: View {
 
     private func handleScan(_ value: String) {
         showScanner = false
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Parse nostr: URI with optional ?name= parameter
-        // Format: nostr:npub1...?name=URL%20Encoded%20Name
-        var npubPart: String
-        var nameParam: String?
-
-        if trimmed.hasPrefix("nostr:") {
-            let withoutScheme = String(trimmed.dropFirst(6))
-            // Split on ? to extract query parameters
-            let parts = withoutScheme.split(separator: "?", maxSplits: 1)
-            npubPart = String(parts[0])
-            if parts.count > 1 {
-                nameParam = parseNameParam(String(parts[1]))
-            }
-        } else if trimmed.hasPrefix("npub1") {
-            let parts = trimmed.split(separator: "?", maxSplits: 1)
-            npubPart = String(parts[0])
-            if parts.count > 1 {
-                nameParam = parseNameParam(String(parts[1]))
-            }
-        } else if trimmed.count == 64 && trimmed.allSatisfy(\.isHexDigit) {
-            npubPart = trimmed
-        } else {
+        guard let parsed = DriverQRCodeParser.parse(value) else {
             errorMessage = "QR code doesn't contain a valid Nostr public key"
             return
         }
 
-        scannedName = nameParam
-        pubkeyInput = npubPart
+        scannedName = parsed.scannedName
+        pubkeyInput = parsed.pubkeyInput
         resolveInput()
-    }
-
-    /// Extract name= parameter from URL query string.
-    private func parseNameParam(_ query: String) -> String? {
-        let pairs = query.split(separator: "&")
-        for pair in pairs {
-            let kv = pair.split(separator: "=", maxSplits: 1)
-            if kv.count == 2 && kv[0] == "name" {
-                return String(kv[1]).removingPercentEncoding
-            }
-        }
-        return nil
     }
 
     // MARK: - Resolve Input

--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -123,6 +123,7 @@ struct AddDriverSheet: View {
                     .foregroundColor(Color.rfOnSurface)
                     .onChange(of: pubkeyInput) {
                         errorMessage = nil
+                        scannedName = nil
                     }
                     .onSubmit { resolveInput() }
 
@@ -282,9 +283,7 @@ struct AddDriverSheet: View {
             return
         }
 
-        if scannedName == nil {
-            scannedName = parsed.scannedName
-        }
+        scannedName = parsed.scannedName
 
         let hexPubkey: String
         if parsed.pubkeyInput.hasPrefix("npub1") {

--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -8,14 +8,12 @@ import RoadFlareCore
 struct AddDriverSheet: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
-    @State private var pubkeyInput = ""
-    @State private var errorMessage: String?
+    @State private var lookupDraft = DriverLookupDraft()
     @State private var showScanner = false
 
     // Resolved driver state
     @State private var resolvedHexPubkey: String?
     @State private var resolvedProfile: UserProfileContent?
-    @State private var scannedName: String?  // From QR ?name= parameter
     @State private var isFetchingProfile = false
     @State private var noteInput = ""
 
@@ -113,7 +111,7 @@ struct AddDriverSheet: View {
                     .font(RFFont.caption())
                     .foregroundColor(Color.rfOnSurfaceVariant)
 
-                TextField("Paste npub or Account ID", text: $pubkeyInput)
+                TextField("Paste npub or Account ID", text: pubkeyInputBinding)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
                     .font(RFFont.mono(14))
@@ -121,20 +119,16 @@ struct AddDriverSheet: View {
                     .background(Color.rfSurfaceContainerLow)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                     .foregroundColor(Color.rfOnSurface)
-                    .onChange(of: pubkeyInput) {
-                        errorMessage = nil
-                        scannedName = nil
-                    }
                     .onSubmit { resolveInput() }
 
                 Button { resolveInput() } label: {
                     Text("Look Up Driver")
                 }
-                .buttonStyle(RFPrimaryButtonStyle(isDisabled: pubkeyInput.trimmingCharacters(in: .whitespaces).isEmpty))
-                .disabled(pubkeyInput.trimmingCharacters(in: .whitespaces).isEmpty || isFetchingProfile)
+                .buttonStyle(RFPrimaryButtonStyle(isDisabled: lookupDraft.pubkeyInput.trimmingCharacters(in: .whitespaces).isEmpty))
+                .disabled(lookupDraft.pubkeyInput.trimmingCharacters(in: .whitespaces).isEmpty || isFetchingProfile)
             }
 
-            if let error = errorMessage {
+            if let error = lookupDraft.errorMessage {
                 Text(error)
                     .font(RFFont.caption())
                     .foregroundColor(Color.rfError)
@@ -224,7 +218,8 @@ struct AddDriverSheet: View {
             Button {
                 resolvedHexPubkey = nil
                 resolvedProfile = nil
-                scannedName = nil
+                lookupDraft.errorMessage = nil
+                lookupDraft.scannedName = nil
                 noteInput = ""
             } label: {
                 Text("Look Up Different Driver")
@@ -244,10 +239,21 @@ struct AddDriverSheet: View {
         }
     }
 
+    private var pubkeyInputBinding: Binding<String> {
+        Binding(
+            get: { lookupDraft.pubkeyInput },
+            set: { newValue in
+                var updatedDraft = lookupDraft
+                updatedDraft.updatePubkeyInput(newValue)
+                lookupDraft = updatedDraft
+            }
+        )
+    }
+
     private var driverDisplayName: String {
         resolvedProfile?.displayName
             ?? resolvedProfile?.name
-            ?? scannedName
+            ?? lookupDraft.scannedName
             ?? "Unknown Driver"
     }
 
@@ -262,41 +268,15 @@ struct AddDriverSheet: View {
 
     private func handleScan(_ value: String) {
         showScanner = false
-        guard let parsed = DriverQRCodeParser.parse(value) else {
-            errorMessage = "QR code doesn't contain a valid Nostr public key"
-            return
-        }
-
-        scannedName = parsed.scannedName
-        pubkeyInput = parsed.pubkeyInput
+        guard lookupDraft.applyScannedCode(value) != nil else { return }
         resolveInput()
     }
 
     // MARK: - Resolve Input
 
     private func resolveInput() {
-        let trimmed = pubkeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-
-        guard let parsed = DriverQRCodeParser.parse(trimmed) else {
-            errorMessage = "Enter a valid npub, hex key, or driver share URL"
-            return
-        }
-
-        scannedName = parsed.scannedName
-
-        let hexPubkey: String
-        if parsed.pubkeyInput.hasPrefix("npub1") {
-            guard let decoded = try? NIP19.npubDecode(parsed.pubkeyInput) else {
-                errorMessage = "Invalid npub format"
-                return
-            }
-            hexPubkey = decoded
-        } else {
-            hexPubkey = parsed.pubkeyInput
-        }
-
-        errorMessage = nil
+        guard let lookup = lookupDraft.resolveLookup() else { return }
+        let hexPubkey = lookup.hexPubkey
 
         // Fetch driver's Kind 0 profile from Nostr, then show the card
         isFetchingProfile = true
@@ -316,7 +296,7 @@ struct AddDriverSheet: View {
     // MARK: - Add Driver
 
     private func addDriver(hexPubkey: String) {
-        let name = resolvedProfile?.displayName ?? resolvedProfile?.name ?? scannedName
+        let name = resolvedProfile?.displayName ?? resolvedProfile?.name ?? lookupDraft.scannedName
         let driver = FollowedDriver(
             pubkey: hexPubkey,
             name: name,

--- a/RoadFlare/RoadFlareCore/Services/DriverLookupDraft.swift
+++ b/RoadFlare/RoadFlareCore/Services/DriverLookupDraft.swift
@@ -1,0 +1,74 @@
+import Foundation
+import RidestrSDK
+
+public struct ResolvedDriverLookup: Equatable {
+    public let hexPubkey: String
+    public let parsedQRCode: ParsedDriverQRCode
+
+    public init(hexPubkey: String, parsedQRCode: ParsedDriverQRCode) {
+        self.hexPubkey = hexPubkey
+        self.parsedQRCode = parsedQRCode
+    }
+}
+
+public struct DriverLookupDraft: Equatable {
+    public var pubkeyInput: String
+    public var errorMessage: String?
+    public var scannedName: String?
+
+    public init(
+        pubkeyInput: String = "",
+        errorMessage: String? = nil,
+        scannedName: String? = nil
+    ) {
+        self.pubkeyInput = pubkeyInput
+        self.errorMessage = errorMessage
+        self.scannedName = scannedName
+    }
+
+    public mutating func updatePubkeyInput(_ newValue: String) {
+        pubkeyInput = newValue
+        errorMessage = nil
+        scannedName = nil
+    }
+
+    @discardableResult
+    public mutating func applyScannedCode(_ rawValue: String) -> ParsedDriverQRCode? {
+        guard let parsed = DriverQRCodeParser.parse(rawValue) else {
+            errorMessage = "QR code doesn't contain a valid Nostr public key"
+            scannedName = nil
+            return nil
+        }
+
+        pubkeyInput = parsed.pubkeyInput
+        scannedName = parsed.scannedName
+        errorMessage = nil
+        return parsed
+    }
+
+    public mutating func resolveLookup() -> ResolvedDriverLookup? {
+        let trimmed = pubkeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        guard let parsed = DriverQRCodeParser.parse(trimmed) else {
+            errorMessage = "Enter a valid npub, hex key, or driver share URL"
+            return nil
+        }
+
+        scannedName = parsed.scannedName
+
+        let hexPubkey: String
+        if parsed.pubkeyInput.hasPrefix("npub1") {
+            guard let decoded = try? NIP19.npubDecode(parsed.pubkeyInput) else {
+                errorMessage = "Invalid npub format"
+                return nil
+            }
+            hexPubkey = decoded
+        } else {
+            hexPubkey = parsed.pubkeyInput
+        }
+
+        errorMessage = nil
+        return ResolvedDriverLookup(hexPubkey: hexPubkey, parsedQRCode: parsed)
+    }
+}

--- a/RoadFlare/RoadFlareCore/Services/DriverQRCodeParser.swift
+++ b/RoadFlare/RoadFlareCore/Services/DriverQRCodeParser.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+public struct ParsedDriverQRCode: Equatable {
+    public let pubkeyInput: String
+    public let scannedName: String?
+}
+
+public enum DriverQRCodeParser {
+    public static func parse(_ rawValue: String) -> ParsedDriverQRCode? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let parsed = parseNostrURI(trimmed) {
+            return parsed
+        }
+
+        if let parsed = parseBareNpub(trimmed) {
+            return parsed
+        }
+
+        if let parsed = parseHexPubkey(trimmed) {
+            return parsed
+        }
+
+        return parseURLOrEmbeddedNpub(trimmed)
+    }
+
+    private static func parseNostrURI(_ value: String) -> ParsedDriverQRCode? {
+        guard value.hasPrefix("nostr:") else { return nil }
+        let withoutScheme = String(value.dropFirst(6))
+        return parseNpubWithOptionalQuery(withoutScheme)
+    }
+
+    private static func parseBareNpub(_ value: String) -> ParsedDriverQRCode? {
+        guard value.hasPrefix("npub1") else { return nil }
+        return parseNpubWithOptionalQuery(value)
+    }
+
+    private static func parseNpubWithOptionalQuery(_ value: String) -> ParsedDriverQRCode? {
+        let parts = value.split(separator: "?", maxSplits: 1)
+        let npubPart = String(parts[0])
+        guard npubPart.hasPrefix("npub1") else { return nil }
+
+        let nameParam: String?
+        if parts.count > 1 {
+            nameParam = parseNameParam(String(parts[1]))
+        } else {
+            nameParam = nil
+        }
+
+        return ParsedDriverQRCode(pubkeyInput: npubPart, scannedName: nameParam)
+    }
+
+    private static func parseHexPubkey(_ value: String) -> ParsedDriverQRCode? {
+        guard value.count == 64, value.allSatisfy(\.isHexDigit) else { return nil }
+        return ParsedDriverQRCode(pubkeyInput: value, scannedName: nil)
+    }
+
+    private static func parseURLOrEmbeddedNpub(_ value: String) -> ParsedDriverQRCode? {
+        guard let npubRange = value.range(of: #"npub1[a-z0-9]{58,}"#, options: .regularExpression) else {
+            return nil
+        }
+
+        let scannedName = parseName(from: value)
+        return ParsedDriverQRCode(pubkeyInput: String(value[npubRange]), scannedName: scannedName)
+    }
+
+    private static func parseName(from value: String) -> String? {
+        if let components = URLComponents(string: value),
+           let name = components.queryItems?.first(where: { $0.name == "name" })?.value,
+           let trimmedName = trimmedNonEmpty(name)
+        {
+            return trimmedName
+        }
+
+        guard let queryStart = value.firstIndex(of: "?") else { return nil }
+        let query = String(value[value.index(after: queryStart)...])
+        return parseNameParam(query)
+    }
+
+    private static func parseNameParam(_ query: String) -> String? {
+        let pairs = query.split(separator: "&")
+        for pair in pairs {
+            let kv = pair.split(separator: "=", maxSplits: 1)
+            if kv.count == 2, kv[0] == "name" {
+                return trimmedNonEmpty(String(kv[1]).removingPercentEncoding ?? String(kv[1]))
+            }
+        }
+        return nil
+    }
+
+    private static func trimmedNonEmpty(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/RoadFlare/RoadFlareCore/Services/DriverQRCodeParser.swift
+++ b/RoadFlare/RoadFlareCore/Services/DriverQRCodeParser.swift
@@ -6,6 +6,13 @@ public struct ParsedDriverQRCode: Equatable {
 }
 
 public enum DriverQRCodeParser {
+    /// Parse a driver identifier from any supported format.
+    ///
+    /// Accepted inputs:
+    /// - `nostr:npub1...` URI (with optional `?name=`)
+    /// - Bare `npub1...` key (with optional `?name=`)
+    /// - 64-character hex public key
+    /// - URL containing an embedded npub (e.g. `https://roadflare.app/share/d/npub1...`)
     public static func parse(_ rawValue: String) -> ParsedDriverQRCode? {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -57,7 +64,7 @@ public enum DriverQRCodeParser {
     }
 
     private static func parseURLOrEmbeddedNpub(_ value: String) -> ParsedDriverQRCode? {
-        guard let npubRange = value.range(of: #"npub1[a-z0-9]{58,}"#, options: .regularExpression) else {
+        guard let npubRange = value.range(of: #"npub1[a-z0-9]{58}"#, options: .regularExpression) else {
             return nil
         }
 

--- a/RoadFlare/RoadFlareTests/DriverLookupDraftTests.swift
+++ b/RoadFlare/RoadFlareTests/DriverLookupDraftTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import RoadFlareCore
+@testable import RidestrSDK
+
+@Suite("Driver Lookup Draft Tests")
+struct DriverLookupDraftTests {
+    private func makeNpub(hex: String = String(repeating: "a", count: 64)) throws -> String {
+        try NIP19.npubEncode(publicKeyHex: hex)
+    }
+
+    @Test func inputChangeClearsStaleScanNameAndError() {
+        var draft = DriverLookupDraft(
+            pubkeyInput: "old-input",
+            errorMessage: "Invalid npub format",
+            scannedName: "Alice"
+        )
+
+        draft.updatePubkeyInput("new-input")
+
+        #expect(draft.pubkeyInput == "new-input")
+        #expect(draft.errorMessage == nil)
+        #expect(draft.scannedName == nil)
+    }
+
+    @Test func resolveLookupForShareURLClearsPreviousScannedName() throws {
+        let npub = try makeNpub(hex: String(repeating: "b", count: 64))
+        var draft = DriverLookupDraft(scannedName: "Alice")
+
+        draft.updatePubkeyInput("https://roadflare.app/share/d/\(npub)")
+        let lookup = draft.resolveLookup()
+        let resolvedLookup = try #require(lookup)
+
+        #expect(draft.scannedName == nil)
+        #expect(resolvedLookup.parsedQRCode.scannedName == nil)
+        #expect(resolvedLookup.hexPubkey == String(repeating: "b", count: 64))
+    }
+
+    @Test func invalidScannedCodeClearsStaleScanName() {
+        var draft = DriverLookupDraft(scannedName: "Alice")
+
+        let parsed = draft.applyScannedCode("https://roadflare.app/share/d/not-a-driver")
+
+        #expect(parsed == nil)
+        #expect(draft.scannedName == nil)
+        #expect(draft.errorMessage == "QR code doesn't contain a valid Nostr public key")
+    }
+}

--- a/RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift
+++ b/RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift
@@ -32,6 +32,30 @@ struct DriverQRCodeParserTests {
         #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: "Driver Dan"))
     }
 
+    @Test func parsesBareNpub() throws {
+        let npub = try makeNpub(hex: String(repeating: "d", count: 64))
+
+        let parsed = DriverQRCodeParser.parse(npub)
+
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: nil))
+    }
+
+    @Test func parsesBareNpubWithNameParameter() throws {
+        let npub = try makeNpub(hex: String(repeating: "e", count: 64))
+
+        let parsed = DriverQRCodeParser.parse("\(npub)?name=Speedy%20Steve")
+
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: "Speedy Steve"))
+    }
+
+    @Test func parsesHexPubkey() {
+        let hex = String(repeating: "f1", count: 32)
+
+        let parsed = DriverQRCodeParser.parse(hex)
+
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: hex, scannedName: nil))
+    }
+
     @Test func rejectsCodesWithoutNostrIdentifier() {
         #expect(DriverQRCodeParser.parse("https://roadflare.app/share/d/not-a-driver") == nil)
     }

--- a/RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift
+++ b/RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import RoadFlareCore
+@testable import RidestrSDK
+
+@Suite("Driver QR Code Parser Tests")
+struct DriverQRCodeParserTests {
+    private func makeNpub(hex: String = String(repeating: "a", count: 64)) throws -> String {
+        try NIP19.npubEncode(publicKeyHex: hex)
+    }
+
+    @Test func parsesNostrURIWithNameParameter() throws {
+        let npub = try makeNpub()
+
+        let parsed = DriverQRCodeParser.parse("nostr:\(npub)?name=Road%20Runner")
+
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: "Road Runner"))
+    }
+
+    @Test func parsesRoadflareShareURLWithNpubInPath() throws {
+        let npub = try makeNpub(hex: String(repeating: "b", count: 64))
+
+        let parsed = DriverQRCodeParser.parse("https://roadflare.app/share/d/\(npub)")
+
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: nil))
+    }
+
+    @Test func parsesRoadflareShareURLWithQueryName() throws {
+        let npub = try makeNpub(hex: String(repeating: "c", count: 64))
+
+        let parsed = DriverQRCodeParser.parse("https://roadflare.app/share/d/\(npub)?name=Driver%20Dan")
+
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: "Driver Dan"))
+    }
+
+    @Test func rejectsCodesWithoutNostrIdentifier() {
+        #expect(DriverQRCodeParser.parse("https://roadflare.app/share/d/not-a-driver") == nil)
+    }
+}


### PR DESCRIPTION
Closes #52

## Summary
- parse URL-style driver QR payloads that embed an `npub`, including the Android driver format `https://roadflare.app/share/d/<npub>`
- move scan parsing into a small `RoadFlareCore` helper so `AddDriverSheet` stays thin and the parser is directly testable
- add regression coverage for `nostr:` URIs, roadflare share URLs, optional `name=` queries, and invalid URL payloads

## Testing
- `xcodebuild -project RoadFlare/RoadFlare.xcodeproj -scheme RoadFlareTests -destination 'platform=iOS Simulator,id=84EB3743-25F7-41AD-94E6-3C833BE4BB29' test`
- `xcodebuild -project RoadFlare/RoadFlare.xcodeproj -scheme RoadFlare -destination 'platform=iOS Simulator,id=84EB3743-25F7-41AD-94E6-3C833BE4BB29' build`
