### PR TITLE
chore(gitignore): exclude .claude/worktrees/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ fastlane/test_output
 # Contributors regenerate via `npx gitnexus@1.5.3 setup`.
 CLAUDE.md
 AGENTS.md
+
+# Claude Code per-session worktrees. `.claude/` itself is intentionally tracked
+# (contains .claude/CLAUDE.md and .claude/skills/gitnexus/**), but the
+# `.claude/worktrees/` subdirectory is local session scratch space created by
+# the Claude Code CLI — never repo content.
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Adds \`.claude/worktrees/\` to \`.gitignore\` so Claude Code's per-session scratch worktrees don't show up as untracked in the main working tree.

## Issue solved

Running \`git status\` on this repo was reporting:

\`\`\`
Untracked files:
    .claude/worktrees/
\`\`\`

Without this ignore rule, a careless \`git add .\` would stage the entire nested worktree directory tree. The contents are not repo content — they're runtime state created by the Claude Code CLI when it sandboxes a session into its own git worktree.

## Why scope to the subdirectory instead of \`.claude/\`

\`.claude/\` itself is **intentionally tracked** — it holds:
- \`.claude/CLAUDE.md\` (project instructions)
- \`.claude/skills/gitnexus/**\` (GitNexus skill configs)

Blanket-ignoring \`.claude/\` would break those. Only \`.claude/worktrees/\` is session-local runtime state.

## Verification

\`\`\`
$ git check-ignore -v .claude/worktrees/sad-curie
.gitignore:45:.claude/worktrees/    .claude/worktrees/sad-curie

$ git check-ignore -v .claude/CLAUDE.md
(no output — not ignored, still tracked)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)