### PR TITLE
refactor: coordinator boundary review + AppState façade (#50 + #48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ AGENTS.md
 # `.claude/worktrees/` subdirectory is local session scratch space created by
 # the Claude Code CLI — never repo content.
 .claude/worktrees/
+
+# Project-local parallel worktrees (feature work, never repo content)
+.worktrees/

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
@@ -170,6 +170,20 @@ public final class FollowedDriversRepository: @unchecked Sendable {
         lock.withLock { driverPingPreflightLocked(driverPubkey: driverPubkey) }
     }
 
+    /// Returns `true` when `driver` is a valid target for a ride request.
+    ///
+    /// The check is a single atomic snapshot across `staleKeyPubkeys` and `driverLocations`
+    /// so a mid-read mutation from a background sync cannot observe inconsistent state.
+    /// Criteria: the driver exists in the repo, has a current RoadFlare key, the key is not
+    /// marked stale, and the driver's last-broadcast status is `online`.
+    ///
+    /// This is the ride-side parallel of `canPingDriver`: both check `hasKey` and
+    /// `!isStale`, but `canPingDriver` requires the driver to be offline while
+    /// `canRequestRide` requires them to be online.
+    public func canRequestRide(_ driver: FollowedDriver) -> Bool {
+        lock.withLock { canRequestRideLocked(driverPubkey: driver.pubkey) }
+    }
+
     // MARK: - Driver Names
 
     /// Cache a driver's display name from their Nostr profile.
@@ -440,6 +454,15 @@ public final class FollowedDriversRepository: @unchecked Sendable {
         let status = driverLocations[driver.pubkey]?.status
         guard status != "online" && status != "on_ride" else { return .ineligible }
         return nil
+    }
+
+    private func canRequestRideLocked(driverPubkey: String) -> Bool {
+        guard let driver = drivers.first(where: { $0.pubkey == driverPubkey }) else {
+            return false
+        }
+        guard driver.hasKey else { return false }
+        guard !staleKeyPubkeys.contains(driverPubkey) else { return false }
+        return driverLocations[driverPubkey]?.status == "online"
     }
 }
 

--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -185,7 +185,7 @@ struct AddDriverSheet: View {
             }
 
             // Already following check
-            if appState.driversRepository?.isFollowing(pubkey: hexPubkey) == true {
+            if appState.isFollowingDriver(pubkey: hexPubkey) {
                 Label("You're already following this driver", systemImage: "checkmark.circle.fill")
                     .font(RFFont.body(15))
                     .foregroundColor(Color.rfOnline)
@@ -281,16 +281,10 @@ struct AddDriverSheet: View {
         // Fetch driver's Kind 0 profile from Nostr, then show the card
         isFetchingProfile = true
         Task {
-            await fetchDriverProfile(hexPubkey)
+            resolvedProfile = await appState.fetchDriverProfile(pubkey: hexPubkey)
             resolvedHexPubkey = hexPubkey
             isFetchingProfile = false
         }
-    }
-
-    private func fetchDriverProfile(_ hexPubkey: String) async {
-        guard let service = appState.roadflareDomainService else { return }
-        let profiles = await service.fetchDriverProfiles(pubkeys: [hexPubkey])
-        resolvedProfile = profiles[hexPubkey]?.value
     }
 
     // MARK: - Add Driver
@@ -302,14 +296,7 @@ struct AddDriverSheet: View {
             name: name,
             note: noteInput.isEmpty ? nil : noteInput
         )
-        appState.driversRepository?.addDriver(driver)
-
-        // Cache the driver's full profile if we fetched it
-        if let profile = resolvedProfile {
-            appState.driversRepository?.cacheDriverProfile(pubkey: hexPubkey, profile: profile)
-        } else if let name, !name.isEmpty {
-            appState.driversRepository?.cacheDriverName(pubkey: hexPubkey, name: name)
-        }
+        appState.addDriver(driver, profile: resolvedProfile, name: name)
 
         // Publish Kind 30011 (source of truth) + Kind 3187 (real-time nudge to driver).
         // On re-add, try to restore the key from Kind 30011 on the relay first.
@@ -319,11 +306,11 @@ struct AddDriverSheet: View {
             await appState.sendFollowNotification(driverPubkey: hexPubkey)
 
             // If no key locally, try restoring from our Kind 30011 backup on the relay
-            if appState.driversRepository?.getRoadflareKey(driverPubkey: hexPubkey) == nil {
+            if !appState.hasKeyForDriver(pubkey: hexPubkey) {
                 await appState.restoreKeyFromBackup(driverPubkey: hexPubkey)
             }
             // If still no key after restore attempt, request from driver
-            if appState.driversRepository?.getRoadflareKey(driverPubkey: hexPubkey) == nil {
+            if !appState.hasKeyForDriver(pubkey: hexPubkey) {
                 await appState.rideCoordinator?.requestKeyRefresh(driverPubkey: hexPubkey)
             }
         }

--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -302,7 +302,7 @@ struct AddDriverSheet: View {
         // On re-add, try to restore the key from Kind 30011 on the relay first.
         // If still no key, send a stale ack to request one from the driver.
         Task {
-            await appState.rideCoordinator?.publishFollowedDriversList()
+            await appState.publishDriversList()
             await appState.sendFollowNotification(driverPubkey: hexPubkey)
 
             // If no key locally, try restoring from our Kind 30011 backup on the relay
@@ -311,7 +311,7 @@ struct AddDriverSheet: View {
             }
             // If still no key after restore attempt, request from driver
             if !appState.hasKeyForDriver(pubkey: hexPubkey) {
-                await appState.rideCoordinator?.requestKeyRefresh(driverPubkey: hexPubkey)
+                await appState.requestDriverKeyRefresh(driverPubkey: hexPubkey)
             }
         }
 

--- a/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
@@ -102,7 +102,9 @@ struct DriverDetailSheet: View {
     }
 
     private var canRequestRide: Bool {
-        currentDriver.hasKey && currentLocation?.status == "online"
+        currentDriver.hasKey
+            && !appState.isDriverKeyStale(pubkey: driver.pubkey)
+            && currentLocation?.status == "online"
     }
 
     private var displayName: String {

--- a/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
@@ -102,9 +102,7 @@ struct DriverDetailSheet: View {
     }
 
     private var canRequestRide: Bool {
-        currentDriver.hasKey
-            && !appState.isDriverKeyStale(pubkey: driver.pubkey)
-            && currentLocation?.status == "online"
+        appState.canRequestRide(currentDriver)
     }
 
     private var displayName: String {

--- a/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
@@ -21,7 +21,7 @@ struct DriverDetailSheet: View {
                     LabeledContent("Name", value: displayName)
                     LabeledContent("Status", value: statusText)
 
-                    if let vehicle = appState.driversRepository?.driverProfiles[driver.pubkey]?.vehicleDescription {
+                    if let vehicle = appState.driverProfile(pubkey: driver.pubkey)?.vehicleDescription {
                         LabeledContent("Vehicle", value: vehicle)
                     }
 
@@ -48,7 +48,7 @@ struct DriverDetailSheet: View {
                     }
                 }
 
-                if let loc = appState.driversRepository?.driverLocations[driver.pubkey] {
+                if let loc = appState.driverLocation(pubkey: driver.pubkey) {
                     Section("Last Known Location") {
                         LabeledContent("Status", value: loc.status)
                         LabeledContent("Last Update", value: formatTimestamp(loc.timestamp))
@@ -75,12 +75,7 @@ struct DriverDetailSheet: View {
 
                 Section {
                     Button("Remove Driver", role: .destructive) {
-                        appState.driversRepository?.removeDriver(pubkey: driver.pubkey)
-                        // Republish updated list and restart location subs with new filter
-                        Task {
-                            await appState.rideCoordinator?.publishFollowedDriversList()
-                            appState.rideCoordinator?.startLocationSubscriptions()
-                        }
+                        appState.removeDriver(pubkey: driver.pubkey)
                         dismiss()
                     }
                 }
@@ -99,11 +94,11 @@ struct DriverDetailSheet: View {
     }
 
     private var currentDriver: FollowedDriver {
-        appState.driversRepository?.getDriver(pubkey: driver.pubkey) ?? driver
+        appState.getDriver(pubkey: driver.pubkey) ?? driver
     }
 
     private var currentLocation: CachedDriverLocation? {
-        appState.driversRepository?.driverLocations[driver.pubkey]
+        appState.driverLocation(pubkey: driver.pubkey)
     }
 
     private var canRequestRide: Bool {
@@ -111,7 +106,7 @@ struct DriverDetailSheet: View {
     }
 
     private var displayName: String {
-        appState.driversRepository?.driverNames[driver.pubkey]
+        appState.driverDisplayName(pubkey: driver.pubkey)
             ?? currentDriver.name
             ?? String(driver.pubkey.prefix(8)) + "..."
     }
@@ -127,16 +122,10 @@ struct DriverDetailSheet: View {
     }
 
     private func persistNoteIfNeeded() {
-        guard let repo = appState.driversRepository else { return }
         let normalized = note.trimmingCharacters(in: .whitespacesAndNewlines)
-        let existing = repo.getDriver(pubkey: driver.pubkey)?.note?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let existing = currentDriver.note?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard normalized != existing else { return }
-
-        repo.updateDriverNote(driverPubkey: driver.pubkey, note: normalized)
-        Task {
-            await appState.rideCoordinator?.publishFollowedDriversList()
-        }
+        appState.updateDriverNote(pubkey: driver.pubkey, note: normalized)
     }
 
     private func formatTimestamp(_ timestamp: Int) -> String {

--- a/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
@@ -363,9 +363,7 @@ struct DriverCard: View {
     }
 
     private var isOnline: Bool {
-        driver.hasKey
-            && !appState.isDriverKeyStale(pubkey: driver.pubkey)
-            && location?.status == "online"
+        appState.canRequestRide(driver)
     }
 
     private var statusText: String {

--- a/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
@@ -21,21 +21,20 @@ struct DriversTab: View {
                 ZStack {
                     Color.rfSurface
 
-                    if let repo = appState.driversRepository, repo.hasDrivers {
+                    if appState.hasFollowedDrivers {
                     ScrollView {
                         VStack(spacing: 16) {
                             // Sorted: online first, then on_ride, then offline
-                            ForEach(sortedDrivers(repo: repo)) { driver in
+                            ForEach(sortedDrivers) { driver in
                                 DriverCard(
                                     driver: driver,
-                                    repo: repo,
                                     onRequest: {
                                         appState.requestRideDriverPubkey = driver.pubkey
                                         appState.selectedTab = 0  // RoadFlare tab
                                     },
                                     onShare: { shareDriver(driver) },
                                     onPing: { pingDriver(driver) },
-                                    onDelete: { removeDriver(driver) },
+                                    onDelete: { appState.removeDriver(pubkey: driver.pubkey) },
                                     onTap: { selectedDriver = driver }
                                 )
                             }
@@ -104,8 +103,8 @@ struct DriversTab: View {
             .sheet(item: $sharingDriver) { driver in
                 DriverShareSheet(
                     driver: driver,
-                    driverName: appState.driversRepository?.driverNames[driver.pubkey] ?? driver.name,
-                    driverProfile: appState.driversRepository?.driverProfiles[driver.pubkey]
+                    driverName: appState.driverDisplayName(pubkey: driver.pubkey) ?? driver.name,
+                    driverProfile: appState.driverProfile(pubkey: driver.pubkey)
                 )
             }
             .refreshable {
@@ -113,7 +112,7 @@ struct DriversTab: View {
             }
             .task {
                 while !Task.isCancelled {
-                    if let rm = appState.relayManager { isOffline = !(await rm.isConnected) }
+                    isOffline = !(await appState.isRelayConnected())
                     try? await Task.sleep(for: .seconds(10))
                 }
             }
@@ -133,7 +132,7 @@ struct DriversTab: View {
         let driverPubkey = driver.pubkey
         Task {
             let result = await appState.sendDriverPing(driverPubkey: driverPubkey)
-            let name = appState.driversRepository?.cachedDriverName(pubkey: driverPubkey)
+            let name = appState.driverDisplayName(pubkey: driverPubkey)
                 ?? String(driverPubkey.prefix(8)) + "..."
             switch result {
             case .sent:
@@ -156,30 +155,21 @@ struct DriversTab: View {
         }
     }
 
-    private func removeDriver(_ driver: FollowedDriver) {
-        appState.driversRepository?.removeDriver(pubkey: driver.pubkey)
-        Task {
-            await appState.rideCoordinator?.publishFollowedDriversList()
-            appState.rideCoordinator?.startLocationSubscriptions()
-        }
-    }
-
     private func refreshDrivers() async {
-        appState.driversRepository?.clearDriverLocations()
-        appState.rideCoordinator?.startLocationSubscriptions()
+        appState.refreshDriverLocations()
         await appState.rideCoordinator?.checkForStaleKeys()
     }
 
     /// Sort drivers: online first, then on_ride, then pending, then offline.
-    private func sortedDrivers(repo: FollowedDriversRepository) -> [FollowedDriver] {
-        repo.drivers.sorted { a, b in
-            driverSortOrder(a, repo: repo) < driverSortOrder(b, repo: repo)
+    private var sortedDrivers: [FollowedDriver] {
+        appState.followedDrivers.sorted { a, b in
+            driverSortOrder(a) < driverSortOrder(b)
         }
     }
 
-    private func driverSortOrder(_ driver: FollowedDriver, repo: FollowedDriversRepository) -> Int {
+    private func driverSortOrder(_ driver: FollowedDriver) -> Int {
         guard driver.hasKey else { return 3 }  // Pending approval
-        guard let loc = repo.driverLocations[driver.pubkey] else { return 4 }  // Offline (no location)
+        guard let loc = appState.driverLocation(pubkey: driver.pubkey) else { return 4 }  // Offline (no location)
         switch loc.status {
         case "online": return 0
         case "on_ride": return 1
@@ -193,17 +183,16 @@ struct DriversTab: View {
 struct DriverCard: View {
     @Environment(AppState.self) private var appState
     let driver: FollowedDriver
-    let repo: FollowedDriversRepository
     let onRequest: () -> Void
     let onShare: () -> Void
     let onPing: () -> Void
     let onDelete: () -> Void
     let onTap: () -> Void
 
-    private var profile: UserProfileContent? { repo.driverProfiles[driver.pubkey] }
-    private var location: CachedDriverLocation? { repo.driverLocations[driver.pubkey] }
+    private var profile: UserProfileContent? { appState.driverProfile(pubkey: driver.pubkey) }
+    private var location: CachedDriverLocation? { appState.driverLocation(pubkey: driver.pubkey) }
     private var displayName: String {
-        repo.driverNames[driver.pubkey] ?? driver.name ?? shortPubkey
+        appState.driverDisplayName(pubkey: driver.pubkey) ?? driver.name ?? shortPubkey
     }
 
     @State private var showDeleteConfirm = false
@@ -371,7 +360,7 @@ struct DriverCard: View {
     // MARK: - Status
 
     private var hasStaleKey: Bool {
-        repo.staleKeyPubkeys.contains(driver.pubkey)
+        appState.isDriverKeyStale(pubkey: driver.pubkey)
     }
 
     private var isOnline: Bool {

--- a/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
@@ -157,7 +157,7 @@ struct DriversTab: View {
 
     private func refreshDrivers() async {
         appState.refreshDriverLocations()
-        await appState.rideCoordinator?.checkForStaleKeys()
+        await appState.checkForStaleDriverKeys()
     }
 
     /// Sort drivers: online first, then on_ride, then pending, then offline.

--- a/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
@@ -127,8 +127,7 @@ struct DriversTab: View {
     private func pingDriver(_ driver: FollowedDriver) {
         // Capture pubkey as a plain String (Sendable) before the task boundary so
         // `driver` (a struct that may not be Sendable) doesn't need to cross the
-        // isolation boundary. The view is @MainActor so the Task body inherits that
-        // isolation; `appState.driversRepository` is accessible without a hop.
+        // isolation boundary.
         let driverPubkey = driver.pubkey
         Task {
             let result = await appState.sendDriverPing(driverPubkey: driverPubkey)
@@ -364,7 +363,9 @@ struct DriverCard: View {
     }
 
     private var isOnline: Bool {
-        driver.hasKey && location?.status == "online"
+        driver.hasKey
+            && !appState.isDriverKeyStale(pubkey: driver.pubkey)
+            && location?.status == "online"
     }
 
     private var statusText: String {

--- a/RoadFlare/RoadFlare/Views/History/HistoryTab.swift
+++ b/RoadFlare/RoadFlare/Views/History/HistoryTab.swift
@@ -16,7 +16,7 @@ struct HistoryTab: View {
                 ZStack {
                     Color.rfSurface
 
-                    if appState.rideHistory.rides.isEmpty {
+                    if appState.rideHistoryEntries.isEmpty {
                     VStack(spacing: 24) {
                         Image(systemName: "clock")
                             .font(.system(size: 48))
@@ -31,14 +31,13 @@ struct HistoryTab: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 12) {
-                            ForEach(appState.rideHistory.rides) { ride in
+                            ForEach(appState.rideHistoryEntries) { ride in
                                 SwipeToDeleteRow {
                                     // History cards are currently read-only.
                                 } onDelete: {
                                     withAnimation {
-                                        appState.rideHistory.removeRide(id: ride.id)
+                                        appState.removeRideHistoryEntry(id: ride.id)
                                     }
-                                    appState.rideCoordinator?.backupRideHistory()
                                 } content: {
                                     RideHistoryCard(ride: ride)
                                 }
@@ -56,7 +55,7 @@ struct HistoryTab: View {
             .sheet(isPresented: $showConnectivity) { ConnectivitySheet() }
             .task {
                 while !Task.isCancelled {
-                    if let rm = appState.relayManager { isOffline = !(await rm.isConnected) }
+                    isOffline = !(await appState.isRelayConnected())
                     try? await Task.sleep(for: .seconds(10))
                 }
             }

--- a/RoadFlare/RoadFlare/Views/Ride/ActiveRideView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/ActiveRideView.swift
@@ -21,7 +21,7 @@ struct ActiveRideView: View {
             paymentMethods: coordinator?.activeRidePaymentMethods
                 ?? appState.settings.roadflarePaymentMethods,
             driverName: coordinator?.session.driverPubkey.flatMap {
-                appState.driversRepository?.cachedDriverName(pubkey: $0)
+                appState.driverDisplayName(pubkey: $0)
             },
             pickupAddress: coordinator?.pickupLocation?.address,
             destinationAddress: coordinator?.destinationLocation?.address,

--- a/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
@@ -195,7 +195,7 @@ struct RideRequestView: View {
                             HStack {
                                 Image(systemName: "creditcard")
                                     .foregroundColor(Color.rfPrimary)
-                                Text(appState.settings.allPaymentMethodNames.joined(separator: ", "))
+                                Text(appState.allPaymentMethodNames.joined(separator: ", "))
                                     .font(RFFont.caption(12))
                                     .foregroundColor(Color.rfOnSurfaceVariant)
                             }

--- a/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
@@ -22,11 +22,7 @@ struct RideRequestView: View {
     private var coordinator: RideCoordinator? { appState.rideCoordinator }
     private var stage: RiderStage { coordinator?.session.stage ?? .idle }
     private var onlineDrivers: [FollowedDriver] {
-        appState.followedDrivers.filter { driver in
-            driver.hasKey
-                && !appState.isDriverKeyStale(pubkey: driver.pubkey)
-                && appState.driverLocation(pubkey: driver.pubkey)?.status == "online"
-        }
+        appState.followedDrivers.filter { appState.canRequestRide($0) }
     }
     private var onlineDriverPubkeys: [String] { onlineDrivers.map(\.pubkey) }
     private var hasValidSelectedDriver: Bool {

--- a/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
@@ -23,7 +23,9 @@ struct RideRequestView: View {
     private var stage: RiderStage { coordinator?.session.stage ?? .idle }
     private var onlineDrivers: [FollowedDriver] {
         appState.followedDrivers.filter { driver in
-            driver.hasKey && appState.driverLocation(pubkey: driver.pubkey)?.status == "online"
+            driver.hasKey
+                && !appState.isDriverKeyStale(pubkey: driver.pubkey)
+                && appState.driverLocation(pubkey: driver.pubkey)?.status == "online"
         }
     }
     private var onlineDriverPubkeys: [String] { onlineDrivers.map(\.pubkey) }

--- a/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
@@ -40,8 +40,27 @@ struct RideRequestView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
-                if appState.hasFollowedDrivers {
-                    if onlineDrivers.isEmpty {
+                if !appState.hasFollowedDrivers {
+                    VStack(spacing: 24) {
+                        Spacer().frame(height: 80)
+                        Image(systemName: "person.2")
+                            .font(.system(size: 48))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                        Text("No Drivers Added")
+                            .font(RFFont.headline(20))
+                            .foregroundColor(Color.rfOnSurface)
+                        Text("Add trusted drivers to your network to request a ride.")
+                            .font(RFFont.body(15))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 32)
+                        Button("Add a Driver") {
+                            appState.selectedTab = 1
+                        }
+                        .buttonStyle(RFPrimaryButtonStyle())
+                        .padding(.horizontal, 48)
+                    }
+                } else if onlineDrivers.isEmpty {
                         VStack(spacing: 24) {
                             Spacer().frame(height: 80)
                             Image(systemName: "car.side")
@@ -63,193 +82,192 @@ struct RideRequestView: View {
                                 .padding(.horizontal, 48)
                             }
                         }
-                    } else {
-                        // Available drivers
-                        VStack(alignment: .leading, spacing: 8) {
-                            SectionLabel("Available Drivers")
-                            ForEach(onlineDrivers) { driver in
-                                Button { selectedDriverPubkey = driver.pubkey } label: {
-                                    HStack(spacing: 12) {
-                                        FlareIndicator(color: selectedDriverPubkey == driver.pubkey ? .rfPrimary : .rfOnline)
-                                            .frame(height: 36)
-                                        VStack(alignment: .leading, spacing: 2) {
-                                            Text(displayName(for: driver))
-                                                .font(RFFont.title(15))
-                                                .foregroundColor(Color.rfOnSurface)
-                                            Text("Available")
-                                                .font(RFFont.caption(11))
-                                                .foregroundColor(Color.rfOnline)
-                                        }
-                                        Spacer()
-                                        if selectedDriverPubkey == driver.pubkey {
-                                            Image(systemName: "checkmark.circle.fill")
-                                                .foregroundColor(Color.rfPrimary)
-                                        }
+                } else {
+                    // Available drivers
+                    VStack(alignment: .leading, spacing: 8) {
+                        SectionLabel("Available Drivers")
+                        ForEach(onlineDrivers) { driver in
+                            Button { selectedDriverPubkey = driver.pubkey } label: {
+                                HStack(spacing: 12) {
+                                    FlareIndicator(color: selectedDriverPubkey == driver.pubkey ? .rfPrimary : .rfOnline)
+                                        .frame(height: 36)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(displayName(for: driver))
+                                            .font(RFFont.title(15))
+                                            .foregroundColor(Color.rfOnSurface)
+                                        Text("Available")
+                                            .font(RFFont.caption(11))
+                                            .foregroundColor(Color.rfOnline)
                                     }
-                                    .rfCard(selectedDriverPubkey == driver.pubkey ? .high : .standard)
+                                    Spacer()
+                                    if selectedDriverPubkey == driver.pubkey {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .foregroundColor(Color.rfPrimary)
+                                    }
+                                }
+                                .rfCard(selectedDriverPubkey == driver.pubkey ? .high : .standard)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
+                    // Ride details
+                    if hasValidSelectedDriver {
+                        VStack(alignment: .leading, spacing: 14) {
+                            SectionLabel("Ride Details")
+
+                            HStack(spacing: 0) {
+                                VStack(spacing: 0) {
+                                    AddressSearchField(
+                                        placeholder: "Pickup address",
+                                        icon: "circle.fill",
+                                        iconColor: .rfOnline,
+                                        text: $pickupAddress,
+                                        onSelect: { _ in recalculateFare() },
+                                        onResolvedLocation: { lat, lon in resolvedPickupCoord = Coordinate(lat: lat, lon: lon) },
+                                        showCurrentLocation: true,
+                                        onUseCurrentLocation: { useCurrentLocation() },
+                                        savedLocations: recentLocationItems
+                                    )
+
+                                    Rectangle().fill(Color.rfSurfaceContainerHigh).frame(height: 1).padding(.leading, 32)
+
+                                    AddressSearchField(
+                                        placeholder: "Destination",
+                                        icon: "circle.fill",
+                                        iconColor: .rfPrimary,
+                                        text: $destinationAddress,
+                                        onSelect: { _ in recalculateFare() },
+                                        onResolvedLocation: { lat, lon in resolvedDestCoord = Coordinate(lat: lat, lon: lon) },
+                                        savedLocations: recentLocationItems
+                                    )
+                                }
+
+                                // Swap button
+                                Button {
+                                    let temp = pickupAddress
+                                    pickupAddress = destinationAddress
+                                    destinationAddress = temp
+                                    let tempCoord = resolvedPickupCoord
+                                    resolvedPickupCoord = resolvedDestCoord
+                                    resolvedDestCoord = tempCoord
+                                    coordinator?.currentFareEstimate = nil
+                                    recalculateFare()
+                                } label: {
+                                    Image(systemName: "arrow.up.arrow.down")
+                                        .font(.system(size: 14, weight: .semibold))
+                                        .foregroundColor(Color.rfOnSurfaceVariant)
+                                        .frame(width: 36, height: 36)
+                                        .background(Color.rfSurfaceContainerHigh)
+                                        .clipShape(Circle())
                                 }
                                 .buttonStyle(.plain)
+                                .padding(.trailing, 8)
                             }
-                        }
+                            .background(Color.rfSurfaceContainer)
+                            .clipShape(RoundedRectangle(cornerRadius: 16))
 
-                        // Ride details
-                        if hasValidSelectedDriver {
-                            VStack(alignment: .leading, spacing: 14) {
-                                SectionLabel("Ride Details")
-
-                                HStack(spacing: 0) {
-                                    VStack(spacing: 0) {
-                                        AddressSearchField(
-                                            placeholder: "Pickup address",
-                                            icon: "circle.fill",
-                                            iconColor: .rfOnline,
-                                            text: $pickupAddress,
-                                            onSelect: { _ in recalculateFare() },
-                                            onResolvedLocation: { lat, lon in resolvedPickupCoord = Coordinate(lat: lat, lon: lon) },
-                                            showCurrentLocation: true,
-                                            onUseCurrentLocation: { useCurrentLocation() },
-                                            savedLocations: recentLocationItems
-                                        )
-
-                                        Rectangle().fill(Color.rfSurfaceContainerHigh).frame(height: 1).padding(.leading, 32)
-
-                                        AddressSearchField(
-                                            placeholder: "Destination",
-                                            icon: "circle.fill",
-                                            iconColor: .rfPrimary,
-                                            text: $destinationAddress,
-                                            onSelect: { _ in recalculateFare() },
-                                            onResolvedLocation: { lat, lon in resolvedDestCoord = Coordinate(lat: lat, lon: lon) },
-                                            savedLocations: recentLocationItems
-                                        )
-                                    }
-
-                                    // Swap button
-                                    Button {
-                                        let temp = pickupAddress
-                                        pickupAddress = destinationAddress
-                                        destinationAddress = temp
-                                        let tempCoord = resolvedPickupCoord
-                                        resolvedPickupCoord = resolvedDestCoord
-                                        resolvedDestCoord = tempCoord
-                                        coordinator?.currentFareEstimate = nil
-                                        recalculateFare()
-                                    } label: {
-                                        Image(systemName: "arrow.up.arrow.down")
-                                            .font(.system(size: 14, weight: .semibold))
-                                            .foregroundColor(Color.rfOnSurfaceVariant)
-                                            .frame(width: 36, height: 36)
-                                            .background(Color.rfSurfaceContainerHigh)
-                                            .clipShape(Circle())
-                                    }
-                                    .buttonStyle(.plain)
-                                    .padding(.trailing, 8)
+                            if isCalculatingFare {
+                                HStack {
+                                    ProgressView().tint(Color.rfPrimary)
+                                    Text("Calculating fare...")
+                                        .font(RFFont.body(14))
+                                        .foregroundColor(Color.rfOnSurfaceVariant)
+                                    Spacer()
                                 }
-                                .background(Color.rfSurfaceContainer)
-                                .clipShape(RoundedRectangle(cornerRadius: 16))
-
-                                if isCalculatingFare {
+                                .rfCard(.high)
+                            } else if let fare = coordinator?.currentFareEstimate {
+                                VStack(spacing: 6) {
                                     HStack {
-                                        ProgressView().tint(Color.rfPrimary)
-                                        Text("Calculating fare...")
-                                            .font(RFFont.body(14))
+                                        Text(String(format: "%.1f mi · %.0f min", fare.distanceMiles, fare.durationMinutes))
+                                            .font(RFFont.caption())
                                             .foregroundColor(Color.rfOnSurfaceVariant)
                                         Spacer()
+                                        Text(formatFare(fare.fareUSD))
+                                            .font(RFFont.headline(24))
+                                            .foregroundColor(Color.rfPrimary)
                                     }
-                                    .rfCard(.high)
-                                } else if let fare = coordinator?.currentFareEstimate {
-                                    VStack(spacing: 6) {
-                                        HStack {
-                                            Text(String(format: "%.1f mi · %.0f min", fare.distanceMiles, fare.durationMinutes))
-                                                .font(RFFont.caption())
-                                                .foregroundColor(Color.rfOnSurfaceVariant)
-                                            Spacer()
-                                            Text(formatFare(fare.fareUSD))
-                                                .font(RFFont.headline(24))
-                                                .foregroundColor(Color.rfPrimary)
-                                        }
-                                    }
-                                    .rfCard(.high)
                                 }
+                                .rfCard(.high)
+                            }
 
-                                // Payment info
-                                HStack {
-                                    Image(systemName: "creditcard")
-                                        .foregroundColor(Color.rfPrimary)
-                                    Text(appState.settings.allPaymentMethodNames.joined(separator: ", "))
-                                        .font(RFFont.caption(12))
-                                        .foregroundColor(Color.rfOnSurfaceVariant)
+                            // Payment info
+                            HStack {
+                                Image(systemName: "creditcard")
+                                    .foregroundColor(Color.rfPrimary)
+                                Text(appState.settings.allPaymentMethodNames.joined(separator: ", "))
+                                    .font(RFFont.caption(12))
+                                    .foregroundColor(Color.rfOnSurfaceVariant)
+                            }
+                            .padding(.horizontal, 4)
+
+                            if let error = fareError {
+                                Text(error).font(RFFont.caption()).foregroundColor(Color.rfError)
+                            }
+
+                            // Show send button only when fare is calculated
+                            if coordinator?.currentFareEstimate != nil && !isCalculatingFare {
+                                Button { sendOffer() } label: {
+                                    Text("Send RoadFlare Request")
                                 }
-                                .padding(.horizontal, 4)
-
-                                if let error = fareError {
-                                    Text(error).font(RFFont.caption()).foregroundColor(Color.rfError)
-                                }
-
-                                // Show send button only when fare is calculated
-                                if coordinator?.currentFareEstimate != nil && !isCalculatingFare {
-                                    Button { sendOffer() } label: {
-                                        Text("Send RoadFlare Request")
-                                    }
-                                    .buttonStyle(RFPrimaryButtonStyle())
-                                } else if pickupAddress.isEmpty || destinationAddress.isEmpty {
-                                    // Show saved locations as quick picks
-                                    VStack(alignment: .leading, spacing: 8) {
-                                        // Favorites
-                                        ForEach(appState.favoriteLocations) { loc in
-                                            Button {
-                                                fillNextAddress(loc)
-                                            } label: {
-                                                HStack(spacing: 10) {
-                                                    Image(systemName: iconForLocation(loc.nickname ?? loc.displayName))
-                                                        .font(.system(size: 13))
-                                                        .foregroundColor(Color.rfPrimary)
-                                                        .frame(width: 20)
-                                                    VStack(alignment: .leading, spacing: 1) {
-                                                        Text(loc.nickname ?? loc.displayName)
-                                                            .font(RFFont.title(13))
-                                                            .foregroundColor(Color.rfOnSurface)
-                                                        Text(loc.addressLine)
-                                                            .font(RFFont.caption(11))
-                                                            .foregroundColor(Color.rfOnSurfaceVariant)
-                                                            .lineLimit(1)
-                                                    }
-                                                    Spacer()
+                                .buttonStyle(RFPrimaryButtonStyle())
+                            } else if pickupAddress.isEmpty || destinationAddress.isEmpty {
+                                // Show saved locations as quick picks
+                                VStack(alignment: .leading, spacing: 8) {
+                                    // Favorites
+                                    ForEach(appState.favoriteLocations) { loc in
+                                        Button {
+                                            fillNextAddress(loc)
+                                        } label: {
+                                            HStack(spacing: 10) {
+                                                Image(systemName: iconForLocation(loc.nickname ?? loc.displayName))
+                                                    .font(.system(size: 13))
+                                                    .foregroundColor(Color.rfPrimary)
+                                                    .frame(width: 20)
+                                                VStack(alignment: .leading, spacing: 1) {
+                                                    Text(loc.nickname ?? loc.displayName)
+                                                        .font(RFFont.title(13))
+                                                        .foregroundColor(Color.rfOnSurface)
+                                                    Text(loc.addressLine)
+                                                        .font(RFFont.caption(11))
+                                                        .foregroundColor(Color.rfOnSurfaceVariant)
+                                                        .lineLimit(1)
                                                 }
-                                                .padding(10)
-                                                .background(Color.rfSurfaceContainer)
-                                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                                                Spacer()
                                             }
-                                            .buttonStyle(.plain)
+                                            .padding(10)
+                                            .background(Color.rfSurfaceContainer)
+                                            .clipShape(RoundedRectangle(cornerRadius: 12))
                                         }
+                                        .buttonStyle(.plain)
+                                    }
 
-                                        // Recents (swipe left to delete)
-                                        ForEach(appState.recentLocations) { loc in
-                                            SwipeToDeleteRow {
-                                                fillNextAddress(loc)
-                                            } onDelete: {
-                                                withAnimation { appState.removeLocation(id: loc.id) }
-                                            } content: {
-                                                HStack(spacing: 10) {
-                                                    Image(systemName: "clock")
-                                                        .font(.system(size: 13))
-                                                        .foregroundColor(Color.rfOffline)
-                                                        .frame(width: 20)
-                                                    VStack(alignment: .leading, spacing: 1) {
-                                                        Text(loc.displayName)
-                                                            .font(RFFont.body(13))
-                                                            .foregroundColor(Color.rfOnSurface)
-                                                        Text(loc.addressLine)
-                                                            .font(RFFont.caption(11))
-                                                            .foregroundColor(Color.rfOnSurfaceVariant)
-                                                            .lineLimit(1)
-                                                    }
-                                                    Spacer()
+                                    // Recents (swipe left to delete)
+                                    ForEach(appState.recentLocations) { loc in
+                                        SwipeToDeleteRow {
+                                            fillNextAddress(loc)
+                                        } onDelete: {
+                                            withAnimation { appState.removeLocation(id: loc.id) }
+                                        } content: {
+                                            HStack(spacing: 10) {
+                                                Image(systemName: "clock")
+                                                    .font(.system(size: 13))
+                                                    .foregroundColor(Color.rfOffline)
+                                                    .frame(width: 20)
+                                                VStack(alignment: .leading, spacing: 1) {
+                                                    Text(loc.displayName)
+                                                        .font(RFFont.body(13))
+                                                        .foregroundColor(Color.rfOnSurface)
+                                                    Text(loc.addressLine)
+                                                        .font(RFFont.caption(11))
+                                                        .foregroundColor(Color.rfOnSurfaceVariant)
+                                                        .lineLimit(1)
                                                 }
-                                                .padding(10)
-                                                .background(Color.rfSurfaceContainer)
-                                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                                                Spacer()
                                             }
+                                            .padding(10)
+                                            .background(Color.rfSurfaceContainer)
+                                            .clipShape(RoundedRectangle(cornerRadius: 12))
                                         }
                                     }
                                 }

--- a/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
@@ -22,9 +22,8 @@ struct RideRequestView: View {
     private var coordinator: RideCoordinator? { appState.rideCoordinator }
     private var stage: RiderStage { coordinator?.session.stage ?? .idle }
     private var onlineDrivers: [FollowedDriver] {
-        guard let repo = appState.driversRepository else { return [] }
-        return repo.drivers.filter { driver in
-            driver.hasKey && repo.driverLocations[driver.pubkey]?.status == "online"
+        appState.followedDrivers.filter { driver in
+            driver.hasKey && appState.driverLocation(pubkey: driver.pubkey)?.status == "online"
         }
     }
     private var onlineDriverPubkeys: [String] { onlineDrivers.map(\.pubkey) }
@@ -33,7 +32,7 @@ struct RideRequestView: View {
         return onlineDriverPubkeys.contains(selectedDriverPubkey)
     }
     private func displayName(for driver: FollowedDriver) -> String {
-        appState.driversRepository?.driverNames[driver.pubkey]
+        appState.driverDisplayName(pubkey: driver.pubkey)
             ?? driver.name
             ?? String(driver.pubkey.prefix(8)) + "..."
     }
@@ -41,7 +40,7 @@ struct RideRequestView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
-                if appState.driversRepository != nil {
+                if appState.hasFollowedDrivers {
                     if onlineDrivers.isEmpty {
                         VStack(spacing: 24) {
                             Spacer().frame(height: 80)
@@ -56,8 +55,7 @@ struct RideRequestView: View {
                                 .foregroundColor(Color.rfOnSurfaceVariant)
                                 .multilineTextAlignment(.center)
                                 .padding(.horizontal, 32)
-                            if let repo = appState.driversRepository,
-                               repo.drivers.contains(where: { appState.canPingDriver($0) }) {
+                            if appState.followedDrivers.contains(where: { appState.canPingDriver($0) }) {
                                 Button("Ping a Driver") {
                                     appState.selectedTab = 1
                                 }
@@ -198,7 +196,7 @@ struct RideRequestView: View {
                                     // Show saved locations as quick picks
                                     VStack(alignment: .leading, spacing: 8) {
                                         // Favorites
-                                        ForEach(appState.savedLocations.favorites) { loc in
+                                        ForEach(appState.favoriteLocations) { loc in
                                             Button {
                                                 fillNextAddress(loc)
                                             } label: {
@@ -226,11 +224,11 @@ struct RideRequestView: View {
                                         }
 
                                         // Recents (swipe left to delete)
-                                        ForEach(appState.savedLocations.recents) { loc in
+                                        ForEach(appState.recentLocations) { loc in
                                             SwipeToDeleteRow {
                                                 fillNextAddress(loc)
                                             } onDelete: {
-                                                withAnimation { appState.savedLocations.remove(id: loc.id) }
+                                                withAnimation { appState.removeLocation(id: loc.id) }
                                             } content: {
                                                 HStack(spacing: 10) {
                                                     Image(systemName: "clock")
@@ -326,10 +324,10 @@ struct RideRequestView: View {
     }
 
     private var recentLocationItems: [(name: String, address: String, lat: Double, lon: Double)] {
-        let favorites = appState.savedLocations.favorites.map { loc in
+        let favorites = appState.favoriteLocations.map { loc in
             (name: loc.nickname ?? loc.displayName, address: loc.addressLine, lat: loc.latitude, lon: loc.longitude)
         }
-        let recents = appState.savedLocations.recents.prefix(5).map { loc in
+        let recents = appState.recentLocations.prefix(5).map { loc in
             (name: loc.displayName, address: loc.addressLine, lat: loc.latitude, lon: loc.longitude)
         }
         return favorites + recents
@@ -403,12 +401,12 @@ struct RideRequestView: View {
                 coordinator?.pickupLocation = pickup
                 coordinator?.destinationLocation = destination
 
-                appState.savedLocations.save(SavedLocation(
+                appState.saveLocation(SavedLocation(
                     id: UUID().uuidString, latitude: pickup.latitude, longitude: pickup.longitude,
                     displayName: pickupAddress, addressLine: pickup.address ?? pickupAddress,
                     isPinned: false, timestampMs: Int(Date.now.timeIntervalSince1970 * 1000)
                 ))
-                appState.savedLocations.save(SavedLocation(
+                appState.saveLocation(SavedLocation(
                     id: UUID().uuidString, latitude: destination.latitude, longitude: destination.longitude,
                     displayName: destinationAddress, addressLine: destination.address ?? destinationAddress,
                     isPinned: false, timestampMs: Int(Date.now.timeIntervalSince1970 * 1000)

--- a/RoadFlare/RoadFlare/Views/Ride/RideTab.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/RideTab.swift
@@ -91,7 +91,7 @@ struct RideTab: View {
 
     private func monitorConnection() async {
         while !Task.isCancelled {
-            if let rm = appState.relayManager { isOffline = !(await rm.isConnected) }
+            isOffline = !(await appState.isRelayConnected())
             try? await Task.sleep(for: .seconds(10))
         }
     }

--- a/RoadFlare/RoadFlare/Views/Settings/SavedLocationsView.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/SavedLocationsView.swift
@@ -19,7 +19,7 @@ struct SavedLocationsView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         SectionLabel("Favorites")
 
-                        if appState.savedLocations.favorites.isEmpty {
+                        if appState.favoriteLocations.isEmpty {
                             HStack {
                                 Image(systemName: "star")
                                     .foregroundColor(Color.rfOnSurfaceVariant)
@@ -29,7 +29,7 @@ struct SavedLocationsView: View {
                             }
                             .rfCard(.low)
                         } else {
-                            ForEach(appState.savedLocations.favorites) { loc in
+                            ForEach(appState.favoriteLocations) { loc in
                                 Button { editingLocation = loc } label: {
                                     HStack(spacing: 12) {
                                         Image(systemName: iconForNickname(loc.nickname))
@@ -60,7 +60,7 @@ struct SavedLocationsView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         SectionLabel("Recent Locations")
 
-                        if appState.savedLocations.recents.isEmpty {
+                        if appState.recentLocations.isEmpty {
                             HStack {
                                 Image(systemName: "clock")
                                     .foregroundColor(Color.rfOnSurfaceVariant)
@@ -70,11 +70,11 @@ struct SavedLocationsView: View {
                             }
                             .rfCard(.low)
                         } else {
-                            ForEach(appState.savedLocations.recents) { loc in
+                            ForEach(appState.recentLocations) { loc in
                                 SwipeToDeleteRow {
                                     editingLocation = loc
                                 } onDelete: {
-                                    withAnimation { appState.savedLocations.remove(id: loc.id) }
+                                    withAnimation { appState.removeLocation(id: loc.id) }
                                 } content: {
                                     HStack(spacing: 12) {
                                         Image(systemName: "clock")
@@ -104,10 +104,9 @@ struct SavedLocationsView: View {
                         }
                     }
 
-                    if !appState.savedLocations.locations.isEmpty {
+                    if !appState.allSavedLocations.isEmpty {
                         Button("Clear All Locations") {
-                            appState.savedLocations.clearAll()
-                            Task { await appState.publishProfileBackup() }
+                            Task { await appState.clearAllLocations() }
                         }
                         .buttonStyle(RFGhostButtonStyle())
                     }
@@ -239,7 +238,7 @@ struct AddFavoriteSheet: View {
                         isPinned: true, nickname: completion.title,
                         timestampMs: Int(Date.now.timeIntervalSince1970 * 1000)
                     )
-                    appState.savedLocations.save(loc)
+                    appState.saveLocation(loc)
                     await appState.publishProfileBackup()
                 }
             } catch {
@@ -307,7 +306,7 @@ struct EditLocationSheet: View {
                     // Save as favorite
                     if !location.isPinned {
                         Button {
-                            appState.savedLocations.pin(id: location.id, nickname: nickname.isEmpty ? location.displayName : nickname)
+                            appState.pinLocation(id: location.id, nickname: nickname.isEmpty ? location.displayName : nickname)
                             Task { await appState.publishProfileBackup() }
                             dismiss()
                         } label: {
@@ -319,7 +318,7 @@ struct EditLocationSheet: View {
                         // Update nickname
                         Button {
                             if !nickname.isEmpty {
-                                appState.savedLocations.pin(id: location.id, nickname: nickname)
+                                appState.pinLocation(id: location.id, nickname: nickname)
                             }
                             Task { await appState.publishProfileBackup() }
                             dismiss()
@@ -333,7 +332,7 @@ struct EditLocationSheet: View {
 
                     // Delete
                     Button(role: .destructive) {
-                        appState.savedLocations.remove(id: location.id)
+                        appState.removeLocation(id: location.id)
                         Task { await appState.publishProfileBackup() }
                         dismiss()
                     } label: {

--- a/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
@@ -43,9 +43,9 @@ struct SettingsTab: View {
                                             .foregroundColor(Color.rfPrimary)
                                     }
                                     VStack(alignment: .leading, spacing: 2) {
-                                        Text(appState.settings.profileName.isEmpty ? "Set your name" : appState.settings.profileName)
+                                        Text(appState.profileName.isEmpty ? "Set your name" : appState.profileName)
                                             .font(RFFont.title(16))
-                                            .foregroundColor(appState.settings.profileName.isEmpty ? Color.rfOnSurfaceVariant : Color.rfOnSurface)
+                                            .foregroundColor(appState.profileName.isEmpty ? Color.rfOnSurfaceVariant : Color.rfOnSurface)
                                         Text("Edit Profile")
                                             .font(RFFont.caption(12))
                                             .foregroundColor(Color.rfOnSurfaceVariant)
@@ -108,7 +108,7 @@ struct SettingsTab: View {
                                         .font(RFFont.body(15))
                                         .foregroundColor(Color.rfOnSurface)
                                     Spacer()
-                                    Text("\(appState.settings.roadflarePaymentMethods.count)")
+                                    Text("\(appState.paymentMethodCount)")
                                         .font(RFFont.caption(12))
                                         .foregroundColor(Color.rfOnSurfaceVariant)
                                     Image(systemName: "chevron.right")
@@ -371,14 +371,14 @@ struct EditProfileSheet: View {
                 }
             }
             .onAppear {
-                editedName = appState.settings.profileName
+                editedName = appState.profileName
             }
         }
     }
 
     private var hasChanges: Bool {
         let trimmed = editedName.trimmingCharacters(in: .whitespaces)
-        return !trimmed.isEmpty && trimmed != appState.settings.profileName
+        return !trimmed.isEmpty && trimmed != appState.profileName
     }
 
     private func save() {

--- a/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
@@ -78,7 +78,7 @@ struct SettingsTab: View {
                                             .font(RFFont.body(15))
                                             .foregroundColor(Color.rfOnSurface)
                                         Spacer()
-                                        Text("\(appState.savedLocations.favorites.count) favorites")
+                                        Text("\(appState.favoritesCount) favorites")
                                             .font(RFFont.caption(12))
                                             .foregroundColor(Color.rfOnSurfaceVariant)
                                         Image(systemName: "chevron.right")
@@ -162,7 +162,7 @@ struct SettingsTab: View {
                                 }
                                 .buttonStyle(.plain)
                                 Button { appState.selectedTab = 1 } label: {
-                                    SettingsRow(icon: "person.2", label: "Drivers", value: "\(appState.driversRepository?.drivers.count ?? 0)")
+                                    SettingsRow(icon: "person.2", label: "Drivers", value: "\(appState.followedDriverCount)")
                                         .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.plain)

--- a/RoadFlare/RoadFlare/Views/Shared/ConnectivityIndicator.swift
+++ b/RoadFlare/RoadFlare/Views/Shared/ConnectivityIndicator.swift
@@ -121,6 +121,6 @@ struct ConnectivitySheet: View {
     }
 
     private func checkConnection() async {
-        if let rm = appState.relayManager { isConnected = await rm.isConnected }
+        isConnected = await appState.isRelayConnected()
     }
 }

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -707,6 +707,9 @@ extension AppState {
     }
 
     /// Add a driver and cache their profile and name if available.
+    /// Note: unlike `removeDriver` and `updateDriverNote`, this does NOT auto-publish the
+    /// updated list. Call `publishDriversList()` and `sendFollowNotification(driverPubkey:)`
+    /// separately after adding (see `AddDriverSheet.addDriver()`).
     public func addDriver(_ driver: FollowedDriver, profile: UserProfileContent? = nil, name: String? = nil) {
         driversRepository?.addDriver(driver)
         if let profile {
@@ -818,7 +821,7 @@ extension AppState {
     }
 }
 
-// MARK: - Façade: Settings (read-only convenience)
+// MARK: - Façade: Settings (read-only badge and display helpers; writes still use appState.settings directly)
 
 extension AppState {
     /// The rider's display name.
@@ -839,6 +842,11 @@ extension AppState {
     /// Number of pinned (favorite) locations.
     public var favoritesCount: Int {
         savedLocations.favorites.count
+    }
+
+    /// Display names for all configured payment methods.
+    public var allPaymentMethodNames: [String] {
+        settings.allPaymentMethodNames
     }
 }
 

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -260,6 +260,17 @@ public final class AppState {
         return repo.canPingDriver(driver)
     }
 
+    /// Returns `true` when `driver` is a valid target for a ride request.
+    ///
+    /// Checks: driver exists in the repo, has a current RoadFlare key, key is not
+    /// stale, and is currently broadcasting status `online`. Used to gate the
+    /// Request-Ride button and online-drivers list. Returns `false` when services
+    /// are not yet configured.
+    public func canRequestRide(_ driver: FollowedDriver) -> Bool {
+        guard let repo = driversRepository else { return false }
+        return repo.canRequestRide(driver)
+    }
+
     /// Send Kind 3189 driver ping request to an offline driver.
     ///
     /// Enforces a 10-minute per-driver cooldown locally. Returns `.rateLimited` if the

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -746,6 +746,21 @@ extension AppState {
         let profiles = await service.fetchDriverProfiles(pubkeys: [pubkey])
         return profiles[pubkey]?.value
     }
+
+    /// Publish the current followed-drivers list (Kind 30011) to the relay.
+    public func publishDriversList() async {
+        await rideCoordinator?.publishFollowedDriversList()
+    }
+
+    /// Request a fresh share key from a driver.
+    public func requestDriverKeyRefresh(driverPubkey: String) async {
+        await rideCoordinator?.requestKeyRefresh(driverPubkey: driverPubkey)
+    }
+
+    /// Check all followed drivers for stale keys and request refreshes.
+    public func checkForStaleDriverKeys() async {
+        await rideCoordinator?.checkForStaleKeys()
+    }
 }
 
 // MARK: - Façade: Ride History

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -648,6 +648,185 @@ public final class AppState {
     }
 }
 
+// MARK: - Façade: Connectivity
+
+extension AppState {
+    /// Async connectivity check for views that need to poll relay status.
+    public func isRelayConnected() async -> Bool {
+        await relayManager?.isConnected ?? false
+    }
+}
+
+// MARK: - Façade: Drivers
+
+extension AppState {
+    /// Whether the rider has any followed drivers.
+    public var hasFollowedDrivers: Bool {
+        driversRepository?.hasDrivers ?? false
+    }
+
+    /// The current list of followed drivers.
+    public var followedDrivers: [FollowedDriver] {
+        driversRepository?.drivers ?? []
+    }
+
+    /// Cached location broadcast for a driver. Nil if no broadcast has been received.
+    public func driverLocation(pubkey: String) -> CachedDriverLocation? {
+        driversRepository?.driverLocations[pubkey]
+    }
+
+    /// Best available display name for a driver: cached Kind 0 profile name, then
+    /// stored follow-list name.
+    public func driverDisplayName(pubkey: String) -> String? {
+        driversRepository?.cachedDriverName(pubkey: pubkey)
+    }
+
+    /// Cached Kind 0 profile for a driver. Nil until a profile fetch has run.
+    public func driverProfile(pubkey: String) -> UserProfileContent? {
+        driversRepository?.driverProfiles[pubkey]
+    }
+
+    /// Whether the driver's current key is flagged as stale.
+    public func isDriverKeyStale(pubkey: String) -> Bool {
+        driversRepository?.staleKeyPubkeys.contains(pubkey) ?? false
+    }
+
+    /// Whether the rider is already following this pubkey.
+    public func isFollowingDriver(pubkey: String) -> Bool {
+        driversRepository?.isFollowing(pubkey: pubkey) ?? false
+    }
+
+    /// Whether the rider has a RoadFlare key for this driver.
+    public func hasKeyForDriver(pubkey: String) -> Bool {
+        driversRepository?.getRoadflareKey(driverPubkey: pubkey) != nil
+    }
+
+    /// Get the current `FollowedDriver` struct for a pubkey (re-fetches live state).
+    public func getDriver(pubkey: String) -> FollowedDriver? {
+        driversRepository?.getDriver(pubkey: pubkey)
+    }
+
+    /// Add a driver and cache their profile and name if available.
+    public func addDriver(_ driver: FollowedDriver, profile: UserProfileContent? = nil, name: String? = nil) {
+        driversRepository?.addDriver(driver)
+        if let profile {
+            driversRepository?.cacheDriverProfile(pubkey: driver.pubkey, profile: profile)
+        } else if let name, !name.isEmpty {
+            driversRepository?.cacheDriverName(pubkey: driver.pubkey, name: name)
+        }
+    }
+
+    /// Remove a driver and republish the updated list.
+    public func removeDriver(pubkey: String) {
+        driversRepository?.removeDriver(pubkey: pubkey)
+        Task {
+            await rideCoordinator?.publishFollowedDriversList()
+            rideCoordinator?.startLocationSubscriptions()
+        }
+    }
+
+    /// Update the personal note for a driver and republish.
+    public func updateDriverNote(pubkey: String, note: String) {
+        driversRepository?.updateDriverNote(driverPubkey: pubkey, note: note)
+        Task {
+            await rideCoordinator?.publishFollowedDriversList()
+        }
+    }
+
+    /// Clear all cached driver locations and restart location subscriptions.
+    public func refreshDriverLocations() {
+        driversRepository?.clearDriverLocations()
+        rideCoordinator?.startLocationSubscriptions()
+    }
+
+    /// Fetch a driver's Kind 0 profile from Nostr. Returns nil if the service
+    /// is not yet initialized or the fetch yields no result.
+    public func fetchDriverProfile(pubkey: String) async -> UserProfileContent? {
+        guard let service = roadflareDomainService else { return nil }
+        let profiles = await service.fetchDriverProfiles(pubkeys: [pubkey])
+        return profiles[pubkey]?.value
+    }
+}
+
+// MARK: - Façade: Ride History
+
+extension AppState {
+    /// The rider's completed ride history entries.
+    public var rideHistoryEntries: [RideHistoryEntry] {
+        rideHistory.rides
+    }
+
+    /// Remove a ride history entry by ID and trigger a backup.
+    public func removeRideHistoryEntry(id: String) {
+        rideHistory.removeRide(id: id)
+        rideCoordinator?.backupRideHistory()
+    }
+}
+
+// MARK: - Façade: Saved Locations
+
+extension AppState {
+    /// Favorite saved locations.
+    public var favoriteLocations: [SavedLocation] {
+        savedLocations.favorites
+    }
+
+    /// Recent (non-pinned) saved locations.
+    public var recentLocations: [SavedLocation] {
+        savedLocations.recents
+    }
+
+    /// All saved locations (favorites + recents).
+    public var allSavedLocations: [SavedLocation] {
+        savedLocations.locations
+    }
+
+    /// Save a location to the recent list.
+    public func saveLocation(_ location: SavedLocation) {
+        savedLocations.save(location)
+    }
+
+    /// Pin a recent location as a favorite.
+    public func pinLocation(id: String, nickname: String) {
+        savedLocations.pin(id: id, nickname: nickname)
+    }
+
+    /// Remove a saved location by ID.
+    public func removeLocation(id: String) {
+        savedLocations.remove(id: id)
+    }
+
+    /// Clear all saved locations and publish the profile backup.
+    public func clearAllLocations() async {
+        savedLocations.clearAll()
+        await publishProfileBackup()
+    }
+}
+
+// MARK: - Façade: Settings (read-only convenience)
+
+extension AppState {
+    /// The rider's display name.
+    public var profileName: String {
+        settings.profileName
+    }
+
+    /// The rider's configured payment method count (for settings badge).
+    public var paymentMethodCount: Int {
+        settings.roadflarePaymentMethods.count
+    }
+
+    /// Number of followed drivers (for settings badge).
+    public var followedDriverCount: Int {
+        driversRepository?.drivers.count ?? 0
+    }
+
+    /// Number of pinned (favorite) locations.
+    public var favoritesCount: Int {
+        savedLocations.favorites.count
+    }
+}
+
 #if DEBUG
 extension AppState {
     /// Test seam for unit tests that exercise ping behavior without running full service setup.

--- a/RoadFlare/RoadFlareTests/AppState/CanRequestRideTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/CanRequestRideTests.swift
@@ -1,0 +1,85 @@
+import Testing
+import RidestrSDK
+
+// Use the SDK's own InMemoryFollowedDriversPersistence (FollowedDriversRepository.swift:459)
+// rather than a hand-rolled fake — it satisfies the same protocol with the same semantics.
+private let testPubkey = String(repeating: "a", count: 64)
+private let testKey = RoadflareKey(
+    privateKeyHex: String(repeating: "b", count: 64),
+    publicKeyHex:  String(repeating: "c", count: 64),
+    version: 1, keyUpdatedAt: nil
+)
+
+private func makeRepo(driver: FollowedDriver) -> FollowedDriversRepository {
+    let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+    repo.addDriver(driver)
+    return repo
+}
+
+@Suite("FollowedDriversRepository.canRequestRide")
+struct CanRequestRideTests {
+
+    @Test func unknownDriver_returnsFalse() {
+        let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+        let stranger = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        #expect(repo.canRequestRide(stranger) == false)
+    }
+
+    @Test func noKey_returnsFalse() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: nil)
+        let repo = makeRepo(driver: driver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "online", timestamp: 1_000_000, keyVersion: 1)
+        #expect(repo.canRequestRide(driver) == false)
+    }
+
+    @Test func staleKey_returnsFalse() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: driver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "online", timestamp: 1_000_000, keyVersion: 1)
+        repo.markKeyStale(pubkey: testPubkey)
+        #expect(repo.canRequestRide(driver) == false)
+    }
+
+    @Test func offline_returnsFalse() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: driver)
+        // No location update → status nil → not online
+        #expect(repo.canRequestRide(driver) == false)
+    }
+
+    @Test func onRide_returnsFalse() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: driver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "on_ride", timestamp: 1_000_000, keyVersion: 1)
+        #expect(repo.canRequestRide(driver) == false)
+    }
+
+    @Test func onlineWithCurrentKey_returnsTrue() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: driver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "online", timestamp: 1_000_000, keyVersion: 1)
+        #expect(repo.canRequestRide(driver) == true)
+    }
+
+    @Test func staleCallerSnapshot_missingKeyButRepoHasCurrentKey_returnsTrue() {
+        let repoDriver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let staleSnapshot = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: nil)
+        let repo = makeRepo(driver: repoDriver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "online", timestamp: 1_000_000, keyVersion: 1)
+        #expect(repo.canRequestRide(staleSnapshot) == true)
+    }
+
+    @Test func staleCallerSnapshot_hasKeyButRepoMissingKey_returnsFalse() {
+        let repoDriver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: nil)
+        let staleSnapshot = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: repoDriver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "online", timestamp: 1_000_000, keyVersion: 1)
+        #expect(repo.canRequestRide(staleSnapshot) == false)
+    }
+}

--- a/decisions/0011-coordinator-boundary.md
+++ b/decisions/0011-coordinator-boundary.md
@@ -181,3 +181,4 @@ of this PR (ADR-0011 companion, issue #48).
 - `RoadFlare/RoadFlare/Views/Settings/SavedLocationsView.swift` (Phase B: remove SDK bypass)
 - `RoadFlare/RoadFlare/Views/Shared/ConnectivityIndicator.swift` (Phase B: remove SDK bypass)
 - `RoadFlare/RoadFlare/Views/Ride/RideTab.swift` (Phase B: remove SDK bypass)
+- `RoadFlare/RoadFlare/Views/Ride/ActiveRideView.swift` (Phase B: remove SDK bypass)

--- a/decisions/0011-coordinator-boundary.md
+++ b/decisions/0011-coordinator-boundary.md
@@ -1,0 +1,180 @@
+# ADR-0011: Coordinator Boundary Review — RoadFlareCore vs RidestrSDK
+
+**Status:** Active
+**Created:** 2026-04-17
+**Tags:** refactor, architecture, coordinator-boundary, ridestr-sdk
+
+## Context
+
+ADR-0001 decomposed `AppState` into coordinator classes (`SyncCoordinator`,
+`ConnectionCoordinator`). ADR-0005 introduced the `RoadFlareCore` framework as the
+boundary between the app-layer orchestration and the SDK. The intent was that
+`AppState` would become "a thin shell that holds coordinators privately and exposes
+forwarding methods for views." That decomposition happened, but two residual problems
+remain:
+
+1. **View bypass**: SwiftUI views still reach through `AppState` to access SDK
+   repositories directly (`appState.driversRepository`, `appState.relayManager`,
+   `appState.roadflareDomainService`). Views import `RidestrSDK` and call methods on
+   `FollowedDriversRepository`, `RelayManager`, and `RoadflareDomainService` without
+   going through any AppState façade method.
+
+2. **Boundary review due**: The five coordinator classes have not been formally
+   reviewed for whether they are sitting at the right abstraction layer. This ADR
+   captures that review.
+
+The five coordinators are:
+- `AppState` — owns SDK services, auth lifecycle, orchestration (~650 LOC)
+- `SyncCoordinator` — Nostr sync orchestration, startup resolution, dirty-tracking
+- `RideCoordinator` — app-layer adapter around `RiderRideSession`; owns UI state,
+  chat/location coordinators, ride state persistence
+- `ChatCoordinator` — manages in-ride chat messaging (Kind 3178) subscriptions and
+  send/receive
+- `LocationCoordinator` — manages location (Kind 30014) and key share (Kind 3186)
+  subscription lifetimes; feeds events into `LocationSyncCoordinator` (SDK)
+
+## Decision
+
+Each coordinator stays in RoadFlareCore or moves to SDK as follows:
+
+**AppState — stays in RoadFlareCore.**
+AppState is pure iOS app orchestration: it owns Keychain-backed key storage, wires
+UserDefaults-backed repositories, manages `authState` transitions driven by
+`UserSettingsRepository`, starts the connection watchdog, and drives the onboarding
+flow. None of that is Nostr protocol logic. The existing pattern of AppState holding
+private coordinators and exposing forwarding methods is correct. The immediate
+follow-up (this PR, Phase B) is to add façade computed properties and action methods
+to AppState so views no longer access `driversRepository` and `relayManager`
+directly.
+
+AppState does contain one piece of protocol logic that warrants review: the
+`sendDriverPing` method builds and publishes a Kind 3189 event. This is symmetric
+with `sendFollowNotification` (Kind 3187). Both build Nostr events inline in AppState
+using `RideshareEventBuilder` and publish via `RelayManager`. The event-building
+itself is SDK logic, but publishing is already a one-liner delegating to the SDK —
+the business logic here is the cooldown state machine and pre-flight checks, which
+are app-level concerns (cooldown lives in memory for the process lifetime, resets on
+logout). This is correctly placed.
+
+**SyncCoordinator — stays in RoadFlareCore. Clean.**
+SyncCoordinator is pure wiring: it calls SDK types (`SyncDomainResolver`,
+`ProfileBackupCoordinator`, `RideHistorySyncCoordinator`, `SyncDomainTracker`,
+`RoadflareDomainService`) and delegates everything to them. The startup sync
+orchestration is coordination logic, not protocol logic — it decides which SDK
+resolver to call and in what order, and reports progress to AppState's UI state
+properties. That belongs in the app layer. Teardown ordering (callbacks nil'd before
+`clearAll`) is an app-lifecycle invariant, not an SDK concern. SyncCoordinator is the
+cleanest of the five coordinators.
+
+**RideCoordinator — stays in RoadFlareCore.**
+RideCoordinator wraps `RiderRideSession` (SDK) and owns: (a) app-layer UI state
+(`currentFareEstimate`, `selectedPaymentMethod`, `pickupLocation`,
+`destinationLocation`, `lastError`), (b) ride history recording with platform
+persistence, (c) delegation of session lifecycle events to child coordinators
+(`ChatCoordinator`, `LocationCoordinator`), and (d) ride-state snapshot
+persistence via `RideStateRepository`. The `sendRideOffer` method constructs
+`RideOfferContent` from app-layer inputs (settings, fare estimates, number-formatting
+concerns) — that assembly logic is correctly app-layer. No SDK protocol logic
+should move up. The ride-state persistence mapping (converting SDK `RiderStage`
+structs to/from `PersistedRideState`) is already in the SDK; `RideCoordinator` only
+calls it.
+
+There is one open question: `RideCoordinator` directly constructs `RideOfferContent`
+including fiat-formatting logic (a `NumberFormatter`, USD-to-sats conversion, fiat
+rail selection per ADR-0008). This is complex enough that a helper on
+`RideOfferContent` or a builder in the SDK might be cleaner, but that is a
+single-file refactor, not a boundary move.
+
+**ChatCoordinator — stays in RoadFlareCore, but has SDK-extractable logic.**
+ChatCoordinator (176 LOC) does two things:
+
+1. *Subscription lifetime management*: starts/stops a Kind 3178 WebSocket
+   subscription with a generation-counter guard pattern. This is the same
+   `ManagedSubscription` pattern used in `LocationCoordinator`. It is app-layer
+   infrastructure (managing `Task` lifetimes and `SubscriptionID` handles against a
+   `RelayManagerProtocol`). Belongs in RoadFlareCore.
+
+2. *Event parsing, deduplication, sorting, and haptics*: calls
+   `RideshareEventParser.parseChatMessage`, deduplicates by event ID, sorts by
+   timestamp, caps at 500 messages, increments `unreadCount`, and calls
+   `HapticManager.messageReceived()`. The parsing call is an SDK delegation. The
+   deduplication, capping, and sorting are generic message-list management that could
+   live in an SDK-owned `ChatMessageStore` type if a driver-side app were ever built
+   that needed the same logic. The haptics call (`HapticManager`) is iOS-platform
+   specific and must stay in the app layer.
+
+**Verdict**: No logic moves to the SDK now. If a driver-side app is built, the
+message deduplication and sorting logic (minus haptics) is a natural extraction
+candidate at that point. See follow-up issue filed below.
+
+**LocationCoordinator — stays in RoadFlareCore. Already at the right abstraction.**
+LocationCoordinator is a thin subscription lifetime manager. After
+`LocationSyncCoordinator` was extracted into the SDK (which owns key share state
+machines, stale key detection, and ack publishing), `LocationCoordinator` does only:
+start/stop two subscriptions (`roadflare-locations` and `key-shares`) using the same
+generation-counter guard pattern, and delegate all event handling to the SDK's
+`LocationSyncCoordinator`. The `handleLocationEvent` method calls
+`RideshareEventParser.parseRoadflareLocation` (SDK) and
+`FollowedDriversRepository.updateDriverLocation` (SDK) — both are pure SDK
+delegations. This is the right split.
+
+## Rationale
+
+The primary principle is: **Nostr protocol logic (event building, parsing,
+subscription filters, state machines) lives in RidestrSDK. App-layer orchestration,
+platform persistence (Keychain, UserDefaults), iOS lifecycle, and UI state live in
+RoadFlareCore.**
+
+By this principle, none of the five coordinators has protocol logic that needs to
+move to the SDK today. The SDK already owns `LocationSyncCoordinator`,
+`ProfileBackupCoordinator`, `RideHistorySyncCoordinator`, `SyncDomainTracker`,
+`SyncDomainResolver`, `RiderRideSession`, and `AccountDeletionService`. RoadFlareCore
+coordinators are already thin wrappers and wiring layers.
+
+The more pressing issue is not coordinator placement but **view bypass**: views
+importing `RidestrSDK` directly to read `FollowedDriversRepository` properties,
+pass `FollowedDriver` values, and call `RelayManager`. That is addressed in Phase B
+of this PR (ADR-0011 companion, issue #48).
+
+## Alternatives Considered
+
+- **Move ChatCoordinator's message deduplication/sorting into a SDK `ChatMessageStore`** —
+  deferred, not rejected. Worth doing if a driver-side app is built. No reason to do
+  it now when there is one consumer and the logic is stable.
+
+- **Move `sendDriverPing` / `sendFollowNotification` logic into a new SDK service** —
+  rejected for now. The cooldown state machine and pre-flight checks are app-level
+  concerns. The event building already delegates to `RideshareEventBuilder` (SDK). No
+  protocol logic is stranded in the app layer.
+
+- **Move subscription lifetime management (the `ManagedSubscription` pattern shared
+  by `ChatCoordinator` and `LocationCoordinator`) into an SDK utility** — rejected.
+  `Task` and `SubscriptionID` management is app-layer infrastructure tied to
+  `@MainActor` and `RelayManagerProtocol`. It would add an SDK dependency on Swift
+  concurrency task management patterns that are only needed in the app layer.
+
+## Consequences
+
+- No code moves to the SDK as a result of this ADR. The boundary is confirmed
+  correct for all five coordinators.
+- Phase B (issue #48, this PR) adds façade computed properties and action methods to
+  `AppState` so views can stop importing `RidestrSDK` for their normal rendering path.
+- A follow-up issue is filed for the ChatCoordinator SDK extraction question to
+  revisit when a driver-side consumer exists.
+- Future coordinators added to RoadFlareCore should follow the established patterns:
+  thin subscription lifetime management, delegation to SDK state machines, and no
+  inline event building beyond what `RideshareEventBuilder` already provides.
+
+## Affected Files
+
+- `RoadFlare/RoadFlareCore/ViewModels/AppState.swift`
+- `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift`
+- `RoadFlare/RoadFlareCore/ViewModels/SyncCoordinator.swift`
+- `RoadFlare/RoadFlareCore/ViewModels/ChatCoordinator.swift`
+- `RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift`
+- `RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift` (Phase B: remove SDK bypass)
+- `RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift` (Phase B: remove SDK bypass)
+- `RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift` (Phase B: remove SDK bypass)
+- `RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift` (Phase B: remove SDK bypass)
+- `RoadFlare/RoadFlare/Views/History/HistoryTab.swift` (Phase B: remove SDK bypass)
+- `RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift` (Phase B: remove SDK bypass)

--- a/decisions/0011-coordinator-boundary.md
+++ b/decisions/0011-coordinator-boundary.md
@@ -178,3 +178,6 @@ of this PR (ADR-0011 companion, issue #48).
 - `RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift` (Phase B: remove SDK bypass)
 - `RoadFlare/RoadFlare/Views/History/HistoryTab.swift` (Phase B: remove SDK bypass)
 - `RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift` (Phase B: remove SDK bypass)
+- `RoadFlare/RoadFlare/Views/Settings/SavedLocationsView.swift` (Phase B: remove SDK bypass)
+- `RoadFlare/RoadFlare/Views/Shared/ConnectivityIndicator.swift` (Phase B: remove SDK bypass)
+- `RoadFlare/RoadFlare/Views/Ride/RideTab.swift` (Phase B: remove SDK bypass)

--- a/decisions/0011-coordinator-boundary.md
+++ b/decisions/0011-coordinator-boundary.md
@@ -24,7 +24,8 @@ remain:
    captures that review.
 
 The five coordinators are:
-- `AppState` — owns SDK services, auth lifecycle, orchestration (~650 LOC)
+- `AppState` — owns SDK services, auth lifecycle, orchestration, plus the
+  Phase B façade extensions added in this PR
 - `SyncCoordinator` — Nostr sync orchestration, startup resolution, dirty-tracking
 - `RideCoordinator` — app-layer adapter around `RiderRideSession`; owns UI state,
   chat/location coordinators, ride state persistence


### PR DESCRIPTION
## Summary

- Documents the RoadFlareCore ↔ RidestrSDK coordinator boundary via ADR-0011 (closes #50)
- Adds app-facing read APIs and action methods to `AppState`/`RoadFlareCore` so SwiftUI views no longer bypass the façade to reach SDK repositories directly (closes #48)

## Scope

**#50 — Coordinator boundary review (ADR-0011):**
- Reviewed `RideCoordinator`, `ChatCoordinator`, `AppState`, `SyncCoordinator`, `LocationCoordinator`
- Decision: all five stay in RoadFlareCore — the SDK already owns the protocol-level types they delegate to
- Filed #60 as a deferred follow-up: ChatCoordinator message-list deduplication/sorting is a natural SDK extraction if a driver-side app is ever built

**#48 — AppState façade:**
- Added façade extensions to `AppState` covering: connectivity (`isRelayConnected()`), drivers (read + follow/unfollow/note actions), ride history (read + delete + backup), saved locations (read + pin/save/remove/clear), settings (badge counts)
- Refactored 8 views: `DriversTab`, `DriverDetailSheet`, `AddDriverSheet`, `RideRequestView`, `HistoryTab`, `SettingsTab`, `SavedLocationsView`, `ConnectivityIndicator`
- Views no longer call repository or service methods directly — all mutations go through AppState façade actions
- `import RidestrSDK` remains in refactored views because they render SDK value types (`FollowedDriver`, `RideHistoryEntry`, `CachedDriverLocation`, etc.) — eliminating those imports is the job of #49 (PR #59, presentation types)

## Merge order

This PR merges **before** #59 (presentation types), which rebases onto it.

## Test plan

- [ ] `xcodebuild` clean build passes — confirmed on iPhone 17 simulator
- [ ] Views compile against new façade APIs without direct repository/service calls
- [ ] ADR-0011 is present in `decisions/`

Closes #50
Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)