### PR TITLE
Add Delete Account feature (closes #51)

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift
@@ -182,7 +182,10 @@ public final class AccountDeletionService: Sendable {
                 kinds: kinds,
                 keypair: keypair
             )
-            _ = try await relayManager.publish(deletionEvent)
+            // Use publishWithRetry: deletion is a critical, non-retryable operation
+            // once the user logs out (keypair is destroyed). Retry survives transient
+            // relay failures that a single publish would surface as permanent errors.
+            _ = try await relayManager.publishWithRetry(deletionEvent)
             return RelayDeletionResult(
                 deletedEventIds: eventIds,
                 targetRelayURLs: DefaultRelays.all,

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift
@@ -57,6 +57,32 @@ public struct RelayDeletionResult: Sendable {
     }
 }
 
+/// Result of verifying a deletion — re-scans relays and counts how many of the
+/// originally-requested event IDs are still visible. Relays implementing NIP-09
+/// should have removed the events; relays that refuse NIP-09 (policy choice)
+/// will still have them. The counts let callers tell the user honestly.
+public struct DeletionVerificationResult: Sendable {
+    /// How many event IDs were in the Kind 5 deletion request.
+    public let requestedCount: Int
+    /// How many of those are still visible on relays after the verification scan.
+    public let remainingCount: Int
+    /// How many appear to have been honoured (requested - remaining).
+    public var deletedCount: Int { requestedCount - remainingCount }
+    /// Whether the verification scan itself produced relay errors (timeouts,
+    /// disconnects). When non-empty the `remainingCount` is a lower bound —
+    /// some relays couldn't be checked.
+    public let scanErrors: [String]
+
+    public init(requestedCount: Int, remainingCount: Int, scanErrors: [String]) {
+        self.requestedCount = requestedCount
+        self.remainingCount = remainingCount
+        self.scanErrors = scanErrors
+    }
+
+    /// True when every requested event is gone from every reachable relay.
+    public var fullyHonoured: Bool { remainingCount == 0 && scanErrors.isEmpty }
+}
+
 // MARK: - Service
 
 /// Scans relays for rider-authored events and publishes NIP-09 Kind 5 deletion requests.
@@ -145,6 +171,35 @@ public final class AccountDeletionService: Sendable {
         return await publishDeletion(
             eventIds: eventIds,
             kinds: Self.roadflareKinds + [.metadata]
+        )
+    }
+
+    // MARK: - Verify
+
+    /// Re-scan relays and count how many of the requested event IDs are still
+    /// visible. Intended to run a beat after a deletion publish so relays have
+    /// time to process the Kind 5 and drop the referenced events.
+    ///
+    /// Waits `settleDelay` seconds before the scan to give relays time to
+    /// process the Kind 5. Defaults to 2s which comfortably covers healthy
+    /// relay processing time; slow relays may still be mid-process when the
+    /// scan runs, in which case their events will show up in `remainingCount`.
+    public func verifyDeletion(
+        targetEventIds: [String],
+        settleDelay: TimeInterval = 2.0
+    ) async -> DeletionVerificationResult {
+        if targetEventIds.isEmpty {
+            return DeletionVerificationResult(requestedCount: 0, remainingCount: 0, scanErrors: [])
+        }
+        try? await Task.sleep(for: .seconds(settleDelay))
+        let scan = await scanRelays()
+        let stillPresent = Set(scan.roadflareEvents.map(\.id))
+            .union(scan.metadataEvents.map(\.id))
+        let remaining = Set(targetEventIds).intersection(stillPresent)
+        return DeletionVerificationResult(
+            requestedCount: targetEventIds.count,
+            remainingCount: remaining.count,
+            scanErrors: scan.scanErrors
         )
     }
 

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+// MARK: - Result Models
+
+/// Result of scanning relays for user-authored events.
+public struct RelayScanResult: Sendable {
+    /// RoadFlare/Ridestr events found (12 rider-authored kinds, excluding Kind 0).
+    public let roadflareEvents: [NostrEvent]
+    /// Kind 0 metadata events found (shared Nostr identity, used by all apps).
+    public let metadataEvents: [NostrEvent]
+    /// Human-readable error messages from queries that failed (relay unreachable,
+    /// timeout, etc.). When non-empty, the scan was incomplete — the caller should
+    /// warn the user before proceeding to deletion.
+    public let scanErrors: [String]
+    /// Relay URLs that were scanned.
+    public let targetRelayURLs: [URL]
+
+    public init(
+        roadflareEvents: [NostrEvent],
+        metadataEvents: [NostrEvent],
+        scanErrors: [String],
+        targetRelayURLs: [URL]
+    ) {
+        self.roadflareEvents = roadflareEvents
+        self.metadataEvents = metadataEvents
+        self.scanErrors = scanErrors
+        self.targetRelayURLs = targetRelayURLs
+    }
+
+    public var roadflareCount: Int { roadflareEvents.count }
+    public var metadataCount: Int { metadataEvents.count }
+    public var totalCount: Int { roadflareCount + metadataCount }
+    public var hasErrors: Bool { !scanErrors.isEmpty }
+}
+
+/// Result of a relay-side deletion pass.
+public struct RelayDeletionResult: Sendable {
+    /// Event IDs included in the Kind 5 deletion request.
+    public let deletedEventIds: [String]
+    /// Relay URLs the deletion was published to.
+    public let targetRelayURLs: [URL]
+    /// True if the Kind 5 event was published, or if there was nothing to delete.
+    public let publishedSuccessfully: Bool
+    /// Human-readable error from the publish step, if any.
+    public let publishError: String?
+
+    public init(
+        deletedEventIds: [String],
+        targetRelayURLs: [URL],
+        publishedSuccessfully: Bool,
+        publishError: String?
+    ) {
+        self.deletedEventIds = deletedEventIds
+        self.targetRelayURLs = targetRelayURLs
+        self.publishedSuccessfully = publishedSuccessfully
+        self.publishError = publishError
+    }
+}
+
+// MARK: - Service
+
+/// Scans relays for rider-authored events and publishes NIP-09 Kind 5 deletion requests.
+///
+/// Create with the app's live `relayManager` (already connected). The service is stateless —
+/// create a fresh instance for each deletion flow.
+///
+/// ## Usage
+/// ```swift
+/// let service = AccountDeletionService(relayManager: rm, keypair: kp)
+/// let scan = await service.scanRelays()
+/// // Show results to user, then:
+/// let result = await service.deleteRoadflareEvents(from: scan)
+/// ```
+public final class AccountDeletionService: Sendable {
+    private let relayManager: any RelayManagerProtocol
+    private let keypair: NostrKeypair
+
+    /// The 12 rider-authored Ridestr event kinds (excludes Kind 0 metadata).
+    public static let roadflareKinds: [EventKind] = [
+        // Parameterized replaceable (always on relays)
+        .followedDriversList,    // 30011
+        .rideHistoryBackup,      // 30174
+        .unifiedProfile,         // 30177
+        .riderRideState,         // 30181
+        // Regular (ephemeral, may still be on relays)
+        .rideOffer,              // 3173
+        .rideConfirmation,       // 3175
+        .chatMessage,            // 3178
+        .cancellation,           // 3179
+        .keyShare,               // 3186
+        .followNotification,     // 3187
+        .keyAcknowledgement,     // 3188
+        .driverPingRequest,      // 3189
+    ]
+
+    public init(relayManager: any RelayManagerProtocol, keypair: NostrKeypair) {
+        self.relayManager = relayManager
+        self.keypair = keypair
+    }
+
+    // MARK: - Scan
+
+    /// Query connected relays for all rider-authored events.
+    /// Two queries: one for all 12 RoadFlare kinds, one for Kind 0 metadata.
+    /// Captures fetch errors in `RelayScanResult.scanErrors` so the caller can
+    /// warn the user when a query failed (rather than silently reporting 0 events).
+    public func scanRelays() async -> RelayScanResult {
+        let roadflareFilter = NostrFilter()
+            .authors([keypair.publicKeyHex])
+            .rawKinds(Self.roadflareKinds.map(\.rawValue))
+
+        let metadataFilter = NostrFilter.metadata(pubkeys: [keypair.publicKeyHex])
+
+        async let rfFetch = fetchWithError(filter: roadflareFilter, label: "RoadFlare events")
+        async let metaFetch = fetchWithError(filter: metadataFilter, label: "Nostr profile")
+
+        let (rfResult, metaResult) = await (rfFetch, metaFetch)
+
+        var errors: [String] = []
+        if let err = rfResult.error { errors.append(err) }
+        if let err = metaResult.error { errors.append(err) }
+
+        return RelayScanResult(
+            roadflareEvents: rfResult.events,
+            metadataEvents: metaResult.events,
+            scanErrors: errors,
+            targetRelayURLs: DefaultRelays.all
+        )
+    }
+
+    // MARK: - Delete
+
+    /// Delete only RoadFlare events (12 Ridestr kinds). Does NOT delete Kind 0 metadata.
+    public func deleteRoadflareEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
+        let eventIds = scan.roadflareEvents.map(\.id)
+        return await publishDeletion(
+            eventIds: eventIds,
+            kinds: Self.roadflareKinds
+        )
+    }
+
+    /// Delete all Ridestr events (12 RoadFlare kinds + Kind 0 metadata).
+    public func deleteAllRidestrEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
+        let eventIds = scan.roadflareEvents.map(\.id) + scan.metadataEvents.map(\.id)
+        return await publishDeletion(
+            eventIds: eventIds,
+            kinds: Self.roadflareKinds + [.metadata]
+        )
+    }
+
+    // MARK: - Private
+
+    private func fetchWithError(
+        filter: NostrFilter,
+        label: String
+    ) async -> (events: [NostrEvent], error: String?) {
+        do {
+            let events = try await relayManager.fetchEvents(
+                filter: filter,
+                timeout: RelayConstants.eoseTimeoutSeconds
+            )
+            return (events, nil)
+        } catch {
+            return ([], "\(label) query failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func publishDeletion(eventIds: [String], kinds: [EventKind]) async -> RelayDeletionResult {
+        guard !eventIds.isEmpty else {
+            return RelayDeletionResult(
+                deletedEventIds: [],
+                targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: true,
+                publishError: nil
+            )
+        }
+
+        do {
+            let deletionEvent = try await RideshareEventBuilder.deletion(
+                eventIds: eventIds,
+                reason: "Account deleted by user",
+                kinds: kinds,
+                keypair: keypair
+            )
+            _ = try await relayManager.publish(deletionEvent)
+            return RelayDeletionResult(
+                deletedEventIds: eventIds,
+                targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: true,
+                publishError: nil
+            )
+        } catch {
+            return RelayDeletionResult(
+                deletedEventIds: eventIds,
+                targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: false,
+                publishError: error.localizedDescription
+            )
+        }
+    }
+}

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/AccountDeletionServiceTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/AccountDeletionServiceTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+@testable import RidestrSDK
+
+private func stubEvent(id: String, kind: UInt16, pubkey: String) -> NostrEvent {
+    let json = """
+    {"id":"\(id)","pubkey":"\(pubkey)","created_at":1700000000,"kind":\(kind),\
+    "tags":[],"content":"","sig":"fakesig"}
+    """
+    return try! JSONDecoder().decode(NostrEvent.self, from: json.data(using: .utf8)!)
+}
+
+@Suite("AccountDeletionService Tests")
+struct AccountDeletionServiceTests {
+    private func makeKit() throws -> (sut: AccountDeletionService, relay: FakeRelayManager, pubkey: String) {
+        let keypair = try NostrKeypair.generate()
+        let relay = FakeRelayManager()
+        let sut = AccountDeletionService(relayManager: relay, keypair: keypair)
+        return (sut, relay, keypair.publicKeyHex)
+    }
+
+    // MARK: - Scan
+
+    @Test func scan_noEvents_returnsEmptyResult() async throws {
+        let (sut, relay, _) = try makeKit()
+        relay.fetchResults = []
+
+        let result = await sut.scanRelays()
+
+        #expect(result.roadflareEvents.isEmpty)
+        #expect(result.metadataEvents.isEmpty)
+        #expect(result.scanErrors.isEmpty)
+        #expect(result.hasErrors == false)
+        #expect(result.targetRelayURLs == DefaultRelays.all)
+        // Two queries: roadflare kinds + kind 0
+        #expect(relay.fetchCalls.count == 2)
+    }
+
+    @Test func scan_withEvents_categorisesCorrectly() async throws {
+        let (sut, relay, pubkey) = try makeKit()
+        let rfEvent = stubEvent(id: "rf1", kind: EventKind.followedDriversList.rawValue, pubkey: pubkey)
+        let metaEvent = stubEvent(id: "meta1", kind: EventKind.metadata.rawValue, pubkey: pubkey)
+        relay.fetchResults = [rfEvent, metaEvent]
+
+        let result = await sut.scanRelays()
+
+        // Both queries return both events — the FakeRelayManager returns fetchResults
+        // for every fetchEvents call. In production, each filter returns only matching
+        // events. This test verifies the result is populated and errors are empty.
+        #expect(!result.roadflareEvents.isEmpty)
+        #expect(!result.metadataEvents.isEmpty)
+        #expect(result.scanErrors.isEmpty)
+    }
+
+    @Test func scan_fetchFailure_capturesErrorsRatherThanSilentEmpty() async throws {
+        // Pragmatic test using a one-off throwing fake: the SDK FakeRelayManager
+        // doesn't expose shouldFailFetch, so we verify the contract that errors
+        // do propagate into scanErrors when fetch throws.
+        final class ThrowingRelay: RelayManagerProtocol, @unchecked Sendable {
+            func connect(to relays: [URL]) async throws {}
+            func disconnect() async {}
+            func publish(_ event: NostrEvent) async throws -> String { event.id }
+            func subscribe(filter: NostrFilter, id: SubscriptionID) async throws -> AsyncStream<NostrEvent> {
+                AsyncStream { $0.finish() }
+            }
+            func unsubscribe(_ id: SubscriptionID) async {}
+            func fetchEvents(filter: NostrFilter, timeout: TimeInterval) async throws -> [NostrEvent] {
+                throw RidestrError.relay(.notConnected)
+            }
+            var isConnected: Bool { false }
+            func reconnectIfNeeded() async {}
+        }
+
+        let keypair = try NostrKeypair.generate()
+        let sut = AccountDeletionService(relayManager: ThrowingRelay(), keypair: keypair)
+
+        let result = await sut.scanRelays()
+
+        #expect(result.roadflareEvents.isEmpty)
+        #expect(result.metadataEvents.isEmpty)
+        #expect(result.hasErrors == true)
+        #expect(result.scanErrors.count == 2)  // both queries failed
+        #expect(result.scanErrors.contains { $0.contains("RoadFlare events query failed") })
+        #expect(result.scanErrors.contains { $0.contains("Nostr profile query failed") })
+    }
+
+    // MARK: - Delete RoadFlare events
+
+    @Test func deleteRoadflare_noEvents_publishesNothing() async throws {
+        let (sut, relay, _) = try makeKit()
+        let scan = RelayScanResult(
+            roadflareEvents: [],
+            metadataEvents: [],
+            scanErrors: [],
+            targetRelayURLs: DefaultRelays.all
+        )
+
+        let result = await sut.deleteRoadflareEvents(from: scan)
+
+        #expect(result.publishedSuccessfully == true)
+        #expect(result.deletedEventIds.isEmpty)
+        #expect(relay.publishedEvents.isEmpty)
+    }
+
+    @Test func deleteRoadflare_withEvents_publishesKind5ForRoadflareOnly() async throws {
+        let (sut, relay, pubkey) = try makeKit()
+        let rfEvent = stubEvent(id: "rf1", kind: EventKind.followedDriversList.rawValue, pubkey: pubkey)
+        let metaEvent = stubEvent(id: "meta1", kind: EventKind.metadata.rawValue, pubkey: pubkey)
+        let scan = RelayScanResult(
+            roadflareEvents: [rfEvent],
+            metadataEvents: [metaEvent],
+            scanErrors: [],
+            targetRelayURLs: DefaultRelays.all
+        )
+
+        let result = await sut.deleteRoadflareEvents(from: scan)
+
+        #expect(result.publishedSuccessfully == true)
+        #expect(result.deletedEventIds == ["rf1"])
+        #expect(relay.publishedEvents.count == 1)
+        let kind5 = relay.publishedEvents[0]
+        #expect(kind5.kind == 5)
+        let eTagIds = kind5.tagValues("e")
+        #expect(eTagIds.contains("rf1"))
+        #expect(!eTagIds.contains("meta1"))  // Kind 0 NOT included
+    }
+
+    // MARK: - Delete all Ridestr events
+
+    @Test func deleteAll_withEvents_publishesKind5IncludingMetadata() async throws {
+        let (sut, relay, pubkey) = try makeKit()
+        let rfEvent = stubEvent(id: "rf1", kind: EventKind.followedDriversList.rawValue, pubkey: pubkey)
+        let metaEvent = stubEvent(id: "meta1", kind: EventKind.metadata.rawValue, pubkey: pubkey)
+        let scan = RelayScanResult(
+            roadflareEvents: [rfEvent],
+            metadataEvents: [metaEvent],
+            scanErrors: [],
+            targetRelayURLs: DefaultRelays.all
+        )
+
+        let result = await sut.deleteAllRidestrEvents(from: scan)
+
+        #expect(result.publishedSuccessfully == true)
+        #expect(result.deletedEventIds.contains("rf1"))
+        #expect(result.deletedEventIds.contains("meta1"))
+        let kind5 = relay.publishedEvents[0]
+        let eTagIds = kind5.tagValues("e")
+        #expect(eTagIds.contains("rf1"))
+        #expect(eTagIds.contains("meta1"))
+    }
+
+    // MARK: - Publish failure
+
+    @Test func delete_publishFails_returnsFailureResult() async throws {
+        let (sut, relay, pubkey) = try makeKit()
+        let rfEvent = stubEvent(id: "rf1", kind: 30011, pubkey: pubkey)
+        let scan = RelayScanResult(
+            roadflareEvents: [rfEvent],
+            metadataEvents: [],
+            scanErrors: [],
+            targetRelayURLs: DefaultRelays.all
+        )
+        relay.shouldFailPublish = true
+
+        let result = await sut.deleteRoadflareEvents(from: scan)
+
+        #expect(result.publishedSuccessfully == false)
+        #expect(result.publishError != nil)
+        #expect(result.deletedEventIds == ["rf1"])
+    }
+
+    // MARK: - Kind lists
+
+    @Test func roadflareKinds_containsAll12RiderAuthoredKinds() {
+        let rawValues = AccountDeletionService.roadflareKinds.map(\.rawValue)
+        // Replaceable
+        #expect(rawValues.contains(30011))  // followedDriversList
+        #expect(rawValues.contains(30174))  // rideHistoryBackup
+        #expect(rawValues.contains(30177))  // unifiedProfile
+        #expect(rawValues.contains(30181))  // riderRideState
+        // Regular/ephemeral
+        #expect(rawValues.contains(3173))   // rideOffer
+        #expect(rawValues.contains(3175))   // rideConfirmation
+        #expect(rawValues.contains(3178))   // chatMessage
+        #expect(rawValues.contains(3179))   // cancellation
+        #expect(rawValues.contains(3186))   // keyShare
+        #expect(rawValues.contains(3187))   // followNotification
+        #expect(rawValues.contains(3188))   // keyAcknowledgement
+        #expect(rawValues.contains(3189))   // driverPingRequest
+    }
+
+    @Test func roadflareKinds_excludesDriverAndNonRidestrKinds() {
+        let rawValues = AccountDeletionService.roadflareKinds.map(\.rawValue)
+        #expect(!rawValues.contains(0))      // metadata — separate tier
+        #expect(!rawValues.contains(3174))   // rideAcceptance — driver-authored
+        #expect(!rawValues.contains(30012))  // driverRoadflareState
+        #expect(!rawValues.contains(30173))  // driverAvailability
+        #expect(!rawValues.contains(30180))  // driverRideState
+    }
+}

--- a/RoadFlare/RoadFlare.xcodeproj/project.pbxproj
+++ b/RoadFlare/RoadFlare.xcodeproj/project.pbxproj
@@ -525,7 +525,6 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = NO;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -540,7 +539,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -560,7 +559,6 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = NO;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -575,7 +573,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -256,43 +256,81 @@ struct DeleteAccountResultsView: View {
     @Environment(AppState.self) private var appState
     let scan: RelayScanResult
 
+    /// Phases of the delete flow on page 2. Starts at .ready (show scan +
+    /// delete button). Progresses through .publishing → .verifying → .success
+    /// after user confirms in the checkbox sheet. .failed surfaces publish
+    /// errors so the user can retry with the session still alive.
+    enum Phase {
+        case ready
+        case publishing
+        case verifying(deletedEventIds: [String])
+        case success(DeletionVerificationResult)
+        case failed(String)
+    }
+
+    @State private var phase: Phase = .ready
     @State private var showDeleteSheet = false
-    @State private var isDeleting = false
-    /// On publish failure the session is preserved (AppState only logs out on
-    /// success), so the banner below renders and the user can retry. Cleared
-    /// at the start of each retry via the sheet's onConfirm.
-    @State private var publishErrorMessage: String?
+
+    private var isBusy: Bool {
+        switch phase {
+        case .publishing, .verifying: true
+        default: false
+        }
+    }
+
+    private var isSuccess: Bool {
+        if case .success = phase { return true }
+        return false
+    }
+
+    private var navTitle: String {
+        switch phase {
+        case .ready, .failed: "Delete Account"
+        case .publishing, .verifying: "Deleting…"
+        case .success: ""
+        }
+    }
 
     var body: some View {
         ZStack {
             Color.rfSurface.ignoresSafeArea()
-            ScrollView {
-                VStack(spacing: 24) {
-                    header
-                    scanSummaryCard
-                    if let publishErrorMessage {
-                        publishErrorBanner(publishErrorMessage)
-                    }
-                    deleteAccountOption
-                    if isDeleting {
-                        deletingIndicator
-                    }
-                    Spacer(minLength: 24)
-                }
-                .padding(.horizontal, 16)
-                .padding(.top, 8)
+            switch phase {
+            case .success(let verification):
+                successContent(verification)
+            default:
+                scanAndConfirmContent
             }
         }
-        .navigationTitle("Delete Account")
+        .navigationTitle(navTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.rfSurface, for: .navigationBar)
-        .navigationBarBackButtonHidden(isDeleting)
+        .navigationBarBackButtonHidden(isBusy || isSuccess)
         .sheet(isPresented: $showDeleteSheet) {
             FullDeletionConfirmSheet(scan: scan) {
-                isDeleting = true
-                publishErrorMessage = nil
                 Task { await performDeletion() }
             }
+        }
+    }
+
+    // MARK: Scan + confirm (pre-delete)
+
+    @ViewBuilder
+    private var scanAndConfirmContent: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                header
+                scanSummaryCard
+                if case .failed(let msg) = phase {
+                    publishErrorBanner(msg)
+                }
+                deleteAccountOption
+                if isBusy {
+                    deletingIndicator
+                }
+                Spacer(minLength: 24)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
         }
     }
 
@@ -342,8 +380,8 @@ struct DeleteAccountResultsView: View {
             } label: {
                 Text("Delete Account")
             }
-            .buttonStyle(RFDestructiveButtonStyle(isDisabled: isDeleting))
-            .disabled(isDeleting)
+            .buttonStyle(RFDestructiveButtonStyle(isDisabled: isBusy))
+            .disabled(isBusy)
 
             Text("Permanently deletes your RoadFlare account, all associated events, and your Nostr profile (Kind 0) from relays. This may affect other Nostr apps that use this identity. This action cannot be undone.")
                 .font(RFFont.caption(12))
@@ -355,7 +393,7 @@ struct DeleteAccountResultsView: View {
     private var deletingIndicator: some View {
         HStack(spacing: 12) {
             ProgressView().tint(Color.rfOnSurface)
-            Text("Deleting…")
+            Text(deletingStatus)
                 .font(RFFont.body(15))
                 .foregroundColor(Color.rfOnSurfaceVariant)
         }
@@ -363,6 +401,61 @@ struct DeleteAccountResultsView: View {
         .padding(.vertical, 16)
         .background(Color.rfSurfaceContainer)
         .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var deletingStatus: String {
+        switch phase {
+        case .publishing: "Publishing deletion request to relays…"
+        case .verifying: "Verifying with relays…"
+        default: "Deleting…"
+        }
+    }
+
+    // MARK: Success (post-delete, pre-logout)
+
+    @ViewBuilder
+    private func successContent(_ verification: DeletionVerificationResult) -> some View {
+        VStack(spacing: 24) {
+            Spacer()
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 96, weight: .regular))
+                .foregroundColor(Color.rfOnline)
+            VStack(spacing: 12) {
+                Text("Account Deletion Successful")
+                    .font(RFFont.headline(22))
+                    .foregroundColor(Color.rfOnSurface)
+                    .multilineTextAlignment(.center)
+                Text(successDetail(for: verification))
+                    .font(RFFont.body(14))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 8)
+            }
+            Spacer()
+            Button {
+                Task { await appState.logout() }
+            } label: {
+                Text("Done")
+            }
+            .buttonStyle(RFPrimaryButtonStyle())
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func successDetail(for v: DeletionVerificationResult) -> String {
+        if v.requestedCount == 0 {
+            return "Your local account data has been cleared. There were no relay events to remove."
+        }
+        if v.fullyHonoured {
+            return "All \(v.requestedCount) event\(v.requestedCount == 1 ? "" : "s") were removed from relays. Tap Done to finish and clear your local account."
+        }
+        if !v.scanErrors.isEmpty && v.remainingCount == 0 {
+            return "Your deletion request was sent to \(scan.targetRelayURLs.count) relays. Some relays couldn't be re-checked, but none of the reachable relays still hold your events. Tap Done to finish and clear your local account."
+        }
+        return "Your deletion request was sent to \(scan.targetRelayURLs.count) relays. \(v.deletedCount) of \(v.requestedCount) event\(v.requestedCount == 1 ? " was" : "s were") confirmed removed; some relays may still be processing or may not honour NIP-09. Tap Done to finish and clear your local account."
     }
 
     private func publishErrorBanner(_ message: String) -> some View {
@@ -387,20 +480,19 @@ struct DeleteAccountResultsView: View {
     // MARK: Actions
 
     private func performDeletion() async {
-        // isDeleting and publishErrorMessage are set synchronously by the
-        // confirm-button action (closes the rapid-tap race); defer guarantees
-        // the UI is unstuck if deletion stops short of logout (publish failure
-        // or active-ride guard hit). On success, logout() replaces the view
-        // tree before this defer fires, so the reset is purely defensive.
-        defer { isDeleting = false }
-        let result = await appState.deleteAllRidestrEvents(from: scan)
-        // On success: logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed.
-        // On failure: AppState preserves the session so this banner can render and the user can retry
-        // (logging out on publish failure would destroy the keypair before the user sees the error,
-        // stranding their events on relays with no retry path).
-        if !result.publishedSuccessfully, let err = result.publishError {
-            publishErrorMessage = err
+        phase = .publishing
+        let result = await appState.publishAccountDeletion(from: scan)
+        guard result.publishedSuccessfully else {
+            phase = .failed(result.publishError ?? "Unknown publish error")
+            return
         }
+        // Publish succeeded; verify before logging out so the user can see
+        // whether relays actually honoured the request. The keypair + relay
+        // manager stay alive through this step because logout() is deferred
+        // until the user taps Done on the success screen.
+        phase = .verifying(deletedEventIds: result.deletedEventIds)
+        let verification = await appState.verifyAccountDeletion(eventIds: result.deletedEventIds)
+        phase = .success(verification)
     }
 }
 

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -425,14 +425,15 @@ struct DeleteAccountResultsView: View {
 
     private func performRoadflareDeletion() async {
         isDeleting = true
-        // defer guarantees the UI is unstuck if deletion ever stops short of logout
-        // (e.g. publish failure or active-ride guard hit). On success, logout() replaces
+        // defer guarantees the UI is unstuck if deletion stops short of logout
+        // (publish failure or active-ride guard hit). On success, logout() replaces
         // the view tree before this defer fires, so the reset is purely defensive.
         defer { isDeleting = false }
         let result = await appState.deleteRoadflareEvents(from: scan)
         // On success: logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed.
-        // On failure: publish never succeeded; AppState still called logout() for RoadFlare-only deletion.
-        // The active-ride guard failure short-circuits before logout — keep the sheet visible with the error.
+        // On failure: AppState preserves the session so this banner can render and the user can retry
+        // (logging out on publish failure would destroy the keypair before the user sees the error,
+        // stranding their events on relays with no retry path).
         if !result.publishedSuccessfully, let err = result.publishError {
             publishErrorMessage = err
         }

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -259,6 +259,10 @@ struct DeleteAccountResultsView: View {
     @State private var showRoadflareConfirm = false
     @State private var showFullDeleteSheet = false
     @State private var isDeleting = false
+    /// When deletion publish fails, the user is still logged out. The root view
+    /// tree swaps to the logged-out UI before this sheet can present an alert,
+    /// so we show a persistent banner here as well as logging to Console.app.
+    @State private var publishErrorMessage: String?
 
     var body: some View {
         ZStack {
@@ -267,6 +271,9 @@ struct DeleteAccountResultsView: View {
                 VStack(spacing: 24) {
                     header
                     scanSummaryCard
+                    if let publishErrorMessage {
+                        publishErrorBanner(publishErrorMessage)
+                    }
                     roadflareDeleteOption
                     fullDeleteOption
                     if isDeleting {
@@ -395,23 +402,49 @@ struct DeleteAccountResultsView: View {
         .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 
+    private func publishErrorBanner(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(Color.rfError)
+                Text("Deletion request failed")
+                    .font(RFFont.title(14))
+                    .foregroundColor(Color.rfOnSurface)
+            }
+            Text(message)
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.rfSurfaceContainer)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
     // MARK: Actions
 
     private func performRoadflareDeletion() async {
         isDeleting = true
         // defer guarantees the UI is unstuck if deletion ever stops short of logout
-        // (e.g. future code path that doesn't call logout). Today, logout() replaces
-        // the view tree before this defer fires; this is purely defensive.
+        // (e.g. publish failure or active-ride guard hit). On success, logout() replaces
+        // the view tree before this defer fires, so the reset is purely defensive.
         defer { isDeleting = false }
-        _ = await appState.deleteRoadflareEvents(from: scan)
-        // logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed.
-        // Publish failures are logged via AppLogger.auth.error in AppState (visible in Console.app).
+        let result = await appState.deleteRoadflareEvents(from: scan)
+        // On success: logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed.
+        // On failure: publish never succeeded; AppState still called logout() for RoadFlare-only deletion.
+        // The active-ride guard failure short-circuits before logout — keep the sheet visible with the error.
+        if !result.publishedSuccessfully, let err = result.publishError {
+            publishErrorMessage = err
+        }
     }
 
     private func performFullDeletion() async {
         isDeleting = true
         defer { isDeleting = false }
-        _ = await appState.deleteAllRidestrEvents(from: scan)
+        let result = await appState.deleteAllRidestrEvents(from: scan)
+        if !result.publishedSuccessfully, let err = result.publishError {
+            publishErrorMessage = err
+        }
     }
 }
 

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -141,6 +141,7 @@ struct DeleteAccountScanView: View {
 
         case .complete(let scan):
             VStack(spacing: 12) {
+                scanCompleteCard(scan)
                 // Surface scan errors honestly — silent "0 events" when relays
                 // were unreachable would mislead the user into thinking nothing
                 // exists when their data may still be on those relays.
@@ -151,10 +152,7 @@ struct DeleteAccountScanView: View {
                 NavigationLink {
                     DeleteAccountResultsView(scan: scan)
                 } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: scan.hasErrors ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
-                        Text("Continue — \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") found")
-                    }
+                    Text("Continue")
                 }
                 .buttonStyle(RFDestructiveButtonStyle())
             }
@@ -167,6 +165,33 @@ struct DeleteAccountScanView: View {
             }
             .buttonStyle(RFSecondaryButtonStyle())
         }
+    }
+
+    @ViewBuilder
+    private func scanCompleteCard(_ scan: RelayScanResult) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: "doc.text.magnifyingglass")
+                    .foregroundColor(Color.rfPrimary)
+                Text("Scan Complete")
+                    .font(RFFont.title(15))
+                    .foregroundColor(Color.rfOnSurface)
+            }
+            // Same nested-Text interpolation pattern as page 2's scan summary —
+            // bold counts anchor the numbers, surrounding text stays muted.
+            Text("Found \(Text("\(scan.roadflareCount)").bold().foregroundColor(Color.rfOnSurface)) RoadFlare event\(scan.roadflareCount == 1 ? "" : "s") and \(Text("\(scan.metadataCount)").bold().foregroundColor(Color.rfOnSurface)) Nostr profile event\(scan.metadataCount == 1 ? "" : "s") across \(scan.targetRelayURLs.count) relays created by your account.")
+                .font(RFFont.body(14))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("Continue to review and confirm deletion.")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+                .padding(.top, 2)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.rfSurfaceContainer)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 
     @ViewBuilder

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -376,7 +376,7 @@ struct DeleteAccountResultsView: View {
 
     private var fullDeleteOption: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Full Deletion")
+            Text("Complete Deletion")
                 .font(RFFont.caption(12))
                 .foregroundColor(Color.rfOnSurfaceVariant)
                 .textCase(.uppercase)
@@ -385,7 +385,7 @@ struct DeleteAccountResultsView: View {
             Button {
                 showFullDeleteSheet = true
             } label: {
-                Text("Delete All Ridestr Events")
+                Text("Completely Delete Account")
             }
             .buttonStyle(RFDestructiveSecondaryButtonStyle())
             .disabled(isDeleting)
@@ -476,59 +476,65 @@ struct FullDeletionConfirmSheet: View {
         ZStack {
             Color.rfSurface.ignoresSafeArea()
 
-            VStack(spacing: 24) {
-                VStack(spacing: 8) {
-                    Image(systemName: "exclamationmark.octagon.fill")
-                        .font(.system(size: 40))
-                        .foregroundColor(Color.rfError)
-                    Text("Full Nostr Deletion")
-                        .font(RFFont.headline(20))
-                        .foregroundColor(Color.rfOnSurface)
+            ScrollView {
+                VStack(spacing: 24) {
+                    VStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.octagon.fill")
+                            .font(.system(size: 40))
+                            .foregroundColor(Color.rfError)
+                        Text("Complete Account Deletion")
+                            .font(RFFont.headline(20))
+                            .foregroundColor(Color.rfOnSurface)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(.top, 16)
+
+                    Text("This deletes all \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") including your Nostr profile (Kind 0 metadata). Please confirm you understand:")
+                        .font(RFFont.body(14))
+                        .foregroundColor(Color.rfOnSurfaceVariant)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 8)
+
+                    VStack(spacing: 0) {
+                        confirmRow(
+                            isOn: $checkProfile,
+                            text: "I understand this deletes my Nostr profile (display name) from relays"
+                        )
+                        Divider().padding(.leading, 46)
+                        confirmRow(
+                            isOn: $checkOtherApps,
+                            text: "I understand this may affect other Nostr apps that use this identity"
+                        )
+                        Divider().padding(.leading, 46)
+                        confirmRow(
+                            isOn: $checkBackedUp,
+                            text: "I have backed up my private key, or I no longer need it"
+                        )
+                    }
+                    .background(Color.rfSurfaceContainer)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+
+                    Button {
+                        dismiss()
+                        onConfirm()
+                    } label: {
+                        Text("Completely Delete Account")
+                    }
+                    .buttonStyle(RFDestructiveButtonStyle(isDisabled: !allChecked))
+                    .disabled(!allChecked)
+
+                    Button("Cancel") { dismiss() }
+                        .buttonStyle(RFGhostButtonStyle())
                 }
-                .padding(.top, 16)
-
-                Text("This deletes all \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") including your Nostr profile (Kind 0 metadata). Please confirm you understand:")
-                    .font(RFFont.body(14))
-                    .foregroundColor(Color.rfOnSurfaceVariant)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 8)
-
-                VStack(spacing: 0) {
-                    confirmRow(
-                        isOn: $checkProfile,
-                        text: "I understand this deletes my Nostr profile (display name) from relays"
-                    )
-                    Divider().padding(.leading, 46)
-                    confirmRow(
-                        isOn: $checkOtherApps,
-                        text: "I understand this may affect other Nostr apps that use this identity"
-                    )
-                    Divider().padding(.leading, 46)
-                    confirmRow(
-                        isOn: $checkBackedUp,
-                        text: "I have backed up my private key, or I no longer need it"
-                    )
-                }
-                .background(Color.rfSurfaceContainer)
-                .clipShape(RoundedRectangle(cornerRadius: 16))
-
-                Button {
-                    dismiss()
-                    onConfirm()
-                } label: {
-                    Text("Delete All Ridestr Events")
-                }
-                .buttonStyle(RFDestructiveButtonStyle(isDisabled: !allChecked))
-                .disabled(!allChecked)
-
-                Button("Cancel") { dismiss() }
-                    .buttonStyle(RFGhostButtonStyle())
-
-                Spacer()
+                .padding(.horizontal, 20)
+                .padding(.bottom, 24)
             }
-            .padding(.horizontal, 20)
         }
-        .presentationDetents([.medium, .large])
+        // .large instead of .medium — wrapped checkbox rows + three buttons don't
+        // fit in half-screen on compact phones, and dragging between detents was
+        // cutting the confirm button off below the fold.
+        .presentationDetents([.large])
     }
 
     @ViewBuilder
@@ -536,7 +542,7 @@ struct FullDeletionConfirmSheet: View {
         Button {
             isOn.wrappedValue.toggle()
         } label: {
-            HStack(spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
                 Image(systemName: isOn.wrappedValue ? "checkmark.square.fill" : "square")
                     .font(.system(size: 20))
                     .foregroundColor(isOn.wrappedValue ? Color.rfError : Color.rfOffline)
@@ -545,7 +551,11 @@ struct FullDeletionConfirmSheet: View {
                     .font(RFFont.body(14))
                     .foregroundColor(Color.rfOnSurface)
                     .multilineTextAlignment(.leading)
-                Spacer()
+                    // Force the Text to take the full remaining width and let it
+                    // wrap vertically as needed — without fixedSize the row keeps
+                    // the text on one line and truncates at the trailing edge.
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(14)
             .contentShape(Rectangle())

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -256,12 +256,11 @@ struct DeleteAccountResultsView: View {
     @Environment(AppState.self) private var appState
     let scan: RelayScanResult
 
-    @State private var showRoadflareConfirm = false
-    @State private var showFullDeleteSheet = false
+    @State private var showDeleteSheet = false
     @State private var isDeleting = false
-    /// When deletion publish fails, the user is still logged out. The root view
-    /// tree swaps to the logged-out UI before this sheet can present an alert,
-    /// so we show a persistent banner here as well as logging to Console.app.
+    /// On publish failure the session is preserved (AppState only logs out on
+    /// success), so the banner below renders and the user can retry. Cleared
+    /// at the start of each retry via the sheet's onConfirm.
     @State private var publishErrorMessage: String?
 
     var body: some View {
@@ -274,8 +273,7 @@ struct DeleteAccountResultsView: View {
                     if let publishErrorMessage {
                         publishErrorBanner(publishErrorMessage)
                     }
-                    roadflareDeleteOption
-                    fullDeleteOption
+                    deleteAccountOption
                     if isDeleting {
                         deletingIndicator
                     }
@@ -285,29 +283,15 @@ struct DeleteAccountResultsView: View {
                 .padding(.top, 8)
             }
         }
-        .navigationTitle("Delete Events")
+        .navigationTitle("Delete Account")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.rfSurface, for: .navigationBar)
         .navigationBarBackButtonHidden(isDeleting)
-        .alert("Delete RoadFlare Events?", isPresented: $showRoadflareConfirm) {
-            Button("Delete", role: .destructive) {
-                // Flip isDeleting synchronously so rapid taps on the alert button
-                // don't spawn a second concurrent deletion Task (SwiftUI alert
-                // buttons aren't debounced and the .disabled(isDeleting) gate on
-                // the page button doesn't cover the alert's confirm).
-                isDeleting = true
-                publishErrorMessage = nil
-                Task { await performRoadflareDeletion() }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This will request deletion of \(scan.roadflareCount) RoadFlare event\(scan.roadflareCount == 1 ? "" : "s") from all relays, then remove all local data and log you out.")
-        }
-        .sheet(isPresented: $showFullDeleteSheet) {
+        .sheet(isPresented: $showDeleteSheet) {
             FullDeletionConfirmSheet(scan: scan) {
                 isDeleting = true
                 publishErrorMessage = nil
-                Task { await performFullDeletion() }
+                Task { await performDeletion() }
             }
         }
     }
@@ -319,10 +303,10 @@ struct DeleteAccountResultsView: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 52))
                 .foregroundColor(Color.rfError)
-            Text("Review & Delete")
+            Text("Delete Your Account")
                 .font(RFFont.headline(22))
                 .foregroundColor(Color.rfOnSurface)
-            Text("Step 2 of 2 — Choose What to Delete")
+            Text("Step 2 of 2 — Review & Confirm")
                 .font(RFFont.caption(12))
                 .foregroundColor(Color.rfOnSurfaceVariant)
         }
@@ -351,46 +335,17 @@ struct DeleteAccountResultsView: View {
         .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 
-    private var roadflareDeleteOption: some View {
+    private var deleteAccountOption: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Recommended")
-                .font(RFFont.caption(12))
-                .foregroundColor(Color.rfOnSurfaceVariant)
-                .textCase(.uppercase)
-                .tracking(1)
-
             Button {
-                showRoadflareConfirm = true
+                showDeleteSheet = true
             } label: {
-                Text("Delete RoadFlare Events")
+                Text("Delete Account")
             }
             .buttonStyle(RFDestructiveButtonStyle(isDisabled: isDeleting))
             .disabled(isDeleting)
 
-            Text("Removes ride history, driver list, saved locations, and all protocol events from relays. Keeps your Nostr profile (Kind 0) intact so other Nostr apps still work.")
-                .font(RFFont.caption(12))
-                .foregroundColor(Color.rfOnSurfaceVariant)
-                .padding(.horizontal, 4)
-        }
-    }
-
-    private var fullDeleteOption: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Complete Deletion")
-                .font(RFFont.caption(12))
-                .foregroundColor(Color.rfOnSurfaceVariant)
-                .textCase(.uppercase)
-                .tracking(1)
-
-            Button {
-                showFullDeleteSheet = true
-            } label: {
-                Text("Completely Delete Account")
-            }
-            .buttonStyle(RFDestructiveSecondaryButtonStyle())
-            .disabled(isDeleting)
-
-            Text("Removes everything above plus your Nostr profile (Kind 0). This may affect other Nostr apps using this identity.")
+            Text("Permanently deletes your RoadFlare account, all associated events, and your Nostr profile (Kind 0) from relays. This may affect other Nostr apps that use this identity. This action cannot be undone.")
                 .font(RFFont.caption(12))
                 .foregroundColor(Color.rfOnSurfaceVariant)
                 .padding(.horizontal, 4)
@@ -431,26 +386,18 @@ struct DeleteAccountResultsView: View {
 
     // MARK: Actions
 
-    private func performRoadflareDeletion() async {
+    private func performDeletion() async {
         // isDeleting and publishErrorMessage are set synchronously by the
         // confirm-button action (closes the rapid-tap race); defer guarantees
         // the UI is unstuck if deletion stops short of logout (publish failure
         // or active-ride guard hit). On success, logout() replaces the view
         // tree before this defer fires, so the reset is purely defensive.
         defer { isDeleting = false }
-        let result = await appState.deleteRoadflareEvents(from: scan)
+        let result = await appState.deleteAllRidestrEvents(from: scan)
         // On success: logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed.
         // On failure: AppState preserves the session so this banner can render and the user can retry
         // (logging out on publish failure would destroy the keypair before the user sees the error,
         // stranding their events on relays with no retry path).
-        if !result.publishedSuccessfully, let err = result.publishError {
-            publishErrorMessage = err
-        }
-    }
-
-    private func performFullDeletion() async {
-        defer { isDeleting = false }
-        let result = await appState.deleteAllRidestrEvents(from: scan)
         if !result.publishedSuccessfully, let err = result.publishError {
             publishErrorMessage = err
         }
@@ -482,14 +429,14 @@ struct FullDeletionConfirmSheet: View {
                         Image(systemName: "exclamationmark.octagon.fill")
                             .font(.system(size: 40))
                             .foregroundColor(Color.rfError)
-                        Text("Complete Account Deletion")
+                        Text("Delete Account")
                             .font(RFFont.headline(20))
                             .foregroundColor(Color.rfOnSurface)
                             .multilineTextAlignment(.center)
                     }
                     .padding(.top, 16)
 
-                    Text("This deletes all \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") including your Nostr profile (Kind 0 metadata). Please confirm you understand:")
+                    Text("This permanently deletes your account and all \(scan.totalCount) associated event\(scan.totalCount == 1 ? "" : "s"), including your Nostr profile (Kind 0 metadata). Please confirm you understand:")
                         .font(RFFont.body(14))
                         .foregroundColor(Color.rfOnSurfaceVariant)
                         .multilineTextAlignment(.center)
@@ -519,7 +466,7 @@ struct FullDeletionConfirmSheet: View {
                         dismiss()
                         onConfirm()
                     } label: {
-                        Text("Completely Delete Account")
+                        Text("Delete My Account")
                     }
                     .buttonStyle(RFDestructiveButtonStyle(isDisabled: !allChecked))
                     .disabled(!allChecked)

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -385,7 +385,7 @@ struct DeleteAccountResultsView: View {
             VStack(spacing: 0) {
                 confirmRow(
                     isOn: $checkProfile,
-                    text: "I understand this deletes my Nostr profile (display name) from relays"
+                    text: "I understand this deletes all my RoadFlare events, Ridestr protocol events, and my Nostr profile (Kind 0 / display name) from relays"
                 )
                 Divider().padding(.leading, 46)
                 confirmRow(
@@ -484,12 +484,18 @@ struct DeleteAccountResultsView: View {
                     .font(RFFont.headline(22))
                     .foregroundColor(Color.rfOnSurface)
                     .multilineTextAlignment(.center)
-                Text(successDetail(for: verification))
-                    .font(RFFont.body(14))
-                    .foregroundColor(Color.rfOnSurfaceVariant)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.horizontal, 8)
+                // Only surface a detail line when verification turned up
+                // something worth telling the user (partial deletion or relay
+                // errors). On a clean success the checkmark + title say enough
+                // — keeps the happy path uncluttered for the App Review video.
+                if let detail = successDetail(for: verification) {
+                    Text(detail)
+                        .font(RFFont.body(14))
+                        .foregroundColor(Color.rfOnSurfaceVariant)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 8)
+                }
             }
             Spacer()
             Button {
@@ -504,17 +510,15 @@ struct DeleteAccountResultsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func successDetail(for v: DeletionVerificationResult) -> String {
-        if v.requestedCount == 0 {
-            return "Your local account data has been cleared. There were no relay events to remove."
-        }
-        if v.fullyHonoured {
-            return "All \(v.requestedCount) event\(v.requestedCount == 1 ? "" : "s") were removed from relays. Tap Done to finish and clear your local account."
-        }
+    /// Returns a detail string only when verification surfaced a partial
+    /// deletion or relay-side check error. Fully-honoured and zero-event
+    /// cases return nil so the success screen stays minimal.
+    private func successDetail(for v: DeletionVerificationResult) -> String? {
+        if v.requestedCount == 0 || v.fullyHonoured { return nil }
         if !v.scanErrors.isEmpty && v.remainingCount == 0 {
-            return "Your deletion request was sent to \(scan.targetRelayURLs.count) relays. Some relays couldn't be re-checked, but none of the reachable relays still hold your events. Tap Done to finish and clear your local account."
+            return "Some relays couldn't be re-checked, but none of the reachable relays still hold your events."
         }
-        return "Your deletion request was sent to \(scan.targetRelayURLs.count) relays. \(v.deletedCount) of \(v.requestedCount) event\(v.requestedCount == 1 ? " was" : "s were") confirmed removed; some relays may still be processing or may not honour NIP-09. Tap Done to finish and clear your local account."
+        return "\(v.deletedCount) of \(v.requestedCount) event\(v.requestedCount == 1 ? " was" : "s were") confirmed removed; some relays may still be processing or may not honour NIP-09."
     }
 
     private func publishErrorBanner(_ message: String) -> some View {

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -337,6 +337,13 @@ struct DeleteAccountResultsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.rfSurface, for: .navigationBar)
         .navigationBarBackButtonHidden(isBusy || isSuccess)
+        // Block swipe-to-dismiss of the enclosing sheet during publishing /
+        // verifying / success. Without this, a swipe-dismiss mid-verify would
+        // leave the publish completed but logout never triggered (user stays
+        // logged in after confirming delete), and during .success the Done tap
+        // is the intentional way out. The .failed phase still allows dismiss
+        // so the user can abandon a failed publish.
+        .interactiveDismissDisabled(isBusy || isSuccess)
     }
 
     // MARK: Scan + confirm (pre-delete)

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -19,13 +19,17 @@ struct DeleteAccountScanView: View {
     @Environment(\.dismiss) private var dismiss
 
     enum ScanPhase {
-        case idle
         case scanning
         case complete(RelayScanResult)
         case failed(String)
     }
 
-    @State private var phase: ScanPhase = .idle
+    /// Initial state is .scanning so the spinner + relay list render
+    /// immediately; the actual scan kicks off in the .task modifier below.
+    /// There is no "idle" state — a user opening this sheet has already
+    /// committed to the delete flow, so asking them to press "Scan Relays"
+    /// before anything happens was a redundant tap.
+    @State private var phase: ScanPhase = .scanning
 
     var body: some View {
         ZStack {
@@ -56,6 +60,12 @@ struct DeleteAccountScanView: View {
                         .foregroundColor(Color.rfOnSurfaceVariant)
                 }
             }
+        }
+        .task {
+            // Auto-start the scan when the view appears. Re-runs if the user
+            // navigates back from page 2, which is acceptable — a fresh scan
+            // reflects current relay state before they commit to deletion.
+            await startScan()
         }
     }
 
@@ -117,14 +127,6 @@ struct DeleteAccountScanView: View {
     @ViewBuilder
     private var primaryAction: some View {
         switch phase {
-        case .idle:
-            Button {
-                Task { await startScan() }
-            } label: {
-                Text("Scan Relays")
-            }
-            .buttonStyle(RFDestructiveButtonStyle())
-
         case .scanning:
             HStack(spacing: 12) {
                 ProgressView().tint(Color.rfOnSurface)
@@ -159,7 +161,7 @@ struct DeleteAccountScanView: View {
 
         case .failed:
             Button {
-                phase = .idle
+                Task { await startScan() }
             } label: {
                 Text("Try Again")
             }
@@ -228,7 +230,6 @@ struct DeleteAccountScanView: View {
 
     private var relayDotColor: Color {
         switch phase {
-        case .idle: Color.rfOffline
         case .scanning: Color.rfPrimary
         case .complete: Color.rfOnline
         case .failed: Color.rfError
@@ -395,7 +396,7 @@ struct DeleteAccountResultsView: View {
                 Divider().padding(.leading, 46)
                 confirmRow(
                     isOn: $checkBackedUp,
-                    text: "I have backed up my private key, or I no longer need it"
+                    text: "I understand this action cannot be undone"
                 )
             }
             .background(Color.rfSurfaceContainer)
@@ -438,14 +439,11 @@ struct DeleteAccountResultsView: View {
                 Text("Delete My Account")
             }
             // Grey (disabled style) until all three boxes are checked; flips to
-            // red (destructive) once the user has confirmed every warning.
+            // red (destructive) once the user has confirmed every warning. The
+            // third checkbox already acknowledges irreversibility, so no
+            // additional caption is needed beneath the button.
             .buttonStyle(RFDestructiveButtonStyle(isDisabled: !allChecked || isBusy))
             .disabled(!allChecked || isBusy)
-
-            Text("This action cannot be undone.")
-                .font(RFFont.caption(12))
-                .foregroundColor(Color.rfOnSurfaceVariant)
-                .padding(.horizontal, 4)
         }
     }
 

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -1,0 +1,513 @@
+import SwiftUI
+import RidestrSDK
+import RoadFlareCore
+
+// MARK: - Container
+
+struct DeleteAccountSheet: View {
+    var body: some View {
+        NavigationStack {
+            DeleteAccountScanView()
+        }
+    }
+}
+
+// MARK: - Page 1: Relay Scan
+
+struct DeleteAccountScanView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    enum ScanPhase {
+        case idle
+        case scanning
+        case complete(RelayScanResult)
+        case failed(String)
+    }
+
+    @State private var phase: ScanPhase = .idle
+
+    var body: some View {
+        ZStack {
+            Color.rfSurface.ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 24) {
+                    header
+                    relayList
+                    errorBanner
+                    primaryAction
+                    nostrExplainer
+                    Spacer(minLength: 24)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+            }
+        }
+        .navigationTitle("Delete Account")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.rfSurface, for: .navigationBar)
+        .toolbar {
+            // ToolbarContentBuilder requires every branch to produce ToolbarContent —
+            // empty branches aren't allowed, so use a single conditional instead.
+            // Hide Cancel during active scan to prevent accidental dismissal.
+            if !isScanning {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(Color.rfOnSurfaceVariant)
+                }
+            }
+        }
+    }
+
+    // MARK: Subviews
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "trash.circle.fill")
+                .font(.system(size: 52))
+                .foregroundColor(Color.rfError)
+            Text("Delete Account")
+                .font(RFFont.headline(22))
+                .foregroundColor(Color.rfOnSurface)
+            Text("Step 1 of 2 — Relay Scan")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+        }
+        .padding(.top, 8)
+    }
+
+    private var relayList: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionLabel("Relays")
+            VStack(spacing: 8) {
+                ForEach(DefaultRelays.all, id: \.absoluteString) { url in
+                    HStack {
+                        Circle()
+                            .fill(relayDotColor)
+                            .frame(width: 6, height: 6)
+                        Text(url.absoluteString)
+                            .font(RFFont.mono(12))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                        Spacer()
+                        if case .scanning = phase {
+                            ProgressView()
+                                .scaleEffect(0.6)
+                                .tint(Color.rfPrimary)
+                        }
+                    }
+                    .rfCard(.low)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var errorBanner: some View {
+        if case .failed(let msg) = phase {
+            Text(msg)
+                .font(RFFont.body(13))
+                .foregroundColor(Color.rfError)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(14)
+                .background(Color.rfSurfaceContainer)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    @ViewBuilder
+    private var primaryAction: some View {
+        switch phase {
+        case .idle:
+            Button {
+                Task { await startScan() }
+            } label: {
+                Text("Scan Relays")
+            }
+            .buttonStyle(RFDestructiveButtonStyle())
+
+        case .scanning:
+            HStack(spacing: 12) {
+                ProgressView().tint(Color.rfOnSurface)
+                Text("Scanning relays…")
+                    .font(RFFont.body(15))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(Color.rfSurfaceContainer)
+            .clipShape(RoundedRectangle(cornerRadius: 24))
+
+        case .complete(let scan):
+            VStack(spacing: 12) {
+                // Surface scan errors honestly — silent "0 events" when relays
+                // were unreachable would mislead the user into thinking nothing
+                // exists when their data may still be on those relays.
+                if scan.hasErrors {
+                    scanErrorWarning(scan)
+                }
+
+                NavigationLink {
+                    DeleteAccountResultsView(scan: scan)
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: scan.hasErrors ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                        Text("Continue — \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") found")
+                    }
+                }
+                .buttonStyle(RFDestructiveButtonStyle())
+            }
+
+        case .failed:
+            Button {
+                phase = .idle
+            } label: {
+                Text("Try Again")
+            }
+            .buttonStyle(RFSecondaryButtonStyle())
+        }
+    }
+
+    @ViewBuilder
+    private func scanErrorWarning(_ scan: RelayScanResult) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(Color.rfError)
+                Text("Scan incomplete")
+                    .font(RFFont.title(14))
+                    .foregroundColor(Color.rfOnSurface)
+            }
+            ForEach(scan.scanErrors, id: \.self) { err in
+                Text(err)
+                    .font(RFFont.caption(12))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+            }
+            Text("You can still continue, but events on unreachable relays may not be deleted.")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.rfSurfaceContainer)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var nostrExplainer: some View {
+        DisclosureGroup {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("RoadFlare is built on Nostr, a decentralized protocol. Your data is stored on independent relays — not on RoadFlare's servers.")
+                    .font(RFFont.body(14))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+
+                Text("When you delete your account, RoadFlare sends a deletion request (NIP-09) to each relay. Most relays honour these requests and remove your events, but because relays are independently operated, removal cannot be guaranteed.")
+                    .font(RFFont.body(14))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+
+                Text("Your private key exists only on this device. Once deleted, the key — and your Nostr identity — cannot be recovered.")
+                    .font(RFFont.body(14))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+            }
+            .padding(.top, 8)
+        } label: {
+            Text("About Nostr & Account Deletion")
+                .font(RFFont.body(15))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+        }
+        .tint(Color.rfOnSurfaceVariant)
+        .padding(16)
+        .background(Color.rfSurfaceContainer)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    // MARK: Helpers
+
+    private var isScanning: Bool {
+        if case .scanning = phase { return true }
+        return false
+    }
+
+    private var relayDotColor: Color {
+        switch phase {
+        case .idle: Color.rfOffline
+        case .scanning: Color.rfPrimary
+        case .complete: Color.rfOnline
+        case .failed: Color.rfError
+        }
+    }
+
+    private func startScan() async {
+        phase = .scanning
+        do {
+            let scan = try await appState.scanRelaysForDeletion()
+            phase = .complete(scan)
+        } catch AccountDeletionError.activeRideInProgress {
+            phase = .failed("You have an active ride. Complete or cancel it before deleting your account.")
+        } catch AccountDeletionError.servicesNotReady {
+            phase = .failed("Unable to connect — please try again.")
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+}
+
+// MARK: - Page 2: Scan Results + Delete Options
+
+struct DeleteAccountResultsView: View {
+    @Environment(AppState.self) private var appState
+    let scan: RelayScanResult
+
+    @State private var showRoadflareConfirm = false
+    @State private var showFullDeleteSheet = false
+    @State private var isDeleting = false
+
+    var body: some View {
+        ZStack {
+            Color.rfSurface.ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 24) {
+                    header
+                    scanSummaryCard
+                    roadflareDeleteOption
+                    fullDeleteOption
+                    if isDeleting {
+                        deletingIndicator
+                    }
+                    Spacer(minLength: 24)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+            }
+        }
+        .navigationTitle("Delete Events")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.rfSurface, for: .navigationBar)
+        .navigationBarBackButtonHidden(isDeleting)
+        .alert("Delete RoadFlare Events?", isPresented: $showRoadflareConfirm) {
+            Button("Delete", role: .destructive) {
+                Task { await performRoadflareDeletion() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will request deletion of \(scan.roadflareCount) RoadFlare event\(scan.roadflareCount == 1 ? "" : "s") from all relays, then remove all local data and log you out.")
+        }
+        .sheet(isPresented: $showFullDeleteSheet) {
+            FullDeletionConfirmSheet(scan: scan) {
+                Task { await performFullDeletion() }
+            }
+        }
+    }
+
+    // MARK: Subviews
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 52))
+                .foregroundColor(Color.rfError)
+            Text("Review & Delete")
+                .font(RFFont.headline(22))
+                .foregroundColor(Color.rfOnSurface)
+            Text("Step 2 of 2 — Choose What to Delete")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+        }
+        .padding(.top, 8)
+    }
+
+    private var scanSummaryCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: "doc.text.magnifyingglass")
+                    .foregroundColor(Color.rfPrimary)
+                Text("Scan Results")
+                    .font(RFFont.title(15))
+                    .foregroundColor(Color.rfOnSurface)
+            }
+            // Use nested-Text interpolation (iOS 15+, recommended in iOS 26 over
+            // deprecated Text + Text concatenation). The bold counts visually
+            // anchor the summary while keeping surrounding text muted.
+            Text("Found \(Text("\(scan.roadflareCount)").bold().foregroundColor(Color.rfOnSurface)) RoadFlare event\(scan.roadflareCount == 1 ? "" : "s") and \(Text("\(scan.metadataCount)").bold().foregroundColor(Color.rfOnSurface)) Nostr profile event\(scan.metadataCount == 1 ? "" : "s") across \(scan.targetRelayURLs.count) relays.")
+                .font(RFFont.body(14))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.rfSurfaceContainer)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var roadflareDeleteOption: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Recommended")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+                .textCase(.uppercase)
+                .tracking(1)
+
+            Button {
+                showRoadflareConfirm = true
+            } label: {
+                Text("Delete RoadFlare Events")
+            }
+            .buttonStyle(RFDestructiveButtonStyle(isDisabled: isDeleting))
+            .disabled(isDeleting)
+
+            Text("Removes ride history, driver list, saved locations, and all protocol events from relays. Keeps your Nostr profile (Kind 0) intact so other Nostr apps still work.")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+                .padding(.horizontal, 4)
+        }
+    }
+
+    private var fullDeleteOption: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Full Deletion")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+                .textCase(.uppercase)
+                .tracking(1)
+
+            Button {
+                showFullDeleteSheet = true
+            } label: {
+                Text("Delete All Ridestr Events")
+            }
+            .buttonStyle(RFDestructiveSecondaryButtonStyle())
+            .disabled(isDeleting)
+
+            Text("Removes everything above plus your Nostr profile (Kind 0). This may affect other Nostr apps using this identity.")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+                .padding(.horizontal, 4)
+        }
+    }
+
+    private var deletingIndicator: some View {
+        HStack(spacing: 12) {
+            ProgressView().tint(Color.rfOnSurface)
+            Text("Deleting…")
+                .font(RFFont.body(15))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 16)
+        .background(Color.rfSurfaceContainer)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    // MARK: Actions
+
+    private func performRoadflareDeletion() async {
+        isDeleting = true
+        // defer guarantees the UI is unstuck if deletion ever stops short of logout
+        // (e.g. future code path that doesn't call logout). Today, logout() replaces
+        // the view tree before this defer fires; this is purely defensive.
+        defer { isDeleting = false }
+        _ = await appState.deleteRoadflareEvents(from: scan)
+        // logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed.
+        // Publish failures are logged via AppLogger.auth.error in AppState (visible in Console.app).
+    }
+
+    private func performFullDeletion() async {
+        isDeleting = true
+        defer { isDeleting = false }
+        _ = await appState.deleteAllRidestrEvents(from: scan)
+    }
+}
+
+// MARK: - Full Deletion Confirmation (checkbox sheet)
+
+struct FullDeletionConfirmSheet: View {
+    let scan: RelayScanResult
+    let onConfirm: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var checkProfile = false
+    @State private var checkOtherApps = false
+    @State private var checkBackedUp = false
+
+    private var allChecked: Bool {
+        checkProfile && checkOtherApps && checkBackedUp
+    }
+
+    var body: some View {
+        ZStack {
+            Color.rfSurface.ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                VStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.octagon.fill")
+                        .font(.system(size: 40))
+                        .foregroundColor(Color.rfError)
+                    Text("Full Nostr Deletion")
+                        .font(RFFont.headline(20))
+                        .foregroundColor(Color.rfOnSurface)
+                }
+                .padding(.top, 16)
+
+                Text("This deletes all \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") including your Nostr profile (Kind 0 metadata). Please confirm you understand:")
+                    .font(RFFont.body(14))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 8)
+
+                VStack(spacing: 0) {
+                    confirmRow(
+                        isOn: $checkProfile,
+                        text: "I understand this deletes my Nostr profile (display name) from relays"
+                    )
+                    Divider().padding(.leading, 46)
+                    confirmRow(
+                        isOn: $checkOtherApps,
+                        text: "I understand this may affect other Nostr apps that use this identity"
+                    )
+                    Divider().padding(.leading, 46)
+                    confirmRow(
+                        isOn: $checkBackedUp,
+                        text: "I have backed up my private key, or I no longer need it"
+                    )
+                }
+                .background(Color.rfSurfaceContainer)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+
+                Button {
+                    dismiss()
+                    onConfirm()
+                } label: {
+                    Text("Delete All Ridestr Events")
+                }
+                .buttonStyle(RFDestructiveButtonStyle(isDisabled: !allChecked))
+                .disabled(!allChecked)
+
+                Button("Cancel") { dismiss() }
+                    .buttonStyle(RFGhostButtonStyle())
+
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    @ViewBuilder
+    private func confirmRow(isOn: Binding<Bool>, text: String) -> some View {
+        Button {
+            isOn.wrappedValue.toggle()
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: isOn.wrappedValue ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 20))
+                    .foregroundColor(isOn.wrappedValue ? Color.rfError : Color.rfOffline)
+                    .frame(width: 24)
+                Text(text)
+                    .font(RFFont.body(14))
+                    .foregroundColor(Color.rfOnSurface)
+                    .multilineTextAlignment(.leading)
+                Spacer()
+            }
+            .padding(14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -269,7 +269,13 @@ struct DeleteAccountResultsView: View {
     }
 
     @State private var phase: Phase = .ready
-    @State private var showDeleteSheet = false
+    @State private var checkProfile = false
+    @State private var checkOtherApps = false
+    @State private var checkBackedUp = false
+
+    private var allChecked: Bool {
+        checkProfile && checkOtherApps && checkBackedUp
+    }
 
     private var isBusy: Bool {
         switch phase {
@@ -305,11 +311,6 @@ struct DeleteAccountResultsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.rfSurface, for: .navigationBar)
         .navigationBarBackButtonHidden(isBusy || isSuccess)
-        .sheet(isPresented: $showDeleteSheet) {
-            FullDeletionConfirmSheet(scan: scan) {
-                Task { await performDeletion() }
-            }
-        }
     }
 
     // MARK: Scan + confirm (pre-delete)
@@ -320,6 +321,7 @@ struct DeleteAccountResultsView: View {
             VStack(spacing: 24) {
                 header
                 scanSummaryCard
+                confirmCheckboxes
                 if case .failed(let msg) = phase {
                     publishErrorBanner(msg)
                 }
@@ -373,17 +375,74 @@ struct DeleteAccountResultsView: View {
         .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 
+    private var confirmCheckboxes: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Please confirm you understand:")
+                .font(RFFont.body(14))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(spacing: 0) {
+                confirmRow(
+                    isOn: $checkProfile,
+                    text: "I understand this deletes my Nostr profile (display name) from relays"
+                )
+                Divider().padding(.leading, 46)
+                confirmRow(
+                    isOn: $checkOtherApps,
+                    text: "I understand this may affect other Nostr apps that use this identity"
+                )
+                Divider().padding(.leading, 46)
+                confirmRow(
+                    isOn: $checkBackedUp,
+                    text: "I have backed up my private key, or I no longer need it"
+                )
+            }
+            .background(Color.rfSurfaceContainer)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+        }
+    }
+
+    @ViewBuilder
+    private func confirmRow(isOn: Binding<Bool>, text: String) -> some View {
+        Button {
+            isOn.wrappedValue.toggle()
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: isOn.wrappedValue ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 20))
+                    .foregroundColor(isOn.wrappedValue ? Color.rfError : Color.rfOffline)
+                    .frame(width: 24)
+                Text(text)
+                    .font(RFFont.body(14))
+                    .foregroundColor(Color.rfOnSurface)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isBusy)
+    }
+
     private var deleteAccountOption: some View {
         VStack(alignment: .leading, spacing: 8) {
             Button {
-                showDeleteSheet = true
+                // Gated on allChecked above — this can only fire when all three
+                // acknowledgements are ticked. Phase flip handled inside
+                // performDeletion so cancel vs. retry behave consistently.
+                Task { await performDeletion() }
             } label: {
-                Text("Delete Account")
+                Text("Delete My Account")
             }
-            .buttonStyle(RFDestructiveButtonStyle(isDisabled: isBusy))
-            .disabled(isBusy)
+            // Grey (disabled style) until all three boxes are checked; flips to
+            // red (destructive) once the user has confirmed every warning.
+            .buttonStyle(RFDestructiveButtonStyle(isDisabled: !allChecked || isBusy))
+            .disabled(!allChecked || isBusy)
 
-            Text("Permanently deletes your RoadFlare account, all associated events, and your Nostr profile (Kind 0) from relays. This may affect other Nostr apps that use this identity. This action cannot be undone.")
+            Text("This action cannot be undone.")
                 .font(RFFont.caption(12))
                 .foregroundColor(Color.rfOnSurfaceVariant)
                 .padding(.horizontal, 4)
@@ -496,109 +555,3 @@ struct DeleteAccountResultsView: View {
     }
 }
 
-// MARK: - Full Deletion Confirmation (checkbox sheet)
-
-struct FullDeletionConfirmSheet: View {
-    let scan: RelayScanResult
-    let onConfirm: () -> Void
-    @Environment(\.dismiss) private var dismiss
-
-    @State private var checkProfile = false
-    @State private var checkOtherApps = false
-    @State private var checkBackedUp = false
-
-    private var allChecked: Bool {
-        checkProfile && checkOtherApps && checkBackedUp
-    }
-
-    var body: some View {
-        ZStack {
-            Color.rfSurface.ignoresSafeArea()
-
-            ScrollView {
-                VStack(spacing: 24) {
-                    VStack(spacing: 8) {
-                        Image(systemName: "exclamationmark.octagon.fill")
-                            .font(.system(size: 40))
-                            .foregroundColor(Color.rfError)
-                        Text("Delete Account")
-                            .font(RFFont.headline(20))
-                            .foregroundColor(Color.rfOnSurface)
-                            .multilineTextAlignment(.center)
-                    }
-                    .padding(.top, 16)
-
-                    Text("This permanently deletes your account and all \(scan.totalCount) associated event\(scan.totalCount == 1 ? "" : "s"), including your Nostr profile (Kind 0 metadata). Please confirm you understand:")
-                        .font(RFFont.body(14))
-                        .foregroundColor(Color.rfOnSurfaceVariant)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.horizontal, 8)
-
-                    VStack(spacing: 0) {
-                        confirmRow(
-                            isOn: $checkProfile,
-                            text: "I understand this deletes my Nostr profile (display name) from relays"
-                        )
-                        Divider().padding(.leading, 46)
-                        confirmRow(
-                            isOn: $checkOtherApps,
-                            text: "I understand this may affect other Nostr apps that use this identity"
-                        )
-                        Divider().padding(.leading, 46)
-                        confirmRow(
-                            isOn: $checkBackedUp,
-                            text: "I have backed up my private key, or I no longer need it"
-                        )
-                    }
-                    .background(Color.rfSurfaceContainer)
-                    .clipShape(RoundedRectangle(cornerRadius: 16))
-
-                    Button {
-                        dismiss()
-                        onConfirm()
-                    } label: {
-                        Text("Delete My Account")
-                    }
-                    .buttonStyle(RFDestructiveButtonStyle(isDisabled: !allChecked))
-                    .disabled(!allChecked)
-
-                    Button("Cancel") { dismiss() }
-                        .buttonStyle(RFGhostButtonStyle())
-                }
-                .padding(.horizontal, 20)
-                .padding(.bottom, 24)
-            }
-        }
-        // .large instead of .medium — wrapped checkbox rows + three buttons don't
-        // fit in half-screen on compact phones, and dragging between detents was
-        // cutting the confirm button off below the fold.
-        .presentationDetents([.large])
-    }
-
-    @ViewBuilder
-    private func confirmRow(isOn: Binding<Bool>, text: String) -> some View {
-        Button {
-            isOn.wrappedValue.toggle()
-        } label: {
-            HStack(alignment: .top, spacing: 12) {
-                Image(systemName: isOn.wrappedValue ? "checkmark.square.fill" : "square")
-                    .font(.system(size: 20))
-                    .foregroundColor(isOn.wrappedValue ? Color.rfError : Color.rfOffline)
-                    .frame(width: 24)
-                Text(text)
-                    .font(RFFont.body(14))
-                    .foregroundColor(Color.rfOnSurface)
-                    .multilineTextAlignment(.leading)
-                    // Force the Text to take the full remaining width and let it
-                    // wrap vertically as needed — without fixedSize the row keeps
-                    // the text on one line and truncates at the trailing edge.
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .padding(14)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-}

--- a/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
@@ -291,6 +291,12 @@ struct DeleteAccountResultsView: View {
         .navigationBarBackButtonHidden(isDeleting)
         .alert("Delete RoadFlare Events?", isPresented: $showRoadflareConfirm) {
             Button("Delete", role: .destructive) {
+                // Flip isDeleting synchronously so rapid taps on the alert button
+                // don't spawn a second concurrent deletion Task (SwiftUI alert
+                // buttons aren't debounced and the .disabled(isDeleting) gate on
+                // the page button doesn't cover the alert's confirm).
+                isDeleting = true
+                publishErrorMessage = nil
                 Task { await performRoadflareDeletion() }
             }
             Button("Cancel", role: .cancel) {}
@@ -299,6 +305,8 @@ struct DeleteAccountResultsView: View {
         }
         .sheet(isPresented: $showFullDeleteSheet) {
             FullDeletionConfirmSheet(scan: scan) {
+                isDeleting = true
+                publishErrorMessage = nil
                 Task { await performFullDeletion() }
             }
         }
@@ -424,10 +432,11 @@ struct DeleteAccountResultsView: View {
     // MARK: Actions
 
     private func performRoadflareDeletion() async {
-        isDeleting = true
-        // defer guarantees the UI is unstuck if deletion stops short of logout
-        // (publish failure or active-ride guard hit). On success, logout() replaces
-        // the view tree before this defer fires, so the reset is purely defensive.
+        // isDeleting and publishErrorMessage are set synchronously by the
+        // confirm-button action (closes the rapid-tap race); defer guarantees
+        // the UI is unstuck if deletion stops short of logout (publish failure
+        // or active-ride guard hit). On success, logout() replaces the view
+        // tree before this defer fires, so the reset is purely defensive.
         defer { isDeleting = false }
         let result = await appState.deleteRoadflareEvents(from: scan)
         // On success: logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed.
@@ -440,7 +449,6 @@ struct DeleteAccountResultsView: View {
     }
 
     private func performFullDeletion() async {
-        isDeleting = true
         defer { isDeleting = false }
         let result = await appState.deleteAllRidestrEvents(from: scan)
         if !result.publishedSuccessfully, let err = result.publishError {

--- a/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
@@ -9,6 +9,7 @@ struct SettingsTab: View {
     @State private var showLogoutConfirm = false
     @State private var showEditProfile = false
     @State private var showConnectivity = false
+    @State private var showDeleteAccount = false
 
     var body: some View {
         NavigationStack {
@@ -170,15 +171,17 @@ struct SettingsTab: View {
                             .clipShape(RoundedRectangle(cornerRadius: 16))
                         }
 
-                        // Logout
-                        Button { showLogoutConfirm = true } label: {
-                            Text("Log Out")
-                                .font(RFFont.body(15))
-                                .foregroundColor(Color.rfError)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 14)
-                                .background(Color.rfSurfaceContainer)
-                                .clipShape(RoundedRectangle(cornerRadius: 16))
+                        // Logout & Delete Account — destructive actions stack
+                        VStack(spacing: 12) {
+                            Button { showLogoutConfirm = true } label: {
+                                Text("Log Out")
+                            }
+                            .buttonStyle(RFDestructiveSecondaryButtonStyle())
+
+                            Button { showDeleteAccount = true } label: {
+                                Text("Delete Account")
+                            }
+                            .buttonStyle(RFDestructiveSecondaryButtonStyle())
                         }
                     }
                     .padding(.horizontal, 16)
@@ -193,6 +196,7 @@ struct SettingsTab: View {
             .sheet(isPresented: $showEditProfile) {
                 EditProfileSheet()
             }
+            .sheet(isPresented: $showDeleteAccount) { DeleteAccountSheet() }
             .alert("Log Out?", isPresented: $showLogoutConfirm) {
                 Button("Log Out", role: .destructive) { Task { await appState.logout() } }
                 Button("Cancel", role: .cancel) {}

--- a/RoadFlare/RoadFlare/Views/Shared/DesignSystem.swift
+++ b/RoadFlare/RoadFlare/Views/Shared/DesignSystem.swift
@@ -147,6 +147,46 @@ struct RFGhostButtonStyle: ButtonStyle {
     }
 }
 
+/// Destructive CTA button — solid red with white text. For prominent destructive
+/// actions like "Delete Account". Mirrors `RFPrimaryButtonStyle` shape and motion
+/// but uses `rfError` instead of the flare gradient.
+struct RFDestructiveButtonStyle: ButtonStyle {
+    var isDisabled = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(RFFont.title(18))
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                isDisabled
+                    ? AnyShapeStyle(Color.rfSurfaceContainerHighest)
+                    : AnyShapeStyle(Color.rfError)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 24))
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+/// Outlined destructive button — card surface with red text. For secondary
+/// destructive actions like "Delete All Ridestr Events" beside a primary
+/// destructive button. Matches the existing Log Out button pattern in Settings.
+struct RFDestructiveSecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(RFFont.title(16))
+            .foregroundColor(Color.rfError)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(Color.rfSurfaceContainer)
+            .clipShape(RoundedRectangle(cornerRadius: 24))
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
 // MARK: - Card Modifier
 
 struct RFCardModifier: ViewModifier {

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -379,6 +379,12 @@ public final class AppState {
     /// Re-checks active-ride state: the user could have started a ride between scan
     /// and confirm (e.g. accepted an offer in another tab), and `logout()` → `clearAll()`
     /// would otherwise tear down an active ride mid-flight.
+    ///
+    /// Only calls `logout()` when the Kind 5 publish succeeds — logging out on
+    /// publish failure would destroy the keypair before the user sees the error,
+    /// leaving their events stranded on relays with no way to retry from this
+    /// device. On failure the caller must surface the error and let the user retry
+    /// or abandon the flow; the local session stays intact until then.
     public func deleteRoadflareEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
         guard let keypair, let relayManager else {
             return RelayDeletionResult(
@@ -395,18 +401,20 @@ public final class AppState {
         }
         let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
         let result = await service.deleteRoadflareEvents(from: scan)
-        if !result.publishedSuccessfully {
+        if result.publishedSuccessfully {
+            await logout()
+        } else {
             AppLogger.auth.error(
                 "RoadFlare event deletion publish failed: \(result.publishError ?? "unknown", privacy: .public)"
             )
         }
-        await logout()
         return result
     }
 
     /// Delete all Ridestr events (including Kind 0 metadata) from relays,
     /// then clear local data and log out. Re-checks active-ride state for the same
-    /// reason as `deleteRoadflareEvents`.
+    /// reason as `deleteRoadflareEvents`, and only logs out on publish success —
+    /// see `deleteRoadflareEvents` for the keypair-preservation rationale.
     public func deleteAllRidestrEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
         guard let keypair, let relayManager else {
             return RelayDeletionResult(
@@ -423,12 +431,13 @@ public final class AppState {
         }
         let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
         let result = await service.deleteAllRidestrEvents(from: scan)
-        if !result.publishedSuccessfully {
+        if result.publishedSuccessfully {
+            await logout()
+        } else {
             AppLogger.auth.error(
                 "Full Ridestr event deletion publish failed: \(result.publishError ?? "unknown", privacy: .public)"
             )
         }
-        await logout()
         return result
     }
 

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -12,6 +12,12 @@ public enum AuthState {
     case ready
 }
 
+/// Reasons account deletion can fail before contacting relays.
+public enum AccountDeletionError: Error, Equatable {
+    case servicesNotReady
+    case activeRideInProgress
+}
+
 /// Central app state coordinator. Owns SDK services and manages auth lifecycle.
 ///
 /// Views access this via `@Environment(AppState.self)`. All sync orchestration
@@ -343,6 +349,68 @@ public final class AppState {
         try? await keyManager?.deleteKeys()
         keypair = nil
         authState = .loggedOut
+    }
+
+    // MARK: - Account Deletion
+
+    /// Scan relays for all rider-authored events. Returns categorised results.
+    /// Call while still logged in (relay + keypair are live).
+    ///
+    /// Defensively reconnects the relay manager if its notification handler died
+    /// (e.g. after backgrounding) so the scan doesn't silently return 0 events
+    /// because the WebSocket is dead.
+    public func scanRelaysForDeletion() async throws -> RelayScanResult {
+        guard let keypair, let relayManager else {
+            throw AccountDeletionError.servicesNotReady
+        }
+        guard !(rideCoordinator?.session.stage.isActiveRide ?? false) else {
+            throw AccountDeletionError.activeRideInProgress
+        }
+        await relayManager.reconnectIfNeeded()
+        let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
+        return await service.scanRelays()
+    }
+
+    /// Delete only RoadFlare events from relays, then clear local data and log out.
+    /// Logs publish failures via `AppLogger.auth.error` so they're visible in Console.app
+    /// — the user is logged out either way (they've committed to deletion), but the
+    /// failure is preserved diagnostically.
+    public func deleteRoadflareEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
+        guard let keypair, let relayManager else {
+            return RelayDeletionResult(
+                deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: false, publishError: "Services not ready"
+            )
+        }
+        let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
+        let result = await service.deleteRoadflareEvents(from: scan)
+        if !result.publishedSuccessfully {
+            AppLogger.auth.error(
+                "RoadFlare event deletion publish failed: \(result.publishError ?? "unknown", privacy: .public)"
+            )
+        }
+        await logout()
+        return result
+    }
+
+    /// Delete all Ridestr events (including Kind 0 metadata) from relays,
+    /// then clear local data and log out.
+    public func deleteAllRidestrEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
+        guard let keypair, let relayManager else {
+            return RelayDeletionResult(
+                deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: false, publishError: "Services not ready"
+            )
+        }
+        let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
+        let result = await service.deleteAllRidestrEvents(from: scan)
+        if !result.publishedSuccessfully {
+            AppLogger.auth.error(
+                "Full Ridestr event deletion publish failed: \(result.publishError ?? "unknown", privacy: .public)"
+            )
+        }
+        await logout()
+        return result
     }
 
     // MARK: - Service Setup

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -358,7 +358,10 @@ public final class AppState {
     ///
     /// Defensively reconnects the relay manager if its notification handler died
     /// (e.g. after backgrounding) so the scan doesn't silently return 0 events
-    /// because the WebSocket is dead.
+    /// because the WebSocket is dead. Uses `reconnectAndRestoreSession()` so any
+    /// live subscriptions (ride coordinator) are restored if the user cancels the
+    /// deletion flow — `reconnectIfNeeded()` alone tears down subscriptions without
+    /// restoring them.
     public func scanRelaysForDeletion() async throws -> RelayScanResult {
         guard let keypair, let relayManager else {
             throw AccountDeletionError.servicesNotReady
@@ -366,20 +369,28 @@ public final class AppState {
         guard !(rideCoordinator?.session.stage.isActiveRide ?? false) else {
             throw AccountDeletionError.activeRideInProgress
         }
-        await relayManager.reconnectIfNeeded()
+        await reconnectAndRestoreSession()
         let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
         return await service.scanRelays()
     }
 
     /// Delete only RoadFlare events from relays, then clear local data and log out.
-    /// Logs publish failures via `AppLogger.auth.error` so they're visible in Console.app
-    /// — the user is logged out either way (they've committed to deletion), but the
-    /// failure is preserved diagnostically.
+    /// Logs publish failures via `AppLogger.auth.error` so they're visible in Console.app.
+    /// Re-checks active-ride state: the user could have started a ride between scan
+    /// and confirm (e.g. accepted an offer in another tab), and `logout()` → `clearAll()`
+    /// would otherwise tear down an active ride mid-flight.
     public func deleteRoadflareEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
         guard let keypair, let relayManager else {
             return RelayDeletionResult(
                 deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
                 publishedSuccessfully: false, publishError: "Services not ready"
+            )
+        }
+        guard !(rideCoordinator?.session.stage.isActiveRide ?? false) else {
+            return RelayDeletionResult(
+                deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: false,
+                publishError: "An active ride started during deletion — cancel it and try again."
             )
         }
         let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
@@ -394,12 +405,20 @@ public final class AppState {
     }
 
     /// Delete all Ridestr events (including Kind 0 metadata) from relays,
-    /// then clear local data and log out.
+    /// then clear local data and log out. Re-checks active-ride state for the same
+    /// reason as `deleteRoadflareEvents`.
     public func deleteAllRidestrEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
         guard let keypair, let relayManager else {
             return RelayDeletionResult(
                 deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
                 publishedSuccessfully: false, publishError: "Services not ready"
+            )
+        }
+        guard !(rideCoordinator?.session.stage.isActiveRide ?? false) else {
+            return RelayDeletionResult(
+                deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: false,
+                publishError: "An active ride started during deletion — cancel it and try again."
             )
         }
         let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -447,6 +447,52 @@ public final class AppState {
         return result
     }
 
+    /// Publish the Kind 5 account deletion event for all Ridestr events + Kind 0.
+    /// Unlike `deleteAllRidestrEvents`, this DOES NOT call `logout()` on success —
+    /// the caller is responsible for invoking `logout()` after the user confirms
+    /// a post-publish verification step. This lets the UI show a verification
+    /// screen (re-scans relays to confirm deletion was honoured) before the
+    /// keypair is destroyed.
+    public func publishAccountDeletion(from scan: RelayScanResult) async -> RelayDeletionResult {
+        guard let keypair, let relayManager else {
+            return RelayDeletionResult(
+                deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: false, publishError: "Services not ready"
+            )
+        }
+        guard !(rideCoordinator?.session.stage.isActiveRide ?? false) else {
+            return RelayDeletionResult(
+                deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: false,
+                publishError: "An active ride started during deletion — cancel it and try again."
+            )
+        }
+        let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
+        let result = await service.deleteAllRidestrEvents(from: scan)
+        if !result.publishedSuccessfully {
+            AppLogger.auth.error(
+                "Account deletion publish failed: \(result.publishError ?? "unknown", privacy: .public)"
+            )
+        }
+        return result
+    }
+
+    /// Re-scan relays for the given event IDs to verify how many were honoured.
+    /// Intended to run after `publishAccountDeletion` returns successfully and
+    /// before the user confirms the final logout. The keypair + relay manager
+    /// must still be live when this is called.
+    public func verifyAccountDeletion(eventIds: [String]) async -> DeletionVerificationResult {
+        guard let keypair, let relayManager else {
+            return DeletionVerificationResult(
+                requestedCount: eventIds.count,
+                remainingCount: eventIds.count,
+                scanErrors: ["Services not ready"]
+            )
+        }
+        let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
+        return await service.verifyDeletion(targetEventIds: eventIds)
+    }
+
     // MARK: - Service Setup
 
     /// Setup with sync status updates for the import flow UI.

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -358,10 +358,13 @@ public final class AppState {
     ///
     /// Defensively reconnects the relay manager if its notification handler died
     /// (e.g. after backgrounding) so the scan doesn't silently return 0 events
-    /// because the WebSocket is dead. Uses `reconnectAndRestoreSession()` so any
-    /// live subscriptions (ride coordinator) are restored if the user cancels the
-    /// deletion flow — `reconnectIfNeeded()` alone tears down subscriptions without
-    /// restoring them.
+    /// because the WebSocket is dead. Restores live ride subscriptions (so they
+    /// survive the user cancelling the sheet) but deliberately skips
+    /// `flushPendingSyncPublishes`: flushing here would push dirty profile/drivers/
+    /// history state to relays right before the user asks to delete everything,
+    /// wasting relay traffic and risking a race where freshly-flushed events
+    /// aren't indexed in time for the scan query — orphaning them on relays
+    /// after the keypair is destroyed.
     public func scanRelaysForDeletion() async throws -> RelayScanResult {
         guard let keypair, let relayManager else {
             throw AccountDeletionError.servicesNotReady
@@ -369,7 +372,10 @@ public final class AppState {
         guard !(rideCoordinator?.session.stage.isActiveRide ?? false) else {
             throw AccountDeletionError.activeRideInProgress
         }
-        await reconnectAndRestoreSession()
+        await relayManager.reconnectIfNeeded()
+        if await relayManager.isConnected {
+            await rideCoordinator?.restoreLiveSubscriptions()
+        }
         let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
         return await service.scanRelays()
     }

--- a/RoadFlare/RoadFlareTests/RoadFlareTests.swift
+++ b/RoadFlare/RoadFlareTests/RoadFlareTests.swift
@@ -286,6 +286,32 @@ struct AppStateTests {
             #expect(Bool(false))
         }
     }
+
+    // MARK: - Account Deletion
+
+    @MainActor
+    @Test func scanRelaysForDeletion_throwsServicesNotReady_whenNotLoggedIn() async throws {
+        let appState = AppState()
+        // Fresh AppState has nil keypair and nil relayManager.
+
+        await #expect(throws: AccountDeletionError.servicesNotReady) {
+            try await appState.scanRelaysForDeletion()
+        }
+    }
+
+    @MainActor
+    @Test func deleteRoadflareEvents_returnsServicesNotReady_whenNotLoggedIn() async throws {
+        let appState = AppState()
+        let scan = RelayScanResult(
+            roadflareEvents: [], metadataEvents: [],
+            scanErrors: [], targetRelayURLs: DefaultRelays.all
+        )
+
+        let result = await appState.deleteRoadflareEvents(from: scan)
+
+        #expect(result.publishedSuccessfully == false)
+        #expect(result.publishError == "Services not ready")
+    }
 }
 
 // MARK: - UserDefaultsDriversPersistence Tests

--- a/decisions/0010-account-deletion-service.md
+++ b/decisions/0010-account-deletion-service.md
@@ -20,7 +20,7 @@ Three pressures shape the design:
 
 **App-layer wrapper.** `AppState` exposes three methods that layer in app-specific preflight and teardown:
 
-- `scanRelaysForDeletion()` — checks keypair + relayManager are live, checks no active ride is in progress (throws `activeRideInProgress`), calls `reconnectAndRestoreSession()` to defensively rebuild dead WebSockets (without stranding live ride subscriptions), then delegates to the service.
+- `scanRelaysForDeletion()` — checks keypair + relayManager are live, checks no active ride is in progress (throws `activeRideInProgress`), calls `reconnectIfNeeded()` + `rideCoordinator?.restoreLiveSubscriptions()` to defensively rebuild dead WebSockets (without stranding live ride subscriptions), then delegates to the service. Deliberately does NOT call `reconnectAndRestoreSession()` because that also flushes pending sync publishes — flushing dirty profile/drivers/history state right before the user asks to delete everything wastes relay traffic and risks a race where freshly-flushed events aren't indexed in time for the scan query.
 - `deleteRoadflareEvents(from:)` / `deleteAllRidestrEvents(from:)` — re-check the active-ride guard at delete time (the user could have accepted an offer in another tab after the scan completed), publish the Kind 5 event via the service, then call `logout()` to tear down local state.
 
 **Two-tier deletion.** The UI (`DeleteAccountSheet`) offers two options on page 2:

--- a/decisions/0010-account-deletion-service.md
+++ b/decisions/0010-account-deletion-service.md
@@ -1,0 +1,66 @@
+# ADR-0010: Account Deletion as Stateless SDK Service with Two-Tier UX
+
+**Date:** 2026-04-16
+**Status:** Accepted
+**Issue:** #51 — In-app account deletion
+
+## Context
+
+Users need an in-app path to permanently delete their RoadFlare account. Unlike logout (which only clears local state), deletion must publish NIP-09 Kind 5 deletion events to every relay before tearing down the local key so the user's data does not linger on public relays.
+
+Three pressures shape the design:
+
+1. **Nostr is decentralized** — relays are independently operated, so the client must publish deletion requests to every relay it has used. There is no server-side "DELETE /account" endpoint.
+2. **Key destruction is terminal** — the user's keypair lives only on-device. Once `logout()` destroys the keys, a failed publish cannot be retried by the same identity. This makes the publish step non-idempotent and high-stakes.
+3. **Mixed identity** — users may have a shared Nostr profile (Kind 0) used by other Nostr apps. Wholesale deletion of Kind 0 is destructive outside RoadFlare's scope, so the UX must separate "delete RoadFlare events" from "delete all Ridestr events including my Nostr profile."
+
+## Decision
+
+**Service placement (SDK vs app).** A new stateless `AccountDeletionService` in `RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift` owns the Nostr protocol semantics: scanning relays for rider-authored events, building Kind 5 deletion events, and publishing with retry. The service is `final Sendable` with two `let` dependencies (`relayManager`, `keypair`) — no mutable state, no `@unchecked Sendable` / `NSLock` needed. Callers create a fresh instance per flow.
+
+**App-layer wrapper.** `AppState` exposes three methods that layer in app-specific preflight and teardown:
+
+- `scanRelaysForDeletion()` — checks keypair + relayManager are live, checks no active ride is in progress (throws `activeRideInProgress`), calls `reconnectAndRestoreSession()` to defensively rebuild dead WebSockets (without stranding live ride subscriptions), then delegates to the service.
+- `deleteRoadflareEvents(from:)` / `deleteAllRidestrEvents(from:)` — re-check the active-ride guard at delete time (the user could have accepted an offer in another tab after the scan completed), publish the Kind 5 event via the service, then call `logout()` to tear down local state.
+
+**Two-tier deletion.** The UI (`DeleteAccountSheet`) offers two options on page 2:
+
+- **Delete RoadFlare events** (recommended) — 12 rider-authored Ridestr kinds. Preserves Kind 0 metadata so other Nostr apps on the same identity continue to work.
+- **Delete all Ridestr events** — 12 kinds + Kind 0. Requires a three-checkbox confirmation sheet (profile impact, other-app impact, key-backup acknowledgement).
+
+**Retry on publish.** The service uses `publishWithRetry(_:)` (not plain `publish`) because the deletion event is critical and non-retryable after logout. Transient relay failures would otherwise be the final error the user ever sees on this identity.
+
+**Error surfacing.** Publish failures are captured in `RelayDeletionResult.publishError` and surfaced to the user in `DeleteAccountResultsView` as a persistent banner (not just a log line). Scan errors are surfaced on page 1 via the existing `scanErrorWarning` affordance.
+
+## Rationale Over Alternatives
+
+| Alternative | Rejected because |
+|---|---|
+| Place deletion logic in `AppState` directly | Nostr protocol semantics (kind list, Kind 5 construction, filter queries) belong in the SDK per project convention — `AppState` should only glue iOS lifecycle to SDK calls |
+| One-tier "delete everything" UX | Users with a shared Nostr identity would lose profile data used by unrelated Nostr apps — a destructive surprise |
+| `reconnectIfNeeded()` alone before scan | Tears down ride-coordinator subscriptions per its documented contract ("callers must re-subscribe after this returns") — would strand live ride sessions if the user cancels the sheet. `reconnectAndRestoreSession()` already bundles the reconnect + `restoreLiveSubscriptions()` pair used elsewhere |
+| Plain `publish` (no retry) | Deletion is one-shot after logout; a transient relay hiccup would silently leave events on relays with no user-visible recovery path |
+| Log publish errors only (no UI banner) | "I confidently deleted my account but my events are still on relays" is the exact footgun NIP-09 is designed to avoid — silent log-only failure reproduces it |
+| Delete without re-checking active-ride state | `logout()` → `prepareForIdentityReplacement()` calls `rideCoordinator?.clearAll()`, which would tear down a live ride mid-flight if one started between scan and confirm |
+
+## Consequences
+
+**Enables:**
+- In-app compliance with user-initiated data deletion expectations (App Store guideline 5.1.1(v)).
+- Reusable SDK surface — `AccountDeletionService` can be consumed by future clients (e.g. drivestr) without app-layer changes.
+- Clear separation: the scan/delete protocol is tested in the SDK (9 tests); the app-layer glue (active-ride guard, error surfacing) is tested in `RoadFlareTests`.
+
+**Known tradeoffs:**
+- Relay independence means deletion cannot be guaranteed — a relay may refuse to honour NIP-09. This is disclosed to the user in the page 1 explainer ("RoadFlare sends a deletion request … but because relays are independently operated, removal cannot be guaranteed"). No code-level mitigation is possible.
+- The retry (up to 3 attempts with exponential backoff) extends the publish window by up to ~3s before the user is logged out. Acceptable tradeoff for a deliberate, user-initiated action.
+- The active-ride guard at delete time rejects the deletion outright rather than offering a "cancel ride first" flow. A future enhancement could auto-cancel the ride as part of the deletion path.
+
+## Affected Files
+
+- `RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift` (new)
+- `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/AccountDeletionServiceTests.swift` (new)
+- `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` — new `AccountDeletionError`, `scanRelaysForDeletion`, `deleteRoadflareEvents`, `deleteAllRidestrEvents`
+- `RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift` (new) — two-page flow
+- `RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift` — Delete Account button
+- `RoadFlare/RoadFlare/Views/Shared/DesignSystem.swift` — `RFDestructiveButtonStyle`, `RFDestructiveSecondaryButtonStyle`
+- `RoadFlare/RoadFlareTests/RoadFlareTests.swift` — `AppState` guard tests

--- a/decisions/0010-account-deletion-service.md
+++ b/decisions/0010-account-deletion-service.md
@@ -32,6 +32,8 @@ Three pressures shape the design:
 
 **Error surfacing.** Publish failures are captured in `RelayDeletionResult.publishError` and surfaced to the user in `DeleteAccountResultsView` as a persistent banner (not just a log line). Scan errors are surfaced on page 1 via the existing `scanErrorWarning` affordance.
 
+**Logout timing.** `logout()` is called only when the Kind 5 publish succeeds. On publish failure the session is preserved so the error banner can render and the user can retry — logging out would destroy the keypair before the error is visible, stranding their events on relays with no retry path from this device. Active-ride and services-not-ready guards also short-circuit before logout so the sheet remains visible with the guard message.
+
 ## Rationale Over Alternatives
 
 | Alternative | Rejected because |

--- a/decisions/0010-account-deletion-service.md
+++ b/decisions/0010-account-deletion-service.md
@@ -23,10 +23,9 @@ Three pressures shape the design:
 - `scanRelaysForDeletion()` — checks keypair + relayManager are live, checks no active ride is in progress (throws `activeRideInProgress`), calls `reconnectIfNeeded()` + `rideCoordinator?.restoreLiveSubscriptions()` to defensively rebuild dead WebSockets (without stranding live ride subscriptions), then delegates to the service. Deliberately does NOT call `reconnectAndRestoreSession()` because that also flushes pending sync publishes — flushing dirty profile/drivers/history state right before the user asks to delete everything wastes relay traffic and risks a race where freshly-flushed events aren't indexed in time for the scan query.
 - `deleteRoadflareEvents(from:)` / `deleteAllRidestrEvents(from:)` — re-check the active-ride guard at delete time (the user could have accepted an offer in another tab after the scan completed), publish the Kind 5 event via the service, then call `logout()` to tear down local state.
 
-**Two-tier deletion.** The UI (`DeleteAccountSheet`) offers two options on page 2:
+**Single-button deletion UX.** The UI (`DeleteAccountSheet`) offers one "Delete Account" action on page 2. It wipes everything: all 12 Ridestr kinds + Kind 0 metadata, destroys the local keypair, and calls `logout()`. A three-checkbox confirmation sheet (profile impact, other-app impact, key-backup acknowledgement) gates the destructive publish.
 
-- **Delete RoadFlare events** (recommended) — 12 rider-authored Ridestr kinds. Preserves Kind 0 metadata so other Nostr apps on the same identity continue to work.
-- **Delete all Ridestr events** — 12 kinds + Kind 0. Requires a three-checkbox confirmation sheet (profile impact, other-app impact, key-backup acknowledgement).
+An earlier design offered two tiers (preserve Kind 0 vs. delete Kind 0). This was collapsed after App Review feedback made clear that multiple "delete" affordances confuse reviewers who expect a single unambiguous path per App Store guideline 5.1.1(v). The SDK still exposes both `deleteRoadflareEvents` and `deleteAllRidestrEvents` — the app just never calls the former today. Keeping the preserve-Kind-0 option in the SDK is cheap insurance if a power-user disclosure ever re-emerges.
 
 **Retry on publish.** The service uses `publishWithRetry(_:)` (not plain `publish`) because the deletion event is critical and non-retryable after logout. Transient relay failures would otherwise be the final error the user ever sees on this identity.
 

--- a/docs/plans/issue-51-delete-account.md
+++ b/docs/plans/issue-51-delete-account.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a two-page in-app Delete Account flow that (1) publishes NIP-09 deletion requests for the user's Nostr events to all known relays and shows per-relay status, then (2) performs full local account cleanup and returns the app to the logged-out/onboarding state.
+**Goal:** Add a two-page in-app Delete Account flow: Page 1 scans relays for the user's events, Page 2 shows results and offers two deletion tiers — RoadFlare-only events or all Ridestr events including Kind 0 metadata — each with appropriate confirmation, followed by local data cleanup and logout.
 
-**Architecture:** A new `AccountDeletionService` in RidestrSDK handles event-ID fetching and Kind 5 deletion publishing via `RelayManagerProtocol`. `AppState` gains `beginRelayDeletion()` and `completeAccountDeletion()` methods. The UI is a sheet with a `NavigationStack` hosting two views — `DeleteAccountRelayView` (Page 1: relay deletion) and `DeleteAccountFinalView` (Page 2: local cleanup confirmation) — triggered from a new "Delete Account" button added to `SettingsTab`.
+**Architecture:** A new `AccountDeletionService` in RidestrSDK handles relay scanning and Kind 5 deletion publishing via `RelayManagerProtocol`. `AppState` gains orchestration methods for scanning, deleting, and completing logout. The UI is a sheet with a `NavigationStack` — Page 1 scans relays, Page 2 shows results and two delete options — triggered from a "Delete Account" button in Settings.
 
-**Tech Stack:** SwiftUI, RidestrSDK (`NostrFilter`, `RideshareEventBuilder`, `RelayManagerProtocol`, `DefaultRelays`), `AppState` (`@Observable`, `@MainActor`), `FakeRelayManager` + Swift Testing for unit tests
+**Tech Stack:** SwiftUI, RidestrSDK (`NostrFilter`, `RideshareEventBuilder`, `RelayManagerProtocol`, `DefaultRelays`, `EventKind`), `AppState` (`@Observable`, `@MainActor`), `FakeRelayManager` + Swift Testing for unit tests
 
 ---
 
@@ -15,24 +15,52 @@
 ### What constitutes "an account"
 
 A RoadFlare account is:
-1. **A Nostr keypair** — private key stored in Keychain at service `"com.roadflare.keys"`, key `"nostr_identity_private_key"`. Cleared by `KeyManager.deleteKeys()`.
+1. **A Nostr keypair** — private key in Keychain at service `"com.roadflare.keys"`, key `"nostr_identity_private_key"`. Cleared by `KeyManager.deleteKeys()`.
 2. **Local UserDefaults data** — profile name, payment methods, saved locations, ride history, followed drivers, sync metadata. Cleared by repository `clearAll()` calls in `prepareForIdentityReplacement()`.
-3. **Nostr-backed events on relays** — the four kinds below. NOT cleared by current `logout()`.
+3. **Nostr events on relays** — rider-authored events across 13 event kinds. NOT cleared by current `logout()`.
 
-### Nostr events that must be deleted (rider-authored, non-ephemeral)
+### Rider-authored event kinds (all Ridestr/RoadFlare)
 
-| Kind | Name | d-tag filter |
-|------|------|--------------|
-| 0 | metadata (profile name) | — (use `NostrFilter.metadata`) |
+**Non-ephemeral (parameterized replaceable, always on relays):**
+
+| Kind | Name | d-tag |
+|------|------|-------|
 | 30011 | followedDriversList | `"roadflare-drivers"` |
 | 30174 | rideHistoryBackup | `"rideshare-history"` |
 | 30177 | unifiedProfile / profileBackup | `"rideshare-profile"` |
+| 30181 | riderRideState | dynamic (confirmationEventId) |
 
-Ephemeral kinds (3173–3189) expire naturally and do **not** need deletion.
+**Ephemeral (expire naturally, but may still be on relays):**
 
-### Current logout flow (reuse for step 2)
+| Kind | Name | Expiry |
+|------|------|--------|
+| 3173 | rideOffer | 15 min |
+| 3175 | rideConfirmation | 8 hrs |
+| 3178 | chatMessage | 8 hrs |
+| 3179 | cancellation | 24 hrs |
+| 3186 | keyShare | 12 hrs |
+| 3187 | followNotification | 5 min |
+| 3188 | keyAcknowledgement | 5 min |
+| 3189 | driverPingRequest | 30 min |
 
-`AppState.logout()` in `RoadFlare/RoadFlareCore/ViewModels/AppState.swift:341`:
+**Shared Nostr identity (not RoadFlare-specific):**
+
+| Kind | Name | Note |
+|------|------|------|
+| 0 | metadata | Profile name — used by all Nostr apps sharing this identity |
+
+Driver-only kinds (30012, 30013, 30014, 30173, 30180, 3174) are not rider-authored and won't appear in scans.
+
+### Two deletion tiers
+
+1. **Delete RoadFlare Events** — the 12 Ridestr kinds above. Simple "are you sure?" confirmation.
+2. **Delete All Ridestr Events** — the same 12 + Kind 0 metadata. Heavier confirmation with checkboxes warning about other Nostr apps.
+
+Both tiers end with local data cleanup (same as `logout()`).
+
+### Current logout flow (reused for local cleanup)
+
+`AppState.logout()` at `RoadFlare/RoadFlareCore/ViewModels/AppState.swift:341`:
 ```swift
 public func logout() async {
     await prepareForIdentityReplacement(clearPersistedSyncState: true)
@@ -41,18 +69,24 @@ public func logout() async {
     authState = .loggedOut
 }
 ```
-`prepareForIdentityReplacement()` at line 458 stops all coordinators, clears all repos, nils service refs.
 
 ### Mid-ride guard
 
-Check `rideCoordinator?.session.stage.isActiveRide` (defined in `RidestrSDK/Sources/RidestrSDK/Models/RideModels.swift:33`). Active stages are `.rideConfirmed`, `.enRoute`, `.driverArrived`, `.inProgress`.
+`rideCoordinator?.session.stage.isActiveRide` (defined at `RideModels.swift:33`). Active stages: `.rideConfirmed`, `.enRoute`, `.driverArrived`, `.inProgress`.
 
-### Relay infrastructure
+### Existing SDK infrastructure
 
-`RelayManagerProtocol.fetchEvents(filter:timeout:)` — one-shot EOSE-aware query, returns matching events.  
-`RelayManagerProtocol.publish(_:)` — publishes to all connected relays.  
-`DefaultRelays.all` — `[wss://relay.damus.io, wss://nos.lol, wss://relay.primal.net]` (3 relays, SDK-defined).  
-`RideshareEventBuilder.deletion(eventIds:reason:kinds:keypair:)` — already implemented in `RidestrSDK/Sources/RidestrSDK/Nostr/RideshareEventBuilder.swift:331`.
+- `RelayManagerProtocol.fetchEvents(filter:timeout:)` — one-shot EOSE query.
+- `RelayManagerProtocol.publish(_:)` — publishes to all connected relays.
+- `DefaultRelays.all` — `[wss://relay.damus.io, wss://nos.lol, wss://relay.primal.net]`.
+- `RideshareEventBuilder.deletion(eventIds:reason:kinds:keypair:)` — Kind 5 builder, already implemented at `RideshareEventBuilder.swift:331`.
+- `NostrFilter` — builder with `.authors()`, `.rawKinds()`, `.kinds()` methods.
+
+### UI patterns to follow
+
+- **ConnectivitySheet** (`ConnectivityIndicator.swift:83`): `DisclosureGroup` titled "About Nostr Protocol" with relay list and card-style background.
+- **BackupKeySheet** (`ProfileSetupView.swift:153`): `DisclosureGroup` titled "About Your Keys" explaining Nostr identity.
+- Both use `.tint(Color.rfOnSurfaceVariant)` + `.padding(16).background(Color.rfSurfaceContainer).clipShape(RoundedRectangle(cornerRadius: 16))`.
 
 ---
 
@@ -60,15 +94,15 @@ Check `rideCoordinator?.session.stage.isActiveRide` (defined in `RidestrSDK/Sour
 
 | Action | Path | Responsibility |
 |--------|------|----------------|
-| Create | `RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift` | Fetch event IDs + publish Kind 5 deletion |
+| Create | `RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift` | Scan relays + publish Kind 5 deletion |
 | Create | `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/AccountDeletionServiceTests.swift` | Unit tests for the service |
-| Create | `RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift` | Two-page deletion UI (both pages) |
-| Modify | `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` | Add `beginRelayDeletion()` + `completeAccountDeletion()` |
+| Create | `RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift` | Two-page UI (scan + delete options) |
+| Modify | `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` | Orchestration methods + `AccountDeletionError` |
 | Modify | `RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift` | Add Delete Account button + sheet presentation |
 
 ---
 
-## Task 1: AccountDeletionService — SDK type and result model
+## Task 1: AccountDeletionService — SDK scan and deletion service
 
 **Files:**
 - Create: `RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift`
@@ -82,8 +116,6 @@ import Foundation
 import Testing
 @testable import RidestrSDK
 
-// Decode a stub NostrEvent from JSON (same pattern as NostrEventTests.swift).
-// Lets us set arbitrary kind/id without calling EventSigner (which needs real crypto).
 private func stubEvent(id: String, kind: UInt16, pubkey: String) -> NostrEvent {
     let json = """
     {"id":"\(id)","pubkey":"\(pubkey)","created_at":1700000000,"kind":\(kind),\
@@ -101,81 +133,144 @@ struct AccountDeletionServiceTests {
         return (sut, relay, keypair.publicKeyHex)
     }
 
-    // MARK: - No events
+    // MARK: - Scan
 
-    @Test func noEvents_returnsSuccessWithEmptyIds_publishesNothing() async throws {
+    @Test func scan_noEvents_returnsEmptyResult() async throws {
         let (sut, relay, _) = try makeKit()
         relay.fetchResults = []
 
-        let result = await sut.deleteUserEvents()
+        let result = await sut.scanRelays()
 
-        #expect(result.publishedSuccessfully == true)
-        #expect(result.targetedEventIds.isEmpty)
-        #expect(result.publishError == nil)
-        #expect(result.queriedKinds == AccountDeletionService.deletableKinds)
+        #expect(result.roadflareEvents.isEmpty)
+        #expect(result.metadataEvents.isEmpty)
         #expect(result.targetRelayURLs == DefaultRelays.all)
-        #expect(relay.publishedEvents.isEmpty)  // no Kind 5 when nothing to delete
+        // Two queries: roadflare kinds + kind 0
+        #expect(relay.fetchCalls.count == 2)
     }
 
-    // MARK: - Events found
-
-    @Test func foundEvents_publishesKind5WithETagsForEachEventId() async throws {
+    @Test func scan_withEvents_categorisesCorrectly() async throws {
         let (sut, relay, pubkey) = try makeKit()
-        let event = stubEvent(id: "aabbcc", kind: 0, pubkey: pubkey)
-        relay.fetchResults = [event]  // returned for every fetchEvents call
+        let rfEvent = stubEvent(id: "rf1", kind: EventKind.followedDriversList.rawValue, pubkey: pubkey)
+        let metaEvent = stubEvent(id: "meta1", kind: EventKind.metadata.rawValue, pubkey: pubkey)
+        relay.fetchResults = [rfEvent, metaEvent]
 
-        let result = await sut.deleteUserEvents()
+        let result = await sut.scanRelays()
+
+        // Both queries return both events — but categorisation is by filter, not by kind.
+        // The service uses two separate fetches, so fetchResults returns the same array twice.
+        // In production, each filter returns only matching events.
+        #expect(!result.roadflareEvents.isEmpty)
+        #expect(!result.metadataEvents.isEmpty)
+    }
+
+    // MARK: - Delete RoadFlare events
+
+    @Test func deleteRoadflare_noEvents_publishesNothing() async throws {
+        let (sut, relay, _) = try makeKit()
+        let scan = RelayScanResult(
+            roadflareEvents: [],
+            metadataEvents: [],
+            targetRelayURLs: DefaultRelays.all
+        )
+
+        let result = await sut.deleteRoadflareEvents(from: scan)
 
         #expect(result.publishedSuccessfully == true)
-        #expect(result.targetedEventIds.contains("aabbcc"))
+        #expect(result.deletedEventIds.isEmpty)
+        #expect(relay.publishedEvents.isEmpty)
+    }
+
+    @Test func deleteRoadflare_withEvents_publishesKind5ForRoadflareOnly() async throws {
+        let (sut, relay, pubkey) = try makeKit()
+        let rfEvent = stubEvent(id: "rf1", kind: EventKind.followedDriversList.rawValue, pubkey: pubkey)
+        let metaEvent = stubEvent(id: "meta1", kind: EventKind.metadata.rawValue, pubkey: pubkey)
+        let scan = RelayScanResult(
+            roadflareEvents: [rfEvent],
+            metadataEvents: [metaEvent],
+            targetRelayURLs: DefaultRelays.all
+        )
+
+        let result = await sut.deleteRoadflareEvents(from: scan)
+
+        #expect(result.publishedSuccessfully == true)
+        #expect(result.deletedEventIds == ["rf1"])
         #expect(relay.publishedEvents.count == 1)
         let kind5 = relay.publishedEvents[0]
         #expect(kind5.kind == 5)
         let eTagIds = kind5.tagValues("e")
-        #expect(eTagIds.contains("aabbcc"))
+        #expect(eTagIds.contains("rf1"))
+        #expect(!eTagIds.contains("meta1"))  // Kind 0 NOT included
     }
 
-    @Test func foundEvents_publishError_returnsFailureResultWithEventIds() async throws {
+    // MARK: - Delete all Ridestr events
+
+    @Test func deleteAll_withEvents_publishesKind5IncludingMetadata() async throws {
         let (sut, relay, pubkey) = try makeKit()
-        let event = stubEvent(id: "aabbcc", kind: 0, pubkey: pubkey)
-        relay.fetchResults = [event]
+        let rfEvent = stubEvent(id: "rf1", kind: EventKind.followedDriversList.rawValue, pubkey: pubkey)
+        let metaEvent = stubEvent(id: "meta1", kind: EventKind.metadata.rawValue, pubkey: pubkey)
+        let scan = RelayScanResult(
+            roadflareEvents: [rfEvent],
+            metadataEvents: [metaEvent],
+            targetRelayURLs: DefaultRelays.all
+        )
+
+        let result = await sut.deleteAllRidestrEvents(from: scan)
+
+        #expect(result.publishedSuccessfully == true)
+        #expect(result.deletedEventIds.contains("rf1"))
+        #expect(result.deletedEventIds.contains("meta1"))
+        let kind5 = relay.publishedEvents[0]
+        let eTagIds = kind5.tagValues("e")
+        #expect(eTagIds.contains("rf1"))
+        #expect(eTagIds.contains("meta1"))
+    }
+
+    // MARK: - Publish failure
+
+    @Test func delete_publishFails_returnsFailureResult() async throws {
+        let (sut, relay, pubkey) = try makeKit()
+        let rfEvent = stubEvent(id: "rf1", kind: 30011, pubkey: pubkey)
+        let scan = RelayScanResult(
+            roadflareEvents: [rfEvent],
+            metadataEvents: [],
+            targetRelayURLs: DefaultRelays.all
+        )
         relay.shouldFailPublish = true
 
-        let result = await sut.deleteUserEvents()
+        let result = await sut.deleteRoadflareEvents(from: scan)
 
         #expect(result.publishedSuccessfully == false)
         #expect(result.publishError != nil)
-        #expect(result.targetedEventIds.contains("aabbcc"))
+        #expect(result.deletedEventIds == ["rf1"])
     }
 
-    // MARK: - Deletable kinds contract
+    // MARK: - Kind lists
 
-    @Test func deletableKinds_containsExpectedKinds() {
-        let rawValues = AccountDeletionService.deletableKinds.map(\.rawValue)
-        #expect(rawValues.contains(0))      // Kind 0: metadata
-        #expect(rawValues.contains(30011))  // Kind 30011: followedDriversList
-        #expect(rawValues.contains(30174))  // Kind 30174: rideHistoryBackup
-        #expect(rawValues.contains(30177))  // Kind 30177: unifiedProfile
+    @Test func roadflareKinds_containsAll12RiderAuthoredKinds() {
+        let rawValues = AccountDeletionService.roadflareKinds.map(\.rawValue)
+        // Replaceable
+        #expect(rawValues.contains(30011))  // followedDriversList
+        #expect(rawValues.contains(30174))  // rideHistoryBackup
+        #expect(rawValues.contains(30177))  // unifiedProfile
+        #expect(rawValues.contains(30181))  // riderRideState
+        // Regular/ephemeral
+        #expect(rawValues.contains(3173))   // rideOffer
+        #expect(rawValues.contains(3175))   // rideConfirmation
+        #expect(rawValues.contains(3178))   // chatMessage
+        #expect(rawValues.contains(3179))   // cancellation
+        #expect(rawValues.contains(3186))   // keyShare
+        #expect(rawValues.contains(3187))   // followNotification
+        #expect(rawValues.contains(3188))   // keyAcknowledgement
+        #expect(rawValues.contains(3189))   // driverPingRequest
     }
 
-    @Test func deletableKinds_doesNotContainEphemeralKinds() {
-        let rawValues = AccountDeletionService.deletableKinds.map(\.rawValue)
-        // Ephemeral kinds (3173–3189) should not be targeted — they expire naturally
-        for ephemeral: UInt16 in [3173, 3175, 3178, 3179, 3186, 3187, 3188, 3189] {
-            #expect(!rawValues.contains(ephemeral))
-        }
-    }
-
-    // MARK: - Filter queries
-
-    @Test func queriesAllDeletableKinds() async throws {
-        let (sut, relay, _) = try makeKit()
-        relay.fetchResults = []
-
-        _ = await sut.deleteUserEvents()
-
-        // One fetchEvents call per deletable kind
-        #expect(relay.fetchCalls.count == AccountDeletionService.deletableKinds.count)
+    @Test func roadflareKinds_excludesDriverAndNonRidestrKinds() {
+        let rawValues = AccountDeletionService.roadflareKinds.map(\.rawValue)
+        #expect(!rawValues.contains(0))      // metadata — separate tier
+        #expect(!rawValues.contains(3174))   // rideAcceptance — driver-authored
+        #expect(!rawValues.contains(30012))  // driverRoadflareState
+        #expect(!rawValues.contains(30173))  // driverAvailability
+        #expect(!rawValues.contains(30180))  // driverRideState
     }
 }
 ```
@@ -199,21 +294,29 @@ Expected: `error: cannot find type 'AccountDeletionService'`
 // RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift
 import Foundation
 
-// MARK: - Result Model
+// MARK: - Result Models
 
-/// Result of a relay-side account event deletion pass.
-///
-/// Deletion on Nostr is best-effort — relays may honour or ignore Kind 5 events.
-/// This result tells the caller what was attempted, not what was guaranteed.
-public struct RelayDeletionResult: Sendable {
-    /// Event IDs found on relays and targeted for deletion.
-    public let targetedEventIds: [String]
-    /// Event kinds that were queried (always `AccountDeletionService.deletableKinds`).
-    public let queriedKinds: [EventKind]
-    /// Relay URLs the deletion request was published to.
+/// Result of scanning relays for user-authored events.
+public struct RelayScanResult: Sendable {
+    /// RoadFlare/Ridestr events found (12 rider-authored kinds, excluding Kind 0).
+    public let roadflareEvents: [NostrEvent]
+    /// Kind 0 metadata events found (shared Nostr identity, used by all apps).
+    public let metadataEvents: [NostrEvent]
+    /// Relay URLs that were scanned.
     public let targetRelayURLs: [URL]
-    /// True if the Kind 5 deletion event was published without error,
-    /// or if there were no events to delete (vacuously successful).
+
+    public var roadflareCount: Int { roadflareEvents.count }
+    public var metadataCount: Int { metadataEvents.count }
+    public var totalCount: Int { roadflareCount + metadataCount }
+}
+
+/// Result of a relay-side deletion pass.
+public struct RelayDeletionResult: Sendable {
+    /// Event IDs included in the Kind 5 deletion request.
+    public let deletedEventIds: [String]
+    /// Relay URLs the deletion was published to.
+    public let targetRelayURLs: [URL]
+    /// True if the Kind 5 event was published, or if there was nothing to delete.
     public let publishedSuccessfully: Bool
     /// Human-readable error from the publish step, if any.
     public let publishError: String?
@@ -221,22 +324,38 @@ public struct RelayDeletionResult: Sendable {
 
 // MARK: - Service
 
-/// Fetches all rider-authored Nostr events and publishes a NIP-09 Kind 5 deletion request.
+/// Scans relays for rider-authored events and publishes NIP-09 Kind 5 deletion requests.
 ///
-/// Intended for use in the two-page Delete Account flow. Create with the app's live
-/// `relayManager` (already connected to `DefaultRelays.all`). Call `deleteUserEvents()`
-/// from Page 1 of the flow before tearing down services.
+/// Create with the app's live `relayManager` (already connected). The service is stateless —
+/// create a fresh instance for each deletion flow.
+///
+/// ## Usage
+/// ```swift
+/// let service = AccountDeletionService(relayManager: rm, keypair: kp)
+/// let scan = await service.scanRelays()
+/// // Show results to user, then:
+/// let result = await service.deleteRoadflareEvents(from: scan)
+/// ```
 public final class AccountDeletionService: Sendable {
     private let relayManager: any RelayManagerProtocol
     private let keypair: NostrKeypair
 
-    /// Rider-authored event kinds that should be deleted on account closure.
-    /// Ephemeral kinds (3173–3189) expire naturally and are excluded.
-    public static let deletableKinds: [EventKind] = [
-        .metadata,
-        .followedDriversList,
-        .rideHistoryBackup,
-        .unifiedProfile,
+    /// The 12 rider-authored Ridestr event kinds (excludes Kind 0 metadata).
+    public static let roadflareKinds: [EventKind] = [
+        // Parameterized replaceable (always on relays)
+        .followedDriversList,    // 30011
+        .rideHistoryBackup,      // 30174
+        .unifiedProfile,         // 30177
+        .riderRideState,         // 30181
+        // Regular (ephemeral, may still be on relays)
+        .rideOffer,              // 3173
+        .rideConfirmation,       // 3175
+        .chatMessage,            // 3178
+        .cancellation,           // 3179
+        .keyShare,               // 3186
+        .followNotification,     // 3187
+        .keyAcknowledgement,     // 3188
+        .driverPingRequest,      // 3189
     ]
 
     public init(relayManager: any RelayManagerProtocol, keypair: NostrKeypair) {
@@ -244,75 +363,89 @@ public final class AccountDeletionService: Sendable {
         self.keypair = keypair
     }
 
-    /// Fetch all deletable user events from relays, publish a Kind 5 deletion request,
-    /// and return a result describing what was attempted.
-    ///
-    /// - Never throws. Errors from relay fetch are silently treated as "no events found"
-    ///   (best-effort); errors from publish are captured in `RelayDeletionResult.publishError`.
-    public func deleteUserEvents() async -> RelayDeletionResult {
-        // 1. Query each deletable kind. Treat fetch errors as empty (relay may be down).
-        var eventIds: [String] = []
-        for kind in Self.deletableKinds {
-            let filter = buildFilter(for: kind)
-            let events = (try? await relayManager.fetchEvents(
-                filter: filter,
-                timeout: RelayConstants.eoseTimeoutSeconds
-            )) ?? []
-            eventIds.append(contentsOf: events.map(\.id))
-        }
+    // MARK: - Scan
 
-        // 2. Nothing to delete — vacuous success (no Kind 5 published).
+    /// Query connected relays for all rider-authored events.
+    /// Two queries: one for all 12 RoadFlare kinds, one for Kind 0 metadata.
+    public func scanRelays() async -> RelayScanResult {
+        let roadflareFilter = NostrFilter()
+            .authors([keypair.publicKeyHex])
+            .rawKinds(Self.roadflareKinds.map(\.rawValue))
+
+        let metadataFilter = NostrFilter.metadata(pubkeys: [keypair.publicKeyHex])
+
+        async let rfFetch = fetchSafe(filter: roadflareFilter)
+        async let metaFetch = fetchSafe(filter: metadataFilter)
+
+        let (rfEvents, metaEvents) = await (rfFetch, metaFetch)
+
+        return RelayScanResult(
+            roadflareEvents: rfEvents,
+            metadataEvents: metaEvents,
+            targetRelayURLs: DefaultRelays.all
+        )
+    }
+
+    // MARK: - Delete
+
+    /// Delete only RoadFlare events (12 Ridestr kinds). Does NOT delete Kind 0 metadata.
+    public func deleteRoadflareEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
+        let eventIds = scan.roadflareEvents.map(\.id)
+        return await publishDeletion(
+            eventIds: eventIds,
+            kinds: Self.roadflareKinds
+        )
+    }
+
+    /// Delete all Ridestr events (12 RoadFlare kinds + Kind 0 metadata).
+    public func deleteAllRidestrEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
+        let eventIds = scan.roadflareEvents.map(\.id) + scan.metadataEvents.map(\.id)
+        return await publishDeletion(
+            eventIds: eventIds,
+            kinds: Self.roadflareKinds + [.metadata]
+        )
+    }
+
+    // MARK: - Private
+
+    private func fetchSafe(filter: NostrFilter) async -> [NostrEvent] {
+        (try? await relayManager.fetchEvents(
+            filter: filter,
+            timeout: RelayConstants.eoseTimeoutSeconds
+        )) ?? []
+    }
+
+    private func publishDeletion(eventIds: [String], kinds: [EventKind]) async -> RelayDeletionResult {
         guard !eventIds.isEmpty else {
             return RelayDeletionResult(
-                targetedEventIds: [],
-                queriedKinds: Self.deletableKinds,
+                deletedEventIds: [],
                 targetRelayURLs: DefaultRelays.all,
                 publishedSuccessfully: true,
                 publishError: nil
             )
         }
 
-        // 3. Build and publish a single Kind 5 event covering all found event IDs.
         do {
             let deletionEvent = try await RideshareEventBuilder.deletion(
                 eventIds: eventIds,
                 reason: "Account deleted by user",
-                kinds: Self.deletableKinds,
+                kinds: kinds,
                 keypair: keypair
             )
             _ = try await relayManager.publish(deletionEvent)
             return RelayDeletionResult(
-                targetedEventIds: eventIds,
-                queriedKinds: Self.deletableKinds,
+                deletedEventIds: eventIds,
                 targetRelayURLs: DefaultRelays.all,
                 publishedSuccessfully: true,
                 publishError: nil
             )
         } catch {
             return RelayDeletionResult(
-                targetedEventIds: eventIds,
-                queriedKinds: Self.deletableKinds,
+                deletedEventIds: eventIds,
                 targetRelayURLs: DefaultRelays.all,
                 publishedSuccessfully: false,
                 publishError: error.localizedDescription
             )
-        }
-    }
-
-    // MARK: - Private
-
-    private func buildFilter(for kind: EventKind) -> NostrFilter {
-        switch kind {
-        case .followedDriversList:
-            return .followedDriversList(myPubkey: keypair.publicKeyHex)
-        case .rideHistoryBackup:
-            return .rideHistoryBackup(myPubkey: keypair.publicKeyHex)
-        case .unifiedProfile:
-            return .profileBackup(myPubkey: keypair.publicKeyHex)
-        case .metadata:
-            return .metadata(pubkeys: [keypair.publicKeyHex])
-        default:
-            return NostrFilter().kinds([kind]).authors([keypair.publicKeyHex])
         }
     }
 }
@@ -330,7 +463,7 @@ xcodebuild test \
   2>&1 | grep -E "Test.*passed|Test.*failed|Build Succeeded|Build FAILED|error:"
 ```
 
-Expected: all 6 tests pass
+Expected: all 9 tests pass.
 
 - [ ] **Step 1.5: Commit**
 
@@ -339,7 +472,7 @@ cd ~/Documents/Projects/roadflare-ios-issue-51
 git add \
   RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift \
   RidestrSDK/Tests/RidestrSDKTests/RoadFlare/AccountDeletionServiceTests.swift
-git commit -m "feat(sdk): add AccountDeletionService for NIP-09 relay event deletion"
+git commit -m "feat(sdk): add AccountDeletionService with relay scan and two-tier deletion"
 ```
 
 ---
@@ -349,31 +482,26 @@ git commit -m "feat(sdk): add AccountDeletionService for NIP-09 relay event dele
 **Files:**
 - Modify: `RoadFlare/RoadFlareCore/ViewModels/AppState.swift`
 
-Add the following block after `logout()` (line 346):
+- [ ] **Step 2.1: Add top-level error enum and AppState methods**
 
-- [ ] **Step 2.1: Add error enum and methods to AppState.swift**
+Add `AccountDeletionError` as a **top-level enum** in `AppState.swift`, above the `AppState` class (next to the existing top-level `AuthState` enum at line 6). This follows the existing `AuthState` pattern and ensures the type is accessible without a prefix in catch clauses:
 
-Insert this block directly after the closing `}` of `logout()` at line 346:
+```swift
+/// Reasons account deletion can fail before contacting relays.
+public enum AccountDeletionError: Error, Equatable {
+    case servicesNotReady
+    case activeRideInProgress
+}
+```
+
+Then add the following methods inside `AppState`, after the closing `}` of `logout()` at line 346:
 
 ```swift
 // MARK: - Account Deletion
 
-/// Reasons beginRelayDeletion() can fail before contacting relays.
-public enum AccountDeletionError: Error {
-    /// Services not ready — user not logged in or relay not connected.
-    case servicesNotReady
-    /// Cannot delete account while a ride is in progress.
-    case activeRideInProgress
-}
-
-/// Phase 1 of account deletion: publish NIP-09 Kind 5 deletion events to relays.
-///
-/// Call this while the user is still logged in (relay + keypair are live).
-/// Guards against active rides. Returns a result describing what was attempted.
-///
-/// - Throws: `AccountDeletionError.servicesNotReady` if not logged in.
-/// - Throws: `AccountDeletionError.activeRideInProgress` if a ride is ongoing.
-public func beginRelayDeletion() async throws -> RelayDeletionResult {
+/// Scan relays for all rider-authored events. Returns categorised results.
+/// Call while still logged in (relay + keypair are live).
+public func scanRelaysForDeletion() async throws -> RelayScanResult {
     guard let keypair, let relayManager else {
         throw AccountDeletionError.servicesNotReady
     }
@@ -381,18 +509,40 @@ public func beginRelayDeletion() async throws -> RelayDeletionResult {
         throw AccountDeletionError.activeRideInProgress
     }
     let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
-    return await service.deleteUserEvents()
+    return await service.scanRelays()
 }
 
-/// Phase 2 of account deletion: clear all local data and return to onboarding.
-///
-/// Reuses the existing logout path. Call only after `beginRelayDeletion()` completes.
-public func completeAccountDeletion() async {
+/// Delete only RoadFlare events from relays, then clear local data and log out.
+public func deleteRoadflareEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
+    guard let keypair, let relayManager else {
+        return RelayDeletionResult(
+            deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
+            publishedSuccessfully: false, publishError: "Services not ready"
+        )
+    }
+    let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
+    let result = await service.deleteRoadflareEvents(from: scan)
     await logout()
+    return result
+}
+
+/// Delete all Ridestr events (including Kind 0 metadata) from relays,
+/// then clear local data and log out.
+public func deleteAllRidestrEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
+    guard let keypair, let relayManager else {
+        return RelayDeletionResult(
+            deletedEventIds: [], targetRelayURLs: DefaultRelays.all,
+            publishedSuccessfully: false, publishError: "Services not ready"
+        )
+    }
+    let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
+    let result = await service.deleteAllRidestrEvents(from: scan)
+    await logout()
+    return result
 }
 ```
 
-- [ ] **Step 2.2: Build the full project to confirm no new errors**
+- [ ] **Step 2.2: Build the full project**
 
 ```bash
 cd ~/Documents/Projects/roadflare-ios-issue-51
@@ -410,7 +560,7 @@ Expected: `Build Succeeded`
 ```bash
 cd ~/Documents/Projects/roadflare-ios-issue-51
 git add RoadFlare/RoadFlareCore/ViewModels/AppState.swift
-git commit -m "feat: add beginRelayDeletion() and completeAccountDeletion() to AppState"
+git commit -m "feat: add relay scan and two-tier account deletion to AppState"
 ```
 
 ---
@@ -419,8 +569,6 @@ git commit -m "feat: add beginRelayDeletion() and completeAccountDeletion() to A
 
 **Files:**
 - Create: `RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift`
-
-The sheet uses a `NavigationStack` with `NavigationLink` to push from Page 1 → Page 2.
 
 - [ ] **Step 3.1: Create DeleteAccountSheet.swift**
 
@@ -435,31 +583,32 @@ import RoadFlareCore
 struct DeleteAccountSheet: View {
     var body: some View {
         NavigationStack {
-            DeleteAccountRelayView()
+            DeleteAccountScanView()
         }
     }
 }
 
-// MARK: - Page 1: Relay Deletion
+// MARK: - Page 1: Relay Scan
 
-private enum RelayDeletionPhase {
-    case idle
-    case deleting
-    case complete(RelayDeletionResult)
-    case failed(String)
-}
-
-struct DeleteAccountRelayView: View {
+struct DeleteAccountScanView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
-    @State private var phase: RelayDeletionPhase = .idle
+
+    enum ScanPhase {
+        case idle
+        case scanning
+        case complete(RelayScanResult)
+        case failed(String)
+    }
+
+    @State private var phase: ScanPhase = .idle
 
     var body: some View {
         ZStack {
             Color.rfSurface.ignoresSafeArea()
             ScrollView {
                 VStack(spacing: 24) {
-                    // Icon + headline
+                    // Header
                     VStack(spacing: 12) {
                         Image(systemName: "trash.circle.fill")
                             .font(.system(size: 52))
@@ -467,60 +616,39 @@ struct DeleteAccountRelayView: View {
                         Text("Delete Account")
                             .font(RFFont.headline(22))
                             .foregroundColor(Color.rfOnSurface)
-                        Text("Step 1 of 2 — Relay Cleanup")
+                        Text("Step 1 of 2 — Relay Scan")
                             .font(RFFont.caption(12))
                             .foregroundColor(Color.rfOnSurfaceVariant)
                     }
                     .padding(.top, 8)
 
-                    // Explanation
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("RoadFlare will request deletion of your events from all known relays. This includes your profile, saved locations, payment methods, ride history, and driver list.")
-                            .font(RFFont.body(14))
-                            .foregroundColor(Color.rfOnSurfaceVariant)
-                        Text("Relay deletion is best-effort. Most relays honour Kind 5 deletion requests, but some may not.")
-                            .font(RFFont.body(14))
-                            .foregroundColor(Color.rfOnSurfaceVariant)
-                    }
-                    .padding(16)
-                    .background(Color.rfSurfaceContainer)
-                    .clipShape(RoundedRectangle(cornerRadius: 16))
-
                     // Relay list
                     VStack(alignment: .leading, spacing: 12) {
-                        Text("Target Relays")
-                            .font(RFFont.caption(12))
-                            .foregroundColor(Color.rfOnSurfaceVariant)
-                            .textCase(.uppercase)
-                            .tracking(1)
-                        VStack(spacing: 0) {
-                            ForEach(DefaultRelays.all, id: \.absoluteString) { relay in
-                                HStack(spacing: 12) {
-                                    Image(systemName: relayStatusIcon(relay))
-                                        .foregroundColor(relayStatusColor(relay))
-                                        .frame(width: 20)
-                                    Text(relay.host ?? relay.absoluteString)
-                                        .font(RFFont.body(14))
-                                        .foregroundColor(Color.rfOnSurface)
+                        SectionLabel("Relays")
+                        VStack(spacing: 8) {
+                            ForEach(DefaultRelays.all, id: \.absoluteString) { url in
+                                HStack {
+                                    Circle()
+                                        .fill(relayDotColor)
+                                        .frame(width: 6, height: 6)
+                                    Text(url.absoluteString)
+                                        .font(RFFont.mono(12))
+                                        .foregroundColor(Color.rfOnSurfaceVariant)
                                     Spacer()
-                                    relayStatusText(relay)
+                                    if case .scanning = phase {
+                                        ProgressView()
+                                            .scaleEffect(0.6)
+                                            .tint(Color.rfPrimary)
+                                    }
                                 }
-                                .padding(14)
-                                if relay != DefaultRelays.all.last {
-                                    Divider().padding(.leading, 46)
-                                }
+                                .rfCard(.low)
                             }
                         }
-                        .background(Color.rfSurfaceContainer)
-                        .clipShape(RoundedRectangle(cornerRadius: 16))
                     }
 
-                    // Result summary (visible after deletion attempt)
-                    if case .complete(let result) = phase {
-                        resultSummary(result)
-                    }
+                    // Error message
                     if case .failed(let msg) = phase {
-                        Text("Error: \(msg)")
+                        Text(msg)
                             .font(RFFont.body(13))
                             .foregroundColor(Color.rfError)
                             .padding(14)
@@ -528,19 +656,93 @@ struct DeleteAccountRelayView: View {
                             .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
 
-                    // Primary action button
-                    primaryButton
+                    // Primary action
+                    switch phase {
+                    case .idle:
+                        Button {
+                            Task { await startScan() }
+                        } label: {
+                            Text("Scan Relays")
+                                .font(RFFont.body(16).bold())
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 16)
+                                .background(Color.rfError)
+                                .clipShape(RoundedRectangle(cornerRadius: 16))
+                        }
 
-                    // Cancel
-                    if case .idle = phase {
-                        Button("Cancel") { dismiss() }
+                    case .scanning:
+                        HStack(spacing: 12) {
+                            ProgressView().tint(Color.rfOnSurface)
+                            Text("Scanning relays…")
+                                .font(RFFont.body(15))
+                                .foregroundColor(Color.rfOnSurfaceVariant)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(Color.rfSurfaceContainer)
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+
+                    case .complete(let scan):
+                        NavigationLink {
+                            DeleteAccountResultsView(scan: scan)
+                        } label: {
+                            HStack {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(Color.rfOnline)
+                                Text("Continue — \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") found")
+                                    .font(RFFont.body(16).bold())
+                            }
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 16)
+                            .background(Color.rfError)
+                            .clipShape(RoundedRectangle(cornerRadius: 16))
+                        }
+
+                    case .failed:
+                        Button {
+                            phase = .idle
+                        } label: {
+                            Text("Try Again")
+                                .font(RFFont.body(15))
+                                .foregroundColor(Color.rfOnSurface)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 16)
+                                .background(Color.rfSurfaceContainer)
+                                .clipShape(RoundedRectangle(cornerRadius: 16))
+                        }
+                    }
+
+                    // Nostr explainer
+                    DisclosureGroup {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("RoadFlare is built on Nostr, a decentralized protocol. Your data is stored on independent relays — not on RoadFlare's servers.")
+                                .font(RFFont.body(14))
+                                .foregroundColor(Color.rfOnSurfaceVariant)
+
+                            Text("When you delete your account, RoadFlare sends a deletion request (NIP-09) to each relay. Most relays honour these requests and remove your events, but because relays are independently operated, removal cannot be guaranteed.")
+                                .font(RFFont.body(14))
+                                .foregroundColor(Color.rfOnSurfaceVariant)
+
+                            Text("Your private key exists only on this device. Once deleted, the key — and your Nostr identity — cannot be recovered.")
+                                .font(RFFont.body(14))
+                                .foregroundColor(Color.rfOnSurfaceVariant)
+                        }
+                        .padding(.top, 8)
+                    } label: {
+                        Text("About Nostr & Account Deletion")
                             .font(RFFont.body(15))
                             .foregroundColor(Color.rfOnSurfaceVariant)
                     }
+                    .tint(Color.rfOnSurfaceVariant)
+                    .padding(16)
+                    .background(Color.rfSurfaceContainer)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
 
                     Spacer(minLength: 24)
                 }
-                .padding(.horizontal, 20)
+                .padding(.horizontal, 16)
                 .padding(.top, 8)
             }
         }
@@ -548,8 +750,10 @@ struct DeleteAccountRelayView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.rfSurface, for: .navigationBar)
         .toolbar {
-            if case .idle = phase {
-                ToolbarItem(placement: .cancellationAction) {
+            ToolbarItem(placement: .cancellationAction) {
+                if case .scanning = phase {
+                    // Hide during active scan
+                } else {
                     Button("Cancel") { dismiss() }
                         .foregroundColor(Color.rfOnSurfaceVariant)
                 }
@@ -557,161 +761,22 @@ struct DeleteAccountRelayView: View {
         }
     }
 
-    // MARK: - Primary button
-
-    @ViewBuilder
-    private var primaryButton: some View {
+    private var relayDotColor: Color {
         switch phase {
-        case .idle:
-            Button {
-                Task { await startDeletion() }
-            } label: {
-                Text("Request Relay Deletion")
-                    .font(RFFont.body(16).bold())
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                    .background(Color.rfError)
-                    .clipShape(RoundedRectangle(cornerRadius: 16))
-            }
-
-        case .deleting:
-            HStack(spacing: 12) {
-                ProgressView().tint(Color.rfOnSurface)
-                Text("Contacting relays…")
-                    .font(RFFont.body(15))
-                    .foregroundColor(Color.rfOnSurfaceVariant)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 16)
-            .background(Color.rfSurfaceContainer)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
-
-        case .complete(let result):
-            NavigationLink {
-                DeleteAccountFinalView()
-            } label: {
-                HStack {
-                    if result.publishedSuccessfully {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(Color.rfOnline)
-                    } else {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(Color.rfError)
-                    }
-                    Text("Continue to Final Step")
-                        .font(RFFont.body(16).bold())
-                }
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 16)
-                .background(result.publishedSuccessfully ? Color.rfError : Color.rfError.opacity(0.7))
-                .clipShape(RoundedRectangle(cornerRadius: 16))
-            }
-
-        case .failed:
-            Button {
-                phase = .idle
-            } label: {
-                Text("Try Again")
-                    .font(RFFont.body(15))
-                    .foregroundColor(Color.rfOnSurface)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                    .background(Color.rfSurfaceContainer)
-                    .clipShape(RoundedRectangle(cornerRadius: 16))
-            }
+        case .idle: Color.rfOffline
+        case .scanning: Color.rfPrimary
+        case .complete: Color.rfOnline
+        case .failed: Color.rfError
         }
     }
 
-    // MARK: - Result summary card
-
-    @ViewBuilder
-    private func resultSummary(_ result: RelayDeletionResult) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Image(systemName: result.publishedSuccessfully ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                    .foregroundColor(result.publishedSuccessfully ? Color.rfOnline : Color.rfError)
-                Text(result.publishedSuccessfully ? "Deletion requested" : "Deletion partially failed")
-                    .font(RFFont.title(15))
-                    .foregroundColor(Color.rfOnSurface)
-            }
-            if result.targetedEventIds.isEmpty {
-                Text("No events found on relays — nothing to delete.")
-                    .font(RFFont.body(13))
-                    .foregroundColor(Color.rfOnSurfaceVariant)
-            } else {
-                Text("\(result.targetedEventIds.count) event(s) targeted across \(result.targetRelayURLs.count) relays.")
-                    .font(RFFont.body(13))
-                    .foregroundColor(Color.rfOnSurfaceVariant)
-            }
-            if let err = result.publishError {
-                Text("Note: \(err)")
-                    .font(RFFont.caption(12))
-                    .foregroundColor(Color.rfError)
-            }
-            Text("You can proceed to final deletion even if relay cleanup was incomplete.")
-                .font(RFFont.caption(12))
-                .foregroundColor(Color.rfOnSurfaceVariant)
-        }
-        .padding(16)
-        .background(Color.rfSurfaceContainer)
-        .clipShape(RoundedRectangle(cornerRadius: 16))
-    }
-
-    // MARK: - Per-relay status icons/colors/text
-
-    private func relayStatusIcon(_ relay: URL) -> String {
-        switch phase {
-        case .idle: return "circle"
-        case .deleting: return "arrow.triangle.2.circlepath"
-        case .complete(let result):
-            return result.publishedSuccessfully ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
-        case .failed: return "xmark.circle.fill"
-        }
-    }
-
-    private func relayStatusColor(_ relay: URL) -> Color {
-        switch phase {
-        case .idle: return Color.rfOffline
-        case .deleting: return Color.rfPrimary
-        case .complete(let result):
-            return result.publishedSuccessfully ? Color.rfOnline : Color.rfError
-        case .failed: return Color.rfError
-        }
-    }
-
-    @ViewBuilder
-    private func relayStatusText(_ relay: URL) -> some View {
-        switch phase {
-        case .idle:
-            Text("Pending")
-                .font(RFFont.caption(12))
-                .foregroundColor(Color.rfOffline)
-        case .deleting:
-            ProgressView()
-                .scaleEffect(0.7)
-                .tint(Color.rfPrimary)
-        case .complete(let result):
-            Text(result.publishedSuccessfully ? "Requested" : "Failed")
-                .font(RFFont.caption(12))
-                .foregroundColor(result.publishedSuccessfully ? Color.rfOnline : Color.rfError)
-        case .failed:
-            Text("Error")
-                .font(RFFont.caption(12))
-                .foregroundColor(Color.rfError)
-        }
-    }
-
-    // MARK: - Action
-
-    private func startDeletion() async {
-        phase = .deleting
+    private func startScan() async {
+        phase = .scanning
         do {
-            let result = try await appState.beginRelayDeletion()
-            phase = .complete(result)
+            let scan = try await appState.scanRelaysForDeletion()
+            phase = .complete(scan)
         } catch AccountDeletionError.activeRideInProgress {
-            phase = .failed("You have an active ride in progress. Please complete or cancel your ride before deleting your account.")
+            phase = .failed("You have an active ride. Complete or cancel it before deleting your account.")
         } catch AccountDeletionError.servicesNotReady {
             phase = .failed("Unable to connect — please try again.")
         } catch {
@@ -720,109 +785,264 @@ struct DeleteAccountRelayView: View {
     }
 }
 
-// MARK: - Page 2: Final Local Removal
+// MARK: - Page 2: Scan Results + Delete Options
 
-struct DeleteAccountFinalView: View {
+struct DeleteAccountResultsView: View {
     @Environment(AppState.self) private var appState
-    @State private var isDeleting = false
+    let scan: RelayScanResult
 
-    private let localDataItems = [
-        ("key.fill", "Private key (from Keychain)"),
-        ("person.fill", "Profile name"),
-        ("creditcard.fill", "Payment preferences"),
-        ("mappin.and.ellipse", "Saved locations & recents"),
-        ("clock.arrow.circlepath", "Ride history"),
-        ("person.2.fill", "Followed drivers"),
-    ]
+    @State private var showRoadflareConfirm = false
+    @State private var showFullDeleteSheet = false
+    @State private var isDeleting = false
 
     var body: some View {
         ZStack {
             Color.rfSurface.ignoresSafeArea()
             ScrollView {
                 VStack(spacing: 24) {
-                    // Icon + headline
+                    // Header
                     VStack(spacing: 12) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 52))
                             .foregroundColor(Color.rfError)
-                        Text("Final Confirmation")
+                        Text("Review & Delete")
                             .font(RFFont.headline(22))
                             .foregroundColor(Color.rfOnSurface)
-                        Text("Step 2 of 2 — Local Data Removal")
+                        Text("Step 2 of 2 — Choose What to Delete")
                             .font(RFFont.caption(12))
                             .foregroundColor(Color.rfOnSurfaceVariant)
                     }
                     .padding(.top, 8)
 
-                    // Warning
-                    Text("This will permanently remove all local account data. This action cannot be undone.")
-                        .font(RFFont.body(14))
-                        .foregroundColor(Color.rfOnSurfaceVariant)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 8)
+                    // Scan summary
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            Image(systemName: "doc.text.magnifyingglass")
+                                .foregroundColor(Color.rfPrimary)
+                            Text("Scan Results")
+                                .font(RFFont.title(15))
+                                .foregroundColor(Color.rfOnSurface)
+                        }
+                        Text("Found **\(scan.roadflareCount)** RoadFlare event\(scan.roadflareCount == 1 ? "" : "s") and **\(scan.metadataCount)** Nostr profile event\(scan.metadataCount == 1 ? "" : "s") across \(scan.targetRelayURLs.count) relays.")
+                            .font(RFFont.body(14))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                    }
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.rfSurfaceContainer)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
 
-                    // What gets deleted
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("What will be removed")
+                    // Option 1: Delete RoadFlare events only
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Recommended")
                             .font(RFFont.caption(12))
                             .foregroundColor(Color.rfOnSurfaceVariant)
                             .textCase(.uppercase)
                             .tracking(1)
-                        VStack(spacing: 0) {
-                            ForEach(localDataItems, id: \.0) { icon, label in
-                                HStack(spacing: 12) {
-                                    Image(systemName: icon)
-                                        .frame(width: 20)
-                                        .foregroundColor(Color.rfError)
-                                    Text(label)
-                                        .font(RFFont.body(14))
-                                        .foregroundColor(Color.rfOnSurface)
-                                    Spacer()
-                                }
-                                .padding(14)
-                                if icon != localDataItems.last?.0 {
-                                    Divider().padding(.leading, 46)
-                                }
+
+                        Button {
+                            showRoadflareConfirm = true
+                        } label: {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Delete RoadFlare Events")
+                                    .font(RFFont.body(16).bold())
+                                    .foregroundColor(.white)
+                                Text("Removes ride history, driver list, saved locations, and all protocol events from relays. Keeps your Nostr profile (Kind 0) intact.")
+                                    .font(RFFont.caption(12))
+                                    .foregroundColor(.white.opacity(0.8))
+                                    .multilineTextAlignment(.leading)
                             }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(16)
+                            .background(Color.rfError)
+                            .clipShape(RoundedRectangle(cornerRadius: 16))
                         }
+                        .disabled(isDeleting)
+                    }
+
+                    // Option 2: Delete all Ridestr events including Kind 0
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Full Deletion")
+                            .font(RFFont.caption(12))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                            .textCase(.uppercase)
+                            .tracking(1)
+
+                        Button {
+                            showFullDeleteSheet = true
+                        } label: {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Delete All Ridestr Events")
+                                    .font(RFFont.body(16).bold())
+                                    .foregroundColor(Color.rfError)
+                                Text("Removes everything above plus your Nostr profile (Kind 0). This may affect other Nostr apps using this identity.")
+                                    .font(RFFont.caption(12))
+                                    .foregroundColor(Color.rfOnSurfaceVariant)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(16)
+                            .background(Color.rfSurfaceContainer)
+                            .clipShape(RoundedRectangle(cornerRadius: 16))
+                        }
+                        .disabled(isDeleting)
+                    }
+
+                    // Deleting indicator
+                    if isDeleting {
+                        HStack(spacing: 12) {
+                            ProgressView().tint(Color.rfOnSurface)
+                            Text("Deleting…")
+                                .font(RFFont.body(15))
+                                .foregroundColor(Color.rfOnSurfaceVariant)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
                         .background(Color.rfSurfaceContainer)
                         .clipShape(RoundedRectangle(cornerRadius: 16))
                     }
 
-                    // Delete button
-                    Button {
-                        isDeleting = true
-                        Task { await appState.completeAccountDeletion() }
-                    } label: {
-                        Group {
-                            if isDeleting {
-                                HStack(spacing: 10) {
-                                    ProgressView().tint(.white)
-                                    Text("Deleting…")
-                                }
-                            } else {
-                                Text("Delete Account")
-                            }
-                        }
-                        .font(RFFont.body(16).bold())
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 16)
-                        .background(isDeleting ? Color.rfError.opacity(0.6) : Color.rfError)
-                        .clipShape(RoundedRectangle(cornerRadius: 16))
-                    }
-                    .disabled(isDeleting)
-
                     Spacer(minLength: 24)
                 }
-                .padding(.horizontal, 20)
+                .padding(.horizontal, 16)
                 .padding(.top, 8)
             }
         }
-        .navigationTitle("Final Step")
+        .navigationTitle("Delete Events")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.rfSurface, for: .navigationBar)
         .navigationBarBackButtonHidden(isDeleting)
+        .alert("Delete RoadFlare Events?", isPresented: $showRoadflareConfirm) {
+            Button("Delete", role: .destructive) {
+                Task { await performRoadflareDeletion() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will request deletion of \(scan.roadflareCount) RoadFlare event\(scan.roadflareCount == 1 ? "" : "s") from all relays, then remove all local data and log you out.")
+        }
+        .sheet(isPresented: $showFullDeleteSheet) {
+            FullDeletionConfirmSheet(scan: scan) {
+                Task { await performFullDeletion() }
+            }
+        }
+    }
+
+    private func performRoadflareDeletion() async {
+        isDeleting = true
+        _ = await appState.deleteRoadflareEvents(from: scan)
+        // logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed
+    }
+
+    private func performFullDeletion() async {
+        isDeleting = true
+        _ = await appState.deleteAllRidestrEvents(from: scan)
+        // logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed
+    }
+}
+
+// MARK: - Full Deletion Confirmation (checkbox sheet)
+
+struct FullDeletionConfirmSheet: View {
+    let scan: RelayScanResult
+    let onConfirm: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var checkProfile = false
+    @State private var checkOtherApps = false
+    @State private var checkBackedUp = false
+
+    private var allChecked: Bool {
+        checkProfile && checkOtherApps && checkBackedUp
+    }
+
+    var body: some View {
+        ZStack {
+            Color.rfSurface.ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                // Header
+                VStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.octagon.fill")
+                        .font(.system(size: 40))
+                        .foregroundColor(Color.rfError)
+                    Text("Full Nostr Deletion")
+                        .font(RFFont.headline(20))
+                        .foregroundColor(Color.rfOnSurface)
+                }
+                .padding(.top, 16)
+
+                Text("This deletes all \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") including your Nostr profile (Kind 0 metadata). Please confirm you understand:")
+                    .font(RFFont.body(14))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 8)
+
+                // Checkboxes
+                VStack(spacing: 0) {
+                    confirmRow(
+                        isOn: $checkProfile,
+                        text: "I understand this deletes my Nostr profile (display name) from relays"
+                    )
+                    Divider().padding(.leading, 46)
+                    confirmRow(
+                        isOn: $checkOtherApps,
+                        text: "I understand this may affect other Nostr apps that use this identity"
+                    )
+                    Divider().padding(.leading, 46)
+                    confirmRow(
+                        isOn: $checkBackedUp,
+                        text: "I have backed up my private key, or I no longer need it"
+                    )
+                }
+                .background(Color.rfSurfaceContainer)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+
+                // Delete button
+                Button {
+                    dismiss()
+                    onConfirm()
+                } label: {
+                    Text("Delete All Ridestr Events")
+                        .font(RFFont.body(16).bold())
+                        .foregroundColor(allChecked ? .white : Color.rfOffline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(allChecked ? Color.rfError : Color.rfSurfaceContainer)
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+                .disabled(!allChecked)
+
+                Button("Cancel") { dismiss() }
+                    .font(RFFont.body(15))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    @ViewBuilder
+    private func confirmRow(isOn: Binding<Bool>, text: String) -> some View {
+        Button {
+            isOn.wrappedValue.toggle()
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: isOn.wrappedValue ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 20))
+                    .foregroundColor(isOn.wrappedValue ? Color.rfError : Color.rfOffline)
+                    .frame(width: 24)
+                Text(text)
+                    .font(RFFont.body(14))
+                    .foregroundColor(Color.rfOnSurface)
+                    .multilineTextAlignment(.leading)
+                Spacer()
+            }
+            .padding(14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }
 ```
@@ -845,7 +1065,7 @@ Expected: `Build Succeeded`
 ```bash
 cd ~/Documents/Projects/roadflare-ios-issue-51
 git add RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
-git commit -m "feat(ui): add DeleteAccountSheet two-page relay+local deletion flow"
+git commit -m "feat(ui): add DeleteAccountSheet with scan + two-tier deletion flow"
 ```
 
 ---
@@ -855,28 +1075,17 @@ git commit -m "feat(ui): add DeleteAccountSheet two-page relay+local deletion fl
 **Files:**
 - Modify: `RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift`
 
-- [ ] **Step 4.1: Add state variable and Delete Account button to SettingsTab**
+- [ ] **Step 4.1: Add state variable and Delete Account button**
 
-In `SettingsTab`, add `@State private var showDeleteAccount = false` alongside the other state variables at the top of the struct (after line 10 where `showLogoutConfirm` is declared):
+Add to the state variables at the top of `SettingsTab` (after line 11):
 
 ```swift
 @State private var showDeleteAccount = false
 ```
 
-Replace the existing Logout section (lines 173–182) with the updated block below that adds a "Delete Account" button beneath "Log Out":
+Add a "Delete Account" button below the existing Logout button. After the Logout button's closing `}` at line 182, add:
 
 ```swift
-// Logout
-Button { showLogoutConfirm = true } label: {
-    Text("Log Out")
-        .font(RFFont.body(15))
-        .foregroundColor(Color.rfError)
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 14)
-        .background(Color.rfSurfaceContainer)
-        .clipShape(RoundedRectangle(cornerRadius: 16))
-}
-
 // Delete Account
 Button { showDeleteAccount = true } label: {
     Text("Delete Account")
@@ -889,7 +1098,7 @@ Button { showDeleteAccount = true } label: {
 }
 ```
 
-Add the sheet presentation alongside the other sheet modifiers (after line 195 where `showEditProfile` sheet is):
+Add the sheet presentation after the existing `.sheet(isPresented: $showEditProfile)` at line 195:
 
 ```swift
 .sheet(isPresented: $showDeleteAccount) { DeleteAccountSheet() }
@@ -908,7 +1117,7 @@ xcodebuild build \
 
 Expected: `Build Succeeded`
 
-- [ ] **Step 4.3: Run all SDK tests to confirm nothing regressed**
+- [ ] **Step 4.3: Run all SDK tests to confirm no regression**
 
 ```bash
 cd ~/Documents/Projects/roadflare-ios-issue-51
@@ -919,7 +1128,7 @@ xcodebuild test \
   2>&1 | grep -E "Test.*passed|Test.*failed|Build Succeeded|Build FAILED|error:"
 ```
 
-Expected: all tests pass, no failures.
+Expected: all tests pass.
 
 - [ ] **Step 4.4: Commit**
 
@@ -934,38 +1143,44 @@ git commit -m "feat(ui): wire Delete Account into Settings tab"
 ## Edge Cases & Implementation Notes
 
 ### Mid-ride guard
-`beginRelayDeletion()` in AppState throws `AccountDeletionError.activeRideInProgress` when `rideCoordinator?.session.stage.isActiveRide` is true. The UI translates this to a user-facing message on Page 1. This prevents data corruption from tearing down services during an active protocol exchange.
+`scanRelaysForDeletion()` throws `AccountDeletionError.activeRideInProgress` when `rideCoordinator?.session.stage.isActiveRide` is true. Page 1 shows this as a user-facing error. Note: `.waitingForAcceptance` and `.driverAccepted` are NOT active rides and don't block — offers expire after 120s and are harmless.
 
-### Relay unreachable / fetch errors
-`AccountDeletionService.deleteUserEvents()` silently treats fetch errors as "no events found" for that kind. A single Kind 5 event covers all found event IDs. If `relayManager` is disconnected when `beginRelayDeletion()` is called, `publish()` throws and the result captures the error in `publishError`.
+### No events to delete
+If the scan finds 0 events (new account, never published), the Continue button shows "0 events found" and Page 2's buttons still work — `deleteRoadflareEvents` with empty scan returns `publishedSuccessfully: true` and proceeds to `logout()`.
 
-### No events to delete (new account)
-If the user never published any events (e.g. imported a key but never completed onboarding), all `fetchEvents` calls return empty. The service returns `publishedSuccessfully: true` with empty `targetedEventIds`. Page 1 shows "No events found on relays — nothing to delete." and still allows proceeding to Page 2.
+### Relay connection lost after scan
+If the relay disconnects between scan and delete, `publish()` throws and the `RelayDeletionResult.publishError` captures it. The deletion methods still call `logout()` to complete local cleanup — the user has already committed to deleting.
 
-### Relay does not support NIP-09 deletion
-Deletion on Nostr is advisory. The UI text ("Relay deletion is best-effort") and result summary ("You can proceed to final deletion even if relay cleanup was incomplete") set honest user expectations. The "Continue to Final Step" NavigationLink is always available after Page 1 completes, regardless of whether publish succeeded.
+### Deletion is best-effort
+NIP-09 Kind 5 is advisory. The "About Nostr & Account Deletion" explainer sets expectations. Page 2's button descriptions reinforce this ("Removes... from relays" / "requests deletion").
 
-### Passkey / iCloud Keychain credentials
-PasskeyManager passkeys sync via iCloud and are NOT cleared by `completeAccountDeletion()`. Page 2 does not mention passkeys because there is no programmatic iOS API to delete iCloud Keychain credentials from within an app. If this becomes a requirement, the user must delete passkeys manually via iOS Settings → Passwords. This is a known limitation, not a bug.
+### Sheet dismissal on logout
+When `deleteRoadflareEvents`/`deleteAllRidestrEvents` call `logout()`, `authState = .loggedOut` causes RootView to replace MainTabView with WelcomeView. The sheet's parent view (SettingsTab inside MainTabView) disappears, automatically dismissing the sheet. This is the same mechanism the existing logout alert uses.
 
-### `roadflare_has_launched` UserDefaults flag
-This flag is intentionally NOT cleared by `completeAccountDeletion()` (it goes through `logout()` which leaves it intact). The flag prevents stale-key detection on reinstall. Clearing it on account deletion would cause the next key import to incorrectly trigger keychain cleanup — the current behavior is correct.
+### Passkeys
+iCloud Keychain passkeys are NOT programmatically deletable by iOS apps. Not mentioned in the UI — known platform limitation.
 
-### Ordering: relay deletion before local cleanup
-Page 1 runs while services are fully live (`relayManager`, `keypair`, `roadflareDomainService` all non-nil). Page 2 calls `completeAccountDeletion()` which tears everything down. This ordering is mandatory — swapping the steps would leave no relay connection to publish Kind 5.
+### `roadflare_has_launched` flag
+Intentionally NOT cleared (same as logout). Prevents stale-key detection on next key import.
 
 ---
 
 ## Acceptance Criteria Checklist
 
 - [ ] Settings tab has a "Delete Account" button distinct from "Log Out"
-- [ ] Tapping "Delete Account" opens a sheet (not a simple alert)
-- [ ] Page 1 shows the list of target relays and an explanation of what will be deleted
-- [ ] Page 1 "Request Relay Deletion" button contacts relays and shows progress
-- [ ] Page 1 shows result (events targeted, relay status) before user can proceed
-- [ ] Page 1 allows continuing to Page 2 even if relay deletion partially fails
-- [ ] Mid-ride: Page 1 shows a clear error and does not proceed
-- [ ] Page 2 lists what local data will be deleted
-- [ ] Page 2 "Delete Account" button calls `completeAccountDeletion()` and returns app to onboarding
-- [ ] All SDK tests pass after implementation
+- [ ] Tapping "Delete Account" opens a sheet
+- [ ] Page 1 shows relay list and a collapsible "About Nostr & Account Deletion" explainer
+- [ ] Page 1 "Scan Relays" queries all 12 Ridestr kinds + Kind 0 and shows progress
+- [ ] Page 1 shows event count and enables Continue after scan completes
+- [ ] Page 1 Cancel button is always visible except during scan
+- [ ] Page 2 shows scan result summary (RoadFlare events + metadata events)
+- [ ] Page 2 "Delete RoadFlare Events" shows simple "are you sure?" confirmation
+- [ ] Page 2 "Delete All Ridestr Events" shows checkbox confirmation sheet with 3 items
+- [ ] Checkbox delete button is disabled until all 3 checkboxes are checked
+- [ ] RoadFlare deletion targets only the 12 Ridestr kinds (not Kind 0)
+- [ ] Full deletion targets all 12 + Kind 0 metadata
+- [ ] Both options clear all local data and return app to onboarding after relay deletion
+- [ ] Mid-ride: scan fails with a clear error message
+- [ ] Page 2 back button navigates to scan results; hidden during deletion
+- [ ] All SDK tests pass
 - [ ] Full Xcode project builds clean (`xcodebuild build`)

--- a/docs/plans/issue-51-delete-account.md
+++ b/docs/plans/issue-51-delete-account.md
@@ -1,0 +1,971 @@
+# Delete Account Feature (Issue #51) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a two-page in-app Delete Account flow that (1) publishes NIP-09 deletion requests for the user's Nostr events to all known relays and shows per-relay status, then (2) performs full local account cleanup and returns the app to the logged-out/onboarding state.
+
+**Architecture:** A new `AccountDeletionService` in RidestrSDK handles event-ID fetching and Kind 5 deletion publishing via `RelayManagerProtocol`. `AppState` gains `beginRelayDeletion()` and `completeAccountDeletion()` methods. The UI is a sheet with a `NavigationStack` hosting two views — `DeleteAccountRelayView` (Page 1: relay deletion) and `DeleteAccountFinalView` (Page 2: local cleanup confirmation) — triggered from a new "Delete Account" button added to `SettingsTab`.
+
+**Tech Stack:** SwiftUI, RidestrSDK (`NostrFilter`, `RideshareEventBuilder`, `RelayManagerProtocol`, `DefaultRelays`), `AppState` (`@Observable`, `@MainActor`), `FakeRelayManager` + Swift Testing for unit tests
+
+---
+
+## Background & Codebase Context
+
+### What constitutes "an account"
+
+A RoadFlare account is:
+1. **A Nostr keypair** — private key stored in Keychain at service `"com.roadflare.keys"`, key `"nostr_identity_private_key"`. Cleared by `KeyManager.deleteKeys()`.
+2. **Local UserDefaults data** — profile name, payment methods, saved locations, ride history, followed drivers, sync metadata. Cleared by repository `clearAll()` calls in `prepareForIdentityReplacement()`.
+3. **Nostr-backed events on relays** — the four kinds below. NOT cleared by current `logout()`.
+
+### Nostr events that must be deleted (rider-authored, non-ephemeral)
+
+| Kind | Name | d-tag filter |
+|------|------|--------------|
+| 0 | metadata (profile name) | — (use `NostrFilter.metadata`) |
+| 30011 | followedDriversList | `"roadflare-drivers"` |
+| 30174 | rideHistoryBackup | `"rideshare-history"` |
+| 30177 | unifiedProfile / profileBackup | `"rideshare-profile"` |
+
+Ephemeral kinds (3173–3189) expire naturally and do **not** need deletion.
+
+### Current logout flow (reuse for step 2)
+
+`AppState.logout()` in `RoadFlare/RoadFlareCore/ViewModels/AppState.swift:341`:
+```swift
+public func logout() async {
+    await prepareForIdentityReplacement(clearPersistedSyncState: true)
+    try? await keyManager?.deleteKeys()
+    keypair = nil
+    authState = .loggedOut
+}
+```
+`prepareForIdentityReplacement()` at line 458 stops all coordinators, clears all repos, nils service refs.
+
+### Mid-ride guard
+
+Check `rideCoordinator?.session.stage.isActiveRide` (defined in `RidestrSDK/Sources/RidestrSDK/Models/RideModels.swift:33`). Active stages are `.rideConfirmed`, `.enRoute`, `.driverArrived`, `.inProgress`.
+
+### Relay infrastructure
+
+`RelayManagerProtocol.fetchEvents(filter:timeout:)` — one-shot EOSE-aware query, returns matching events.  
+`RelayManagerProtocol.publish(_:)` — publishes to all connected relays.  
+`DefaultRelays.all` — `[wss://relay.damus.io, wss://nos.lol, wss://relay.primal.net]` (3 relays, SDK-defined).  
+`RideshareEventBuilder.deletion(eventIds:reason:kinds:keypair:)` — already implemented in `RidestrSDK/Sources/RidestrSDK/Nostr/RideshareEventBuilder.swift:331`.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift` | Fetch event IDs + publish Kind 5 deletion |
+| Create | `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/AccountDeletionServiceTests.swift` | Unit tests for the service |
+| Create | `RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift` | Two-page deletion UI (both pages) |
+| Modify | `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` | Add `beginRelayDeletion()` + `completeAccountDeletion()` |
+| Modify | `RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift` | Add Delete Account button + sheet presentation |
+
+---
+
+## Task 1: AccountDeletionService — SDK type and result model
+
+**Files:**
+- Create: `RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift`
+- Create: `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/AccountDeletionServiceTests.swift`
+
+- [ ] **Step 1.1: Write the failing test file**
+
+```swift
+// RidestrSDK/Tests/RidestrSDKTests/RoadFlare/AccountDeletionServiceTests.swift
+import Foundation
+import Testing
+@testable import RidestrSDK
+
+// Decode a stub NostrEvent from JSON (same pattern as NostrEventTests.swift).
+// Lets us set arbitrary kind/id without calling EventSigner (which needs real crypto).
+private func stubEvent(id: String, kind: UInt16, pubkey: String) -> NostrEvent {
+    let json = """
+    {"id":"\(id)","pubkey":"\(pubkey)","created_at":1700000000,"kind":\(kind),\
+    "tags":[],"content":"","sig":"fakesig"}
+    """
+    return try! JSONDecoder().decode(NostrEvent.self, from: json.data(using: .utf8)!)
+}
+
+@Suite("AccountDeletionService Tests")
+struct AccountDeletionServiceTests {
+    private func makeKit() throws -> (sut: AccountDeletionService, relay: FakeRelayManager, pubkey: String) {
+        let keypair = try NostrKeypair.generate()
+        let relay = FakeRelayManager()
+        let sut = AccountDeletionService(relayManager: relay, keypair: keypair)
+        return (sut, relay, keypair.publicKeyHex)
+    }
+
+    // MARK: - No events
+
+    @Test func noEvents_returnsSuccessWithEmptyIds_publishesNothing() async throws {
+        let (sut, relay, _) = try makeKit()
+        relay.fetchResults = []
+
+        let result = await sut.deleteUserEvents()
+
+        #expect(result.publishedSuccessfully == true)
+        #expect(result.targetedEventIds.isEmpty)
+        #expect(result.publishError == nil)
+        #expect(result.queriedKinds == AccountDeletionService.deletableKinds)
+        #expect(result.targetRelayURLs == DefaultRelays.all)
+        #expect(relay.publishedEvents.isEmpty)  // no Kind 5 when nothing to delete
+    }
+
+    // MARK: - Events found
+
+    @Test func foundEvents_publishesKind5WithETagsForEachEventId() async throws {
+        let (sut, relay, pubkey) = try makeKit()
+        let event = stubEvent(id: "aabbcc", kind: 0, pubkey: pubkey)
+        relay.fetchResults = [event]  // returned for every fetchEvents call
+
+        let result = await sut.deleteUserEvents()
+
+        #expect(result.publishedSuccessfully == true)
+        #expect(result.targetedEventIds.contains("aabbcc"))
+        #expect(relay.publishedEvents.count == 1)
+        let kind5 = relay.publishedEvents[0]
+        #expect(kind5.kind == 5)
+        let eTagIds = kind5.tagValues("e")
+        #expect(eTagIds.contains("aabbcc"))
+    }
+
+    @Test func foundEvents_publishError_returnsFailureResultWithEventIds() async throws {
+        let (sut, relay, pubkey) = try makeKit()
+        let event = stubEvent(id: "aabbcc", kind: 0, pubkey: pubkey)
+        relay.fetchResults = [event]
+        relay.shouldFailPublish = true
+
+        let result = await sut.deleteUserEvents()
+
+        #expect(result.publishedSuccessfully == false)
+        #expect(result.publishError != nil)
+        #expect(result.targetedEventIds.contains("aabbcc"))
+    }
+
+    // MARK: - Deletable kinds contract
+
+    @Test func deletableKinds_containsExpectedKinds() {
+        let rawValues = AccountDeletionService.deletableKinds.map(\.rawValue)
+        #expect(rawValues.contains(0))      // Kind 0: metadata
+        #expect(rawValues.contains(30011))  // Kind 30011: followedDriversList
+        #expect(rawValues.contains(30174))  // Kind 30174: rideHistoryBackup
+        #expect(rawValues.contains(30177))  // Kind 30177: unifiedProfile
+    }
+
+    @Test func deletableKinds_doesNotContainEphemeralKinds() {
+        let rawValues = AccountDeletionService.deletableKinds.map(\.rawValue)
+        // Ephemeral kinds (3173–3189) should not be targeted — they expire naturally
+        for ephemeral: UInt16 in [3173, 3175, 3178, 3179, 3186, 3187, 3188, 3189] {
+            #expect(!rawValues.contains(ephemeral))
+        }
+    }
+
+    // MARK: - Filter queries
+
+    @Test func queriesAllDeletableKinds() async throws {
+        let (sut, relay, _) = try makeKit()
+        relay.fetchResults = []
+
+        _ = await sut.deleteUserEvents()
+
+        // One fetchEvents call per deletable kind
+        #expect(relay.fetchCalls.count == AccountDeletionService.deletableKinds.count)
+    }
+}
+```
+
+- [ ] **Step 1.2: Run test to confirm compile failure**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+xcodebuild test \
+  -workspace RoadFlare.xcworkspace \
+  -scheme RidestrSDK \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  2>&1 | grep -E "error:|Build Succeeded|Build FAILED"
+```
+
+Expected: `error: cannot find type 'AccountDeletionService'`
+
+- [ ] **Step 1.3: Create AccountDeletionService.swift**
+
+```swift
+// RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift
+import Foundation
+
+// MARK: - Result Model
+
+/// Result of a relay-side account event deletion pass.
+///
+/// Deletion on Nostr is best-effort — relays may honour or ignore Kind 5 events.
+/// This result tells the caller what was attempted, not what was guaranteed.
+public struct RelayDeletionResult: Sendable {
+    /// Event IDs found on relays and targeted for deletion.
+    public let targetedEventIds: [String]
+    /// Event kinds that were queried (always `AccountDeletionService.deletableKinds`).
+    public let queriedKinds: [EventKind]
+    /// Relay URLs the deletion request was published to.
+    public let targetRelayURLs: [URL]
+    /// True if the Kind 5 deletion event was published without error,
+    /// or if there were no events to delete (vacuously successful).
+    public let publishedSuccessfully: Bool
+    /// Human-readable error from the publish step, if any.
+    public let publishError: String?
+}
+
+// MARK: - Service
+
+/// Fetches all rider-authored Nostr events and publishes a NIP-09 Kind 5 deletion request.
+///
+/// Intended for use in the two-page Delete Account flow. Create with the app's live
+/// `relayManager` (already connected to `DefaultRelays.all`). Call `deleteUserEvents()`
+/// from Page 1 of the flow before tearing down services.
+public final class AccountDeletionService: Sendable {
+    private let relayManager: any RelayManagerProtocol
+    private let keypair: NostrKeypair
+
+    /// Rider-authored event kinds that should be deleted on account closure.
+    /// Ephemeral kinds (3173–3189) expire naturally and are excluded.
+    public static let deletableKinds: [EventKind] = [
+        .metadata,
+        .followedDriversList,
+        .rideHistoryBackup,
+        .unifiedProfile,
+    ]
+
+    public init(relayManager: any RelayManagerProtocol, keypair: NostrKeypair) {
+        self.relayManager = relayManager
+        self.keypair = keypair
+    }
+
+    /// Fetch all deletable user events from relays, publish a Kind 5 deletion request,
+    /// and return a result describing what was attempted.
+    ///
+    /// - Never throws. Errors from relay fetch are silently treated as "no events found"
+    ///   (best-effort); errors from publish are captured in `RelayDeletionResult.publishError`.
+    public func deleteUserEvents() async -> RelayDeletionResult {
+        // 1. Query each deletable kind. Treat fetch errors as empty (relay may be down).
+        var eventIds: [String] = []
+        for kind in Self.deletableKinds {
+            let filter = buildFilter(for: kind)
+            let events = (try? await relayManager.fetchEvents(
+                filter: filter,
+                timeout: RelayConstants.eoseTimeoutSeconds
+            )) ?? []
+            eventIds.append(contentsOf: events.map(\.id))
+        }
+
+        // 2. Nothing to delete — vacuous success (no Kind 5 published).
+        guard !eventIds.isEmpty else {
+            return RelayDeletionResult(
+                targetedEventIds: [],
+                queriedKinds: Self.deletableKinds,
+                targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: true,
+                publishError: nil
+            )
+        }
+
+        // 3. Build and publish a single Kind 5 event covering all found event IDs.
+        do {
+            let deletionEvent = try await RideshareEventBuilder.deletion(
+                eventIds: eventIds,
+                reason: "Account deleted by user",
+                kinds: Self.deletableKinds,
+                keypair: keypair
+            )
+            _ = try await relayManager.publish(deletionEvent)
+            return RelayDeletionResult(
+                targetedEventIds: eventIds,
+                queriedKinds: Self.deletableKinds,
+                targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: true,
+                publishError: nil
+            )
+        } catch {
+            return RelayDeletionResult(
+                targetedEventIds: eventIds,
+                queriedKinds: Self.deletableKinds,
+                targetRelayURLs: DefaultRelays.all,
+                publishedSuccessfully: false,
+                publishError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    private func buildFilter(for kind: EventKind) -> NostrFilter {
+        switch kind {
+        case .followedDriversList:
+            return .followedDriversList(myPubkey: keypair.publicKeyHex)
+        case .rideHistoryBackup:
+            return .rideHistoryBackup(myPubkey: keypair.publicKeyHex)
+        case .unifiedProfile:
+            return .profileBackup(myPubkey: keypair.publicKeyHex)
+        case .metadata:
+            return .metadata(pubkeys: [keypair.publicKeyHex])
+        default:
+            return NostrFilter().kinds([kind]).authors([keypair.publicKeyHex])
+        }
+    }
+}
+```
+
+- [ ] **Step 1.4: Run the tests**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+xcodebuild test \
+  -workspace RoadFlare.xcworkspace \
+  -scheme RidestrSDK \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -only-testing:RidestrSDKTests/AccountDeletionServiceTests \
+  2>&1 | grep -E "Test.*passed|Test.*failed|Build Succeeded|Build FAILED|error:"
+```
+
+Expected: all 6 tests pass
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+git add \
+  RidestrSDK/Sources/RidestrSDK/RoadFlare/AccountDeletionService.swift \
+  RidestrSDK/Tests/RidestrSDKTests/RoadFlare/AccountDeletionServiceTests.swift
+git commit -m "feat(sdk): add AccountDeletionService for NIP-09 relay event deletion"
+```
+
+---
+
+## Task 2: AppState — orchestration methods
+
+**Files:**
+- Modify: `RoadFlare/RoadFlareCore/ViewModels/AppState.swift`
+
+Add the following block after `logout()` (line 346):
+
+- [ ] **Step 2.1: Add error enum and methods to AppState.swift**
+
+Insert this block directly after the closing `}` of `logout()` at line 346:
+
+```swift
+// MARK: - Account Deletion
+
+/// Reasons beginRelayDeletion() can fail before contacting relays.
+public enum AccountDeletionError: Error {
+    /// Services not ready — user not logged in or relay not connected.
+    case servicesNotReady
+    /// Cannot delete account while a ride is in progress.
+    case activeRideInProgress
+}
+
+/// Phase 1 of account deletion: publish NIP-09 Kind 5 deletion events to relays.
+///
+/// Call this while the user is still logged in (relay + keypair are live).
+/// Guards against active rides. Returns a result describing what was attempted.
+///
+/// - Throws: `AccountDeletionError.servicesNotReady` if not logged in.
+/// - Throws: `AccountDeletionError.activeRideInProgress` if a ride is ongoing.
+public func beginRelayDeletion() async throws -> RelayDeletionResult {
+    guard let keypair, let relayManager else {
+        throw AccountDeletionError.servicesNotReady
+    }
+    guard !(rideCoordinator?.session.stage.isActiveRide ?? false) else {
+        throw AccountDeletionError.activeRideInProgress
+    }
+    let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
+    return await service.deleteUserEvents()
+}
+
+/// Phase 2 of account deletion: clear all local data and return to onboarding.
+///
+/// Reuses the existing logout path. Call only after `beginRelayDeletion()` completes.
+public func completeAccountDeletion() async {
+    await logout()
+}
+```
+
+- [ ] **Step 2.2: Build the full project to confirm no new errors**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+xcodebuild build \
+  -workspace RoadFlare.xcworkspace \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  2>&1 | grep -E "error:|Build Succeeded|Build FAILED"
+```
+
+Expected: `Build Succeeded`
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+git add RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+git commit -m "feat: add beginRelayDeletion() and completeAccountDeletion() to AppState"
+```
+
+---
+
+## Task 3: DeleteAccountSheet — two-page UI
+
+**Files:**
+- Create: `RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift`
+
+The sheet uses a `NavigationStack` with `NavigationLink` to push from Page 1 → Page 2.
+
+- [ ] **Step 3.1: Create DeleteAccountSheet.swift**
+
+```swift
+// RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+import SwiftUI
+import RidestrSDK
+import RoadFlareCore
+
+// MARK: - Container
+
+struct DeleteAccountSheet: View {
+    var body: some View {
+        NavigationStack {
+            DeleteAccountRelayView()
+        }
+    }
+}
+
+// MARK: - Page 1: Relay Deletion
+
+private enum RelayDeletionPhase {
+    case idle
+    case deleting
+    case complete(RelayDeletionResult)
+    case failed(String)
+}
+
+struct DeleteAccountRelayView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+    @State private var phase: RelayDeletionPhase = .idle
+
+    var body: some View {
+        ZStack {
+            Color.rfSurface.ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 24) {
+                    // Icon + headline
+                    VStack(spacing: 12) {
+                        Image(systemName: "trash.circle.fill")
+                            .font(.system(size: 52))
+                            .foregroundColor(Color.rfError)
+                        Text("Delete Account")
+                            .font(RFFont.headline(22))
+                            .foregroundColor(Color.rfOnSurface)
+                        Text("Step 1 of 2 — Relay Cleanup")
+                            .font(RFFont.caption(12))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                    }
+                    .padding(.top, 8)
+
+                    // Explanation
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("RoadFlare will request deletion of your events from all known relays. This includes your profile, saved locations, payment methods, ride history, and driver list.")
+                            .font(RFFont.body(14))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                        Text("Relay deletion is best-effort. Most relays honour Kind 5 deletion requests, but some may not.")
+                            .font(RFFont.body(14))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                    }
+                    .padding(16)
+                    .background(Color.rfSurfaceContainer)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+
+                    // Relay list
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Target Relays")
+                            .font(RFFont.caption(12))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                            .textCase(.uppercase)
+                            .tracking(1)
+                        VStack(spacing: 0) {
+                            ForEach(DefaultRelays.all, id: \.absoluteString) { relay in
+                                HStack(spacing: 12) {
+                                    Image(systemName: relayStatusIcon(relay))
+                                        .foregroundColor(relayStatusColor(relay))
+                                        .frame(width: 20)
+                                    Text(relay.host ?? relay.absoluteString)
+                                        .font(RFFont.body(14))
+                                        .foregroundColor(Color.rfOnSurface)
+                                    Spacer()
+                                    relayStatusText(relay)
+                                }
+                                .padding(14)
+                                if relay != DefaultRelays.all.last {
+                                    Divider().padding(.leading, 46)
+                                }
+                            }
+                        }
+                        .background(Color.rfSurfaceContainer)
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                    }
+
+                    // Result summary (visible after deletion attempt)
+                    if case .complete(let result) = phase {
+                        resultSummary(result)
+                    }
+                    if case .failed(let msg) = phase {
+                        Text("Error: \(msg)")
+                            .font(RFFont.body(13))
+                            .foregroundColor(Color.rfError)
+                            .padding(14)
+                            .background(Color.rfSurfaceContainer)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+
+                    // Primary action button
+                    primaryButton
+
+                    // Cancel
+                    if case .idle = phase {
+                        Button("Cancel") { dismiss() }
+                            .font(RFFont.body(15))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                    }
+
+                    Spacer(minLength: 24)
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+            }
+        }
+        .navigationTitle("Delete Account")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.rfSurface, for: .navigationBar)
+        .toolbar {
+            if case .idle = phase {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(Color.rfOnSurfaceVariant)
+                }
+            }
+        }
+    }
+
+    // MARK: - Primary button
+
+    @ViewBuilder
+    private var primaryButton: some View {
+        switch phase {
+        case .idle:
+            Button {
+                Task { await startDeletion() }
+            } label: {
+                Text("Request Relay Deletion")
+                    .font(RFFont.body(16).bold())
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(Color.rfError)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+
+        case .deleting:
+            HStack(spacing: 12) {
+                ProgressView().tint(Color.rfOnSurface)
+                Text("Contacting relays…")
+                    .font(RFFont.body(15))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(Color.rfSurfaceContainer)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+
+        case .complete(let result):
+            NavigationLink {
+                DeleteAccountFinalView()
+            } label: {
+                HStack {
+                    if result.publishedSuccessfully {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(Color.rfOnline)
+                    } else {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(Color.rfError)
+                    }
+                    Text("Continue to Final Step")
+                        .font(RFFont.body(16).bold())
+                }
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(result.publishedSuccessfully ? Color.rfError : Color.rfError.opacity(0.7))
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+
+        case .failed:
+            Button {
+                phase = .idle
+            } label: {
+                Text("Try Again")
+                    .font(RFFont.body(15))
+                    .foregroundColor(Color.rfOnSurface)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(Color.rfSurfaceContainer)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+        }
+    }
+
+    // MARK: - Result summary card
+
+    @ViewBuilder
+    private func resultSummary(_ result: RelayDeletionResult) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: result.publishedSuccessfully ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                    .foregroundColor(result.publishedSuccessfully ? Color.rfOnline : Color.rfError)
+                Text(result.publishedSuccessfully ? "Deletion requested" : "Deletion partially failed")
+                    .font(RFFont.title(15))
+                    .foregroundColor(Color.rfOnSurface)
+            }
+            if result.targetedEventIds.isEmpty {
+                Text("No events found on relays — nothing to delete.")
+                    .font(RFFont.body(13))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+            } else {
+                Text("\(result.targetedEventIds.count) event(s) targeted across \(result.targetRelayURLs.count) relays.")
+                    .font(RFFont.body(13))
+                    .foregroundColor(Color.rfOnSurfaceVariant)
+            }
+            if let err = result.publishError {
+                Text("Note: \(err)")
+                    .font(RFFont.caption(12))
+                    .foregroundColor(Color.rfError)
+            }
+            Text("You can proceed to final deletion even if relay cleanup was incomplete.")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+        }
+        .padding(16)
+        .background(Color.rfSurfaceContainer)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    // MARK: - Per-relay status icons/colors/text
+
+    private func relayStatusIcon(_ relay: URL) -> String {
+        switch phase {
+        case .idle: return "circle"
+        case .deleting: return "arrow.triangle.2.circlepath"
+        case .complete(let result):
+            return result.publishedSuccessfully ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+        case .failed: return "xmark.circle.fill"
+        }
+    }
+
+    private func relayStatusColor(_ relay: URL) -> Color {
+        switch phase {
+        case .idle: return Color.rfOffline
+        case .deleting: return Color.rfPrimary
+        case .complete(let result):
+            return result.publishedSuccessfully ? Color.rfOnline : Color.rfError
+        case .failed: return Color.rfError
+        }
+    }
+
+    @ViewBuilder
+    private func relayStatusText(_ relay: URL) -> some View {
+        switch phase {
+        case .idle:
+            Text("Pending")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfOffline)
+        case .deleting:
+            ProgressView()
+                .scaleEffect(0.7)
+                .tint(Color.rfPrimary)
+        case .complete(let result):
+            Text(result.publishedSuccessfully ? "Requested" : "Failed")
+                .font(RFFont.caption(12))
+                .foregroundColor(result.publishedSuccessfully ? Color.rfOnline : Color.rfError)
+        case .failed:
+            Text("Error")
+                .font(RFFont.caption(12))
+                .foregroundColor(Color.rfError)
+        }
+    }
+
+    // MARK: - Action
+
+    private func startDeletion() async {
+        phase = .deleting
+        do {
+            let result = try await appState.beginRelayDeletion()
+            phase = .complete(result)
+        } catch AccountDeletionError.activeRideInProgress {
+            phase = .failed("You have an active ride in progress. Please complete or cancel your ride before deleting your account.")
+        } catch AccountDeletionError.servicesNotReady {
+            phase = .failed("Unable to connect — please try again.")
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+}
+
+// MARK: - Page 2: Final Local Removal
+
+struct DeleteAccountFinalView: View {
+    @Environment(AppState.self) private var appState
+    @State private var isDeleting = false
+
+    private let localDataItems = [
+        ("key.fill", "Private key (from Keychain)"),
+        ("person.fill", "Profile name"),
+        ("creditcard.fill", "Payment preferences"),
+        ("mappin.and.ellipse", "Saved locations & recents"),
+        ("clock.arrow.circlepath", "Ride history"),
+        ("person.2.fill", "Followed drivers"),
+    ]
+
+    var body: some View {
+        ZStack {
+            Color.rfSurface.ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 24) {
+                    // Icon + headline
+                    VStack(spacing: 12) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 52))
+                            .foregroundColor(Color.rfError)
+                        Text("Final Confirmation")
+                            .font(RFFont.headline(22))
+                            .foregroundColor(Color.rfOnSurface)
+                        Text("Step 2 of 2 — Local Data Removal")
+                            .font(RFFont.caption(12))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                    }
+                    .padding(.top, 8)
+
+                    // Warning
+                    Text("This will permanently remove all local account data. This action cannot be undone.")
+                        .font(RFFont.body(14))
+                        .foregroundColor(Color.rfOnSurfaceVariant)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 8)
+
+                    // What gets deleted
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("What will be removed")
+                            .font(RFFont.caption(12))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                            .textCase(.uppercase)
+                            .tracking(1)
+                        VStack(spacing: 0) {
+                            ForEach(localDataItems, id: \.0) { icon, label in
+                                HStack(spacing: 12) {
+                                    Image(systemName: icon)
+                                        .frame(width: 20)
+                                        .foregroundColor(Color.rfError)
+                                    Text(label)
+                                        .font(RFFont.body(14))
+                                        .foregroundColor(Color.rfOnSurface)
+                                    Spacer()
+                                }
+                                .padding(14)
+                                if icon != localDataItems.last?.0 {
+                                    Divider().padding(.leading, 46)
+                                }
+                            }
+                        }
+                        .background(Color.rfSurfaceContainer)
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                    }
+
+                    // Delete button
+                    Button {
+                        isDeleting = true
+                        Task { await appState.completeAccountDeletion() }
+                    } label: {
+                        Group {
+                            if isDeleting {
+                                HStack(spacing: 10) {
+                                    ProgressView().tint(.white)
+                                    Text("Deleting…")
+                                }
+                            } else {
+                                Text("Delete Account")
+                            }
+                        }
+                        .font(RFFont.body(16).bold())
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(isDeleting ? Color.rfError.opacity(0.6) : Color.rfError)
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                    }
+                    .disabled(isDeleting)
+
+                    Spacer(minLength: 24)
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+            }
+        }
+        .navigationTitle("Final Step")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.rfSurface, for: .navigationBar)
+        .navigationBarBackButtonHidden(isDeleting)
+    }
+}
+```
+
+- [ ] **Step 3.2: Build to confirm no compile errors**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+xcodebuild build \
+  -workspace RoadFlare.xcworkspace \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  2>&1 | grep -E "error:|Build Succeeded|Build FAILED"
+```
+
+Expected: `Build Succeeded`
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+git add RoadFlare/RoadFlare/Views/Settings/DeleteAccountSheet.swift
+git commit -m "feat(ui): add DeleteAccountSheet two-page relay+local deletion flow"
+```
+
+---
+
+## Task 4: Wire into SettingsTab
+
+**Files:**
+- Modify: `RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift`
+
+- [ ] **Step 4.1: Add state variable and Delete Account button to SettingsTab**
+
+In `SettingsTab`, add `@State private var showDeleteAccount = false` alongside the other state variables at the top of the struct (after line 10 where `showLogoutConfirm` is declared):
+
+```swift
+@State private var showDeleteAccount = false
+```
+
+Replace the existing Logout section (lines 173–182) with the updated block below that adds a "Delete Account" button beneath "Log Out":
+
+```swift
+// Logout
+Button { showLogoutConfirm = true } label: {
+    Text("Log Out")
+        .font(RFFont.body(15))
+        .foregroundColor(Color.rfError)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .background(Color.rfSurfaceContainer)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+}
+
+// Delete Account
+Button { showDeleteAccount = true } label: {
+    Text("Delete Account")
+        .font(RFFont.body(15))
+        .foregroundColor(Color.rfError)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .background(Color.rfSurfaceContainer)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+}
+```
+
+Add the sheet presentation alongside the other sheet modifiers (after line 195 where `showEditProfile` sheet is):
+
+```swift
+.sheet(isPresented: $showDeleteAccount) { DeleteAccountSheet() }
+```
+
+- [ ] **Step 4.2: Build to confirm no compile errors**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+xcodebuild build \
+  -workspace RoadFlare.xcworkspace \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  2>&1 | grep -E "error:|Build Succeeded|Build FAILED"
+```
+
+Expected: `Build Succeeded`
+
+- [ ] **Step 4.3: Run all SDK tests to confirm nothing regressed**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+xcodebuild test \
+  -workspace RoadFlare.xcworkspace \
+  -scheme RidestrSDK \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  2>&1 | grep -E "Test.*passed|Test.*failed|Build Succeeded|Build FAILED|error:"
+```
+
+Expected: all tests pass, no failures.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios-issue-51
+git add RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
+git commit -m "feat(ui): wire Delete Account into Settings tab"
+```
+
+---
+
+## Edge Cases & Implementation Notes
+
+### Mid-ride guard
+`beginRelayDeletion()` in AppState throws `AccountDeletionError.activeRideInProgress` when `rideCoordinator?.session.stage.isActiveRide` is true. The UI translates this to a user-facing message on Page 1. This prevents data corruption from tearing down services during an active protocol exchange.
+
+### Relay unreachable / fetch errors
+`AccountDeletionService.deleteUserEvents()` silently treats fetch errors as "no events found" for that kind. A single Kind 5 event covers all found event IDs. If `relayManager` is disconnected when `beginRelayDeletion()` is called, `publish()` throws and the result captures the error in `publishError`.
+
+### No events to delete (new account)
+If the user never published any events (e.g. imported a key but never completed onboarding), all `fetchEvents` calls return empty. The service returns `publishedSuccessfully: true` with empty `targetedEventIds`. Page 1 shows "No events found on relays — nothing to delete." and still allows proceeding to Page 2.
+
+### Relay does not support NIP-09 deletion
+Deletion on Nostr is advisory. The UI text ("Relay deletion is best-effort") and result summary ("You can proceed to final deletion even if relay cleanup was incomplete") set honest user expectations. The "Continue to Final Step" NavigationLink is always available after Page 1 completes, regardless of whether publish succeeded.
+
+### Passkey / iCloud Keychain credentials
+PasskeyManager passkeys sync via iCloud and are NOT cleared by `completeAccountDeletion()`. Page 2 does not mention passkeys because there is no programmatic iOS API to delete iCloud Keychain credentials from within an app. If this becomes a requirement, the user must delete passkeys manually via iOS Settings → Passwords. This is a known limitation, not a bug.
+
+### `roadflare_has_launched` UserDefaults flag
+This flag is intentionally NOT cleared by `completeAccountDeletion()` (it goes through `logout()` which leaves it intact). The flag prevents stale-key detection on reinstall. Clearing it on account deletion would cause the next key import to incorrectly trigger keychain cleanup — the current behavior is correct.
+
+### Ordering: relay deletion before local cleanup
+Page 1 runs while services are fully live (`relayManager`, `keypair`, `roadflareDomainService` all non-nil). Page 2 calls `completeAccountDeletion()` which tears everything down. This ordering is mandatory — swapping the steps would leave no relay connection to publish Kind 5.
+
+---
+
+## Acceptance Criteria Checklist
+
+- [ ] Settings tab has a "Delete Account" button distinct from "Log Out"
+- [ ] Tapping "Delete Account" opens a sheet (not a simple alert)
+- [ ] Page 1 shows the list of target relays and an explanation of what will be deleted
+- [ ] Page 1 "Request Relay Deletion" button contacts relays and shows progress
+- [ ] Page 1 shows result (events targeted, relay status) before user can proceed
+- [ ] Page 1 allows continuing to Page 2 even if relay deletion partially fails
+- [ ] Mid-ride: Page 1 shows a clear error and does not proceed
+- [ ] Page 2 lists what local data will be deleted
+- [ ] Page 2 "Delete Account" button calls `completeAccountDeletion()` and returns app to onboarding
+- [ ] All SDK tests pass after implementation
+- [ ] Full Xcode project builds clean (`xcodebuild build`)

--- a/docs/plans/issue-51-delete-account.md
+++ b/docs/plans/issue-51-delete-account.md
@@ -143,6 +143,8 @@ struct AccountDeletionServiceTests {
 
         #expect(result.roadflareEvents.isEmpty)
         #expect(result.metadataEvents.isEmpty)
+        #expect(result.scanErrors.isEmpty)
+        #expect(result.hasErrors == false)
         #expect(result.targetRelayURLs == DefaultRelays.all)
         // Two queries: roadflare kinds + kind 0
         #expect(relay.fetchCalls.count == 2)
@@ -161,6 +163,44 @@ struct AccountDeletionServiceTests {
         // In production, each filter returns only matching events.
         #expect(!result.roadflareEvents.isEmpty)
         #expect(!result.metadataEvents.isEmpty)
+        #expect(result.scanErrors.isEmpty)
+    }
+
+    @Test func scan_fetchFailure_capturesErrorsRatherThanSilentEmpty() async throws {
+        // FakeRelayManager doesn't expose shouldFailFetch, but `disconnect()` causes
+        // RelayManager.fetchEvents to throw .notConnected in production. Here we
+        // simulate by making fetchEvents return events for one call and configuring
+        // a custom failing fake. For the SDK fake, treat lack of connection as the
+        // closest analog: the test verifies the contract that errors do propagate
+        // into scanErrors when fetch throws.
+        //
+        // Pragmatic test: build a one-off fake that throws.
+        final class ThrowingRelay: RelayManagerProtocol, @unchecked Sendable {
+            func connect(to relays: [URL]) async throws {}
+            func disconnect() async {}
+            func publish(_ event: NostrEvent) async throws -> String { event.id }
+            func subscribe(filter: NostrFilter, id: SubscriptionID) async throws -> AsyncStream<NostrEvent> {
+                AsyncStream { $0.finish() }
+            }
+            func unsubscribe(_ id: SubscriptionID) async {}
+            func fetchEvents(filter: NostrFilter, timeout: TimeInterval) async throws -> [NostrEvent] {
+                throw RidestrError.relay(.notConnected)
+            }
+            var isConnected: Bool { false }
+            func reconnectIfNeeded() async {}
+        }
+
+        let keypair = try NostrKeypair.generate()
+        let sut = AccountDeletionService(relayManager: ThrowingRelay(), keypair: keypair)
+
+        let result = await sut.scanRelays()
+
+        #expect(result.roadflareEvents.isEmpty)
+        #expect(result.metadataEvents.isEmpty)
+        #expect(result.hasErrors == true)
+        #expect(result.scanErrors.count == 2)  // both queries failed
+        #expect(result.scanErrors.contains { $0.contains("RoadFlare events query failed") })
+        #expect(result.scanErrors.contains { $0.contains("Nostr profile query failed") })
     }
 
     // MARK: - Delete RoadFlare events
@@ -170,6 +210,7 @@ struct AccountDeletionServiceTests {
         let scan = RelayScanResult(
             roadflareEvents: [],
             metadataEvents: [],
+            scanErrors: [],
             targetRelayURLs: DefaultRelays.all
         )
 
@@ -187,6 +228,7 @@ struct AccountDeletionServiceTests {
         let scan = RelayScanResult(
             roadflareEvents: [rfEvent],
             metadataEvents: [metaEvent],
+            scanErrors: [],
             targetRelayURLs: DefaultRelays.all
         )
 
@@ -211,6 +253,7 @@ struct AccountDeletionServiceTests {
         let scan = RelayScanResult(
             roadflareEvents: [rfEvent],
             metadataEvents: [metaEvent],
+            scanErrors: [],
             targetRelayURLs: DefaultRelays.all
         )
 
@@ -233,6 +276,7 @@ struct AccountDeletionServiceTests {
         let scan = RelayScanResult(
             roadflareEvents: [rfEvent],
             metadataEvents: [],
+            scanErrors: [],
             targetRelayURLs: DefaultRelays.all
         )
         relay.shouldFailPublish = true
@@ -302,12 +346,17 @@ public struct RelayScanResult: Sendable {
     public let roadflareEvents: [NostrEvent]
     /// Kind 0 metadata events found (shared Nostr identity, used by all apps).
     public let metadataEvents: [NostrEvent]
+    /// Human-readable error messages from queries that failed (relay unreachable,
+    /// timeout, etc.). When non-empty, the scan was incomplete — the caller should
+    /// warn the user before proceeding to deletion.
+    public let scanErrors: [String]
     /// Relay URLs that were scanned.
     public let targetRelayURLs: [URL]
 
     public var roadflareCount: Int { roadflareEvents.count }
     public var metadataCount: Int { metadataEvents.count }
     public var totalCount: Int { roadflareCount + metadataCount }
+    public var hasErrors: Bool { !scanErrors.isEmpty }
 }
 
 /// Result of a relay-side deletion pass.
@@ -367,6 +416,8 @@ public final class AccountDeletionService: Sendable {
 
     /// Query connected relays for all rider-authored events.
     /// Two queries: one for all 12 RoadFlare kinds, one for Kind 0 metadata.
+    /// Captures fetch errors in `RelayScanResult.scanErrors` so the caller can
+    /// warn the user when a query failed (rather than silently reporting 0 events).
     public func scanRelays() async -> RelayScanResult {
         let roadflareFilter = NostrFilter()
             .authors([keypair.publicKeyHex])
@@ -374,14 +425,19 @@ public final class AccountDeletionService: Sendable {
 
         let metadataFilter = NostrFilter.metadata(pubkeys: [keypair.publicKeyHex])
 
-        async let rfFetch = fetchSafe(filter: roadflareFilter)
-        async let metaFetch = fetchSafe(filter: metadataFilter)
+        async let rfFetch = fetchWithError(filter: roadflareFilter, label: "RoadFlare events")
+        async let metaFetch = fetchWithError(filter: metadataFilter, label: "Nostr profile")
 
-        let (rfEvents, metaEvents) = await (rfFetch, metaFetch)
+        let (rfResult, metaResult) = await (rfFetch, metaFetch)
+
+        var errors: [String] = []
+        if let err = rfResult.error { errors.append(err) }
+        if let err = metaResult.error { errors.append(err) }
 
         return RelayScanResult(
-            roadflareEvents: rfEvents,
-            metadataEvents: metaEvents,
+            roadflareEvents: rfResult.events,
+            metadataEvents: metaResult.events,
+            scanErrors: errors,
             targetRelayURLs: DefaultRelays.all
         )
     }
@@ -408,11 +464,16 @@ public final class AccountDeletionService: Sendable {
 
     // MARK: - Private
 
-    private func fetchSafe(filter: NostrFilter) async -> [NostrEvent] {
-        (try? await relayManager.fetchEvents(
-            filter: filter,
-            timeout: RelayConstants.eoseTimeoutSeconds
-        )) ?? []
+    private func fetchWithError(filter: NostrFilter, label: String) async -> (events: [NostrEvent], error: String?) {
+        do {
+            let events = try await relayManager.fetchEvents(
+                filter: filter,
+                timeout: RelayConstants.eoseTimeoutSeconds
+            )
+            return (events, nil)
+        } catch {
+            return ([], "\(label) query failed: \(error.localizedDescription)")
+        }
     }
 
     private func publishDeletion(eventIds: [String], kinds: [EventKind]) async -> RelayDeletionResult {
@@ -463,7 +524,7 @@ xcodebuild test \
   2>&1 | grep -E "Test.*passed|Test.*failed|Build Succeeded|Build FAILED|error:"
 ```
 
-Expected: all 9 tests pass.
+Expected: all 10 tests pass (includes the new scan-error path test).
 
 - [ ] **Step 1.5: Commit**
 
@@ -501,6 +562,10 @@ Then add the following methods inside `AppState`, after the closing `}` of `logo
 
 /// Scan relays for all rider-authored events. Returns categorised results.
 /// Call while still logged in (relay + keypair are live).
+///
+/// Defensively reconnects the relay manager if its notification handler died
+/// (e.g. after backgrounding) so the scan doesn't silently return 0 events
+/// because the WebSocket is dead.
 public func scanRelaysForDeletion() async throws -> RelayScanResult {
     guard let keypair, let relayManager else {
         throw AccountDeletionError.servicesNotReady
@@ -508,11 +573,15 @@ public func scanRelaysForDeletion() async throws -> RelayScanResult {
     guard !(rideCoordinator?.session.stage.isActiveRide ?? false) else {
         throw AccountDeletionError.activeRideInProgress
     }
+    await relayManager.reconnectIfNeeded()
     let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
     return await service.scanRelays()
 }
 
 /// Delete only RoadFlare events from relays, then clear local data and log out.
+/// Logs publish failures via `AppLogger.auth.error` so they're visible in Console.app
+/// — the user is logged out either way (they've committed to deletion), but the
+/// failure is preserved diagnostically.
 public func deleteRoadflareEvents(from scan: RelayScanResult) async -> RelayDeletionResult {
     guard let keypair, let relayManager else {
         return RelayDeletionResult(
@@ -522,6 +591,11 @@ public func deleteRoadflareEvents(from scan: RelayScanResult) async -> RelayDele
     }
     let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
     let result = await service.deleteRoadflareEvents(from: scan)
+    if !result.publishedSuccessfully {
+        AppLogger.auth.error(
+            "RoadFlare event deletion publish failed: \(result.publishError ?? "unknown", privacy: .public)"
+        )
+    }
     await logout()
     return result
 }
@@ -537,12 +611,49 @@ public func deleteAllRidestrEvents(from scan: RelayScanResult) async -> RelayDel
     }
     let service = AccountDeletionService(relayManager: relayManager, keypair: keypair)
     let result = await service.deleteAllRidestrEvents(from: scan)
+    if !result.publishedSuccessfully {
+        AppLogger.auth.error(
+            "Full Ridestr event deletion publish failed: \(result.publishError ?? "unknown", privacy: .public)"
+        )
+    }
     await logout()
     return result
 }
 ```
 
-- [ ] **Step 2.2: Build the full project**
+- [ ] **Step 2.2: Add AppState guard tests**
+
+Append the following to the existing `AppStateTests` suite in `RoadFlare/RoadFlareTests/RoadFlareTests.swift` (the suite starts at line 147):
+
+```swift
+    @MainActor
+    @Test func scanRelaysForDeletion_throwsServicesNotReady_whenNotLoggedIn() async throws {
+        let appState = AppState()
+        // Fresh AppState has nil keypair and nil relayManager.
+
+        await #expect(throws: AccountDeletionError.servicesNotReady) {
+            try await appState.scanRelaysForDeletion()
+        }
+    }
+
+    @MainActor
+    @Test func deleteRoadflareEvents_returnsServicesNotReady_whenNotLoggedIn() async throws {
+        let appState = AppState()
+        let scan = RelayScanResult(
+            roadflareEvents: [], metadataEvents: [],
+            scanErrors: [], targetRelayURLs: DefaultRelays.all
+        )
+
+        let result = await appState.deleteRoadflareEvents(from: scan)
+
+        #expect(result.publishedSuccessfully == false)
+        #expect(result.publishError == "Services not ready")
+    }
+```
+
+The mid-ride guard (`activeRideInProgress`) is not unit-tested here because it requires constructing a `RideCoordinator` with an active session — too heavy for a unit test. The guard logic is a single `if` against a public property and is covered by the integration test scenario in the acceptance criteria.
+
+- [ ] **Step 2.3: Build the full project and run AppState tests**
 
 ```bash
 cd ~/Documents/Projects/roadflare-ios-issue-51
@@ -551,15 +662,24 @@ xcodebuild build \
   -scheme RoadFlare \
   -destination 'platform=iOS Simulator,name=iPhone 16' \
   2>&1 | grep -E "error:|Build Succeeded|Build FAILED"
+
+xcodebuild test \
+  -workspace RoadFlare.xcworkspace \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -only-testing:RoadFlareTests/AppStateTests \
+  2>&1 | grep -E "Test.*passed|Test.*failed|Build Succeeded|Build FAILED|error:"
 ```
 
-Expected: `Build Succeeded`
+Expected: `Build Succeeded` and all AppState tests pass.
 
-- [ ] **Step 2.3: Commit**
+- [ ] **Step 2.4: Commit**
 
 ```bash
 cd ~/Documents/Projects/roadflare-ios-issue-51
-git add RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+git add \
+  RoadFlare/RoadFlareCore/ViewModels/AppState.swift \
+  RoadFlare/RoadFlareTests/RoadFlareTests.swift
 git commit -m "feat: add relay scan and two-tier account deletion to AppState"
 ```
 
@@ -684,20 +804,48 @@ struct DeleteAccountScanView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 16))
 
                     case .complete(let scan):
-                        NavigationLink {
-                            DeleteAccountResultsView(scan: scan)
-                        } label: {
-                            HStack {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundColor(Color.rfOnline)
-                                Text("Continue — \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") found")
-                                    .font(RFFont.body(16).bold())
+                        VStack(spacing: 12) {
+                            // Surface scan errors honestly — a silent "0 events"
+                            // when relays were unreachable would mislead the user.
+                            if scan.hasErrors {
+                                VStack(alignment: .leading, spacing: 6) {
+                                    HStack(spacing: 8) {
+                                        Image(systemName: "exclamationmark.triangle.fill")
+                                            .foregroundColor(Color.rfError)
+                                        Text("Scan incomplete")
+                                            .font(RFFont.title(14))
+                                            .foregroundColor(Color.rfOnSurface)
+                                    }
+                                    ForEach(scan.scanErrors, id: \.self) { err in
+                                        Text(err)
+                                            .font(RFFont.caption(12))
+                                            .foregroundColor(Color.rfOnSurfaceVariant)
+                                    }
+                                    Text("You can still continue, but events on unreachable relays may not be deleted.")
+                                        .font(RFFont.caption(12))
+                                        .foregroundColor(Color.rfOnSurfaceVariant)
+                                }
+                                .padding(14)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color.rfSurfaceContainer)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
                             }
-                            .foregroundColor(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 16)
-                            .background(Color.rfError)
-                            .clipShape(RoundedRectangle(cornerRadius: 16))
+
+                            NavigationLink {
+                                DeleteAccountResultsView(scan: scan)
+                            } label: {
+                                HStack {
+                                    Image(systemName: scan.hasErrors ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                                        .foregroundColor(scan.hasErrors ? Color.rfError : Color.rfOnline)
+                                    Text("Continue — \(scan.totalCount) event\(scan.totalCount == 1 ? "" : "s") found")
+                                        .font(RFFont.body(16).bold())
+                                }
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 16)
+                                .background(Color.rfError)
+                                .clipShape(RoundedRectangle(cornerRadius: 16))
+                            }
                         }
 
                     case .failed:
@@ -750,10 +898,13 @@ struct DeleteAccountScanView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.rfSurface, for: .navigationBar)
         .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                if case .scanning = phase {
-                    // Hide during active scan
-                } else {
+            // @ToolbarContentBuilder supports if/else (iOS 16+); cleaner than
+            // a conditional inside a single ToolbarItem (which would reserve
+            // a phantom slot when the inner content is EmptyView).
+            if case .scanning = phase {
+                // No toolbar item during active scan — prevents accidental cancel.
+            } else {
+                ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                         .foregroundColor(Color.rfOnSurfaceVariant)
                 }
@@ -823,9 +974,18 @@ struct DeleteAccountResultsView: View {
                                 .font(RFFont.title(15))
                                 .foregroundColor(Color.rfOnSurface)
                         }
-                        Text("Found **\(scan.roadflareCount)** RoadFlare event\(scan.roadflareCount == 1 ? "" : "s") and **\(scan.metadataCount)** Nostr profile event\(scan.metadataCount == 1 ? "" : "s") across \(scan.targetRelayURLs.count) relays.")
-                            .font(RFFont.body(14))
-                            .foregroundColor(Color.rfOnSurfaceVariant)
+                        // Use Text concatenation rather than markdown in interpolation —
+                        // SwiftUI's markdown-via-LocalizedStringKey behaviour with
+                        // \() interpolation is unreliable; concatenation is guaranteed.
+                        (
+                            Text("Found ")
+                            + Text("\(scan.roadflareCount)").bold().foregroundColor(Color.rfOnSurface)
+                            + Text(" RoadFlare event\(scan.roadflareCount == 1 ? "" : "s") and ")
+                            + Text("\(scan.metadataCount)").bold().foregroundColor(Color.rfOnSurface)
+                            + Text(" Nostr profile event\(scan.metadataCount == 1 ? "" : "s") across \(scan.targetRelayURLs.count) relays.")
+                        )
+                        .font(RFFont.body(14))
+                        .foregroundColor(Color.rfOnSurfaceVariant)
                     }
                     .padding(16)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -929,14 +1089,20 @@ struct DeleteAccountResultsView: View {
 
     private func performRoadflareDeletion() async {
         isDeleting = true
+        // defer guarantees the UI is unstuck if deletion ever stops short of logout
+        // (e.g. future code path that doesn't call logout). Today, logout() replaces
+        // the view tree before this defer fires; this is purely defensive.
+        defer { isDeleting = false }
         _ = await appState.deleteRoadflareEvents(from: scan)
-        // logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed
+        // logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed.
+        // Publish failures are logged via AppLogger.auth.error in AppState (visible in Console.app).
     }
 
     private func performFullDeletion() async {
         isDeleting = true
+        defer { isDeleting = false }
         _ = await appState.deleteAllRidestrEvents(from: scan)
-        // logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed
+        // logout() sets authState = .loggedOut → RootView replaces MainTabView → sheet dismissed.
     }
 }
 
@@ -1149,7 +1315,13 @@ git commit -m "feat(ui): wire Delete Account into Settings tab"
 If the scan finds 0 events (new account, never published), the Continue button shows "0 events found" and Page 2's buttons still work — `deleteRoadflareEvents` with empty scan returns `publishedSuccessfully: true` and proceeds to `logout()`.
 
 ### Relay connection lost after scan
-If the relay disconnects between scan and delete, `publish()` throws and the `RelayDeletionResult.publishError` captures it. The deletion methods still call `logout()` to complete local cleanup — the user has already committed to deleting.
+If the relay disconnects between scan and delete, `publish()` throws and the `RelayDeletionResult.publishError` captures it. AppState logs the failure via `AppLogger.auth.error` (visible in Console.app for diagnostics) and still calls `logout()` to complete local cleanup — the user has already committed to deleting.
+
+### Relay connection dead before scan (backgrounded app)
+`scanRelaysForDeletion()` calls `await relayManager.reconnectIfNeeded()` before scanning. This handles the case where the WebSocket died while the app was backgrounded — without this, `fetchEvents` would silently throw and the user would see "0 events found" wrongly.
+
+### Scan errors surfaced to user
+If a relay query throws (e.g. timeout, connection refused), the error is captured in `RelayScanResult.scanErrors` rather than silently dropped. Page 1 displays a "Scan incomplete" warning above the Continue button. The user can still proceed but is informed that some events may not be deleted. This prevents the "I confidently deleted my account but my events are still on relays" footgun.
 
 ### Deletion is best-effort
 NIP-09 Kind 5 is advisory. The "About Nostr & Account Deletion" explainer sets expectations. Page 2's button descriptions reinforce this ("Removes... from relays" / "requests deletion").
@@ -1172,6 +1344,8 @@ Intentionally NOT cleared (same as logout). Prevents stale-key detection on next
 - [ ] Page 1 shows relay list and a collapsible "About Nostr & Account Deletion" explainer
 - [ ] Page 1 "Scan Relays" queries all 12 Ridestr kinds + Kind 0 and shows progress
 - [ ] Page 1 shows event count and enables Continue after scan completes
+- [ ] Page 1 surfaces scan errors in a warning banner when relays were unreachable (not silent 0)
+- [ ] Page 1 calls `reconnectIfNeeded()` before scanning to handle dead background WebSockets
 - [ ] Page 1 Cancel button is always visible except during scan
 - [ ] Page 2 shows scan result summary (RoadFlare events + metadata events)
 - [ ] Page 2 "Delete RoadFlare Events" shows simple "are you sure?" confirmation
@@ -1180,7 +1354,10 @@ Intentionally NOT cleared (same as logout). Prevents stale-key detection on next
 - [ ] RoadFlare deletion targets only the 12 Ridestr kinds (not Kind 0)
 - [ ] Full deletion targets all 12 + Kind 0 metadata
 - [ ] Both options clear all local data and return app to onboarding after relay deletion
+- [ ] Publish failures are logged via `AppLogger.auth.error` for diagnostic visibility
 - [ ] Mid-ride: scan fails with a clear error message
+- [ ] Not-logged-in: `scanRelaysForDeletion()` throws `servicesNotReady` (covered by AppState test)
 - [ ] Page 2 back button navigates to scan results; hidden during deletion
-- [ ] All SDK tests pass
+- [ ] All SDK tests pass (10 tests including scan-error path)
+- [ ] AppState tests pass (2 new tests for deletion guards)
 - [ ] Full Xcode project builds clean (`xcodebuild build`)


### PR DESCRIPTION
## Summary

Adds an in-app Delete Account flow (closes #51, App Store 5.1.1(v) compliance) that publishes NIP-09 Kind 5 deletion requests to relays, verifies with relays that the deletion was honoured, and then tears down the local keypair and all local state.

See [ADR-0010](decisions/0010-account-deletion-service.md) for design rationale — SDK vs. app split, single-button UX, logout-timing invariant, retry choice, and flush-skip on scan.

## End-to-end flow (Settings → Welcome)

1. **Settings → Delete Account** — opens `DeleteAccountSheet` in a NavigationStack.
2. **Page 1 — Relay Scan** — auto-scans on appear (no redundant "Scan Relays" button). Shows relay list with live status dots, a "Scan Complete" summary card once done, and a plain red **Continue** button. Errors per-relay are surfaced honestly (no silent "0 events" footgun); active-ride state is rejected with `AccountDeletionError.activeRideInProgress`.
3. **Page 2 — Review & Confirm** — scan summary card + three inline acknowledgement checkboxes ("deletes all my RoadFlare / Ridestr / Nostr profile events", "may affect other Nostr apps", "this action cannot be undone"). **Delete My Account** button is grey/disabled until all three are checked, flips to red when ready.
4. **Publishing / Verifying** — publishes Kind 5 via `publishWithRetry` (critical, non-retryable after logout), then re-scans relays after a 2s settle to count how many of the requested events were actually honoured.
5. **Success screen** — big green checkmark, "Account Deletion Successful", **Done** button. On clean success: no detail line (keeps happy path uncluttered). On partial/error: honest explainer line appears.
6. **Done** — tapping triggers `logout()` → `authState = .loggedOut` → `RootView` replaces `MainTabView` with `WelcomeView`.

## Architecture

- **`AccountDeletionService`** (RidestrSDK) — stateless `public final class … Sendable`. Exposes `scanRelays()`, `deleteRoadflareEvents(from:)`, `deleteAllRidestrEvents(from:)`, and `verifyDeletion(targetEventIds:settleDelay:)`. Builds Kind 5 events via existing `RideshareEventBuilder.deletion` and publishes with `publishWithRetry`. Concurrent fetches with `async let`.
- **`AppState.scanRelaysForDeletion()`** — guards `activeRideInProgress`, reconnects without flushing (flushing would push dirty state to relays just before deletion), restores ride subscriptions so they survive sheet-cancel.
- **`AppState.publishAccountDeletion(from:)`** — publishes Kind 5 but deliberately does NOT call `logout()`. The caller owns logout timing so the keypair stays alive through the verification step.
- **`AppState.verifyAccountDeletion(eventIds:)`** — delegates to the service's `verifyDeletion`, re-scanning relays and counting how many requested events are still visible.
- **`AppState.logout()`** — only fires on the success screen's Done tap, never on publish failure (publish failure preserves the session so the user can retry or abandon; destroying the keypair on failure would strand events on relays with no retry path).
- **Design system additions:** `RFDestructiveButtonStyle` (solid red CTA, supports `isDisabled` grey state) and `RFDestructiveSecondaryButtonStyle` (outlined destructive). Existing Log Out button uses the secondary style.

## Test Plan

### Automated (passing)
- [x] 9 SDK tests in `AccountDeletionServiceTests` (scan/delete/error paths, kind list contracts) — all passing
- [x] 2 AppState tests covering services-not-ready guards
- [x] Full SDK suite: 821 tests passing
- [x] `xcodebuild build` + `xcodebuild test` clean on iPhone 17 Pro / iOS 26.2

### Manual QA
- [ ] Settings → Delete Account opens the sheet; page 1 auto-scans without user input
- [ ] Scan-complete summary card shows correct event counts and relay count
- [ ] Continue button is plain red (no icon/status); tap navigates to page 2
- [ ] Page 2 Delete My Account button is grey until all 3 checkboxes checked, turns red when all checked
- [ ] Tap Delete My Account → "Deleting…" status → post-publish verification → success screen
- [ ] Success screen shows checkmark + "Account Deletion Successful" + Done (clean case has no detail line)
- [ ] Done tap returns to Welcome screen
- [ ] Mid-ride: scan shows "You have an active ride" error
- [ ] Relay unreachable during scan: "Scan incomplete" banner with per-relay errors
- [ ] Airplane mode during publish: session preserved, "Deletion request failed" banner renders, user can retry
- [ ] Back button on page 2 hidden during publishing/verifying/success (only Done exits)
- [ ] Partial deletion: success screen shows "X of Y confirmed removed" detail

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)