### PR TITLE
refactor: app presentation types for view-layer decoupling (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ AGENTS.md
 # `.claude/worktrees/` subdirectory is local session scratch space created by
 # the Claude Code CLI — never repo content.
 .claude/worktrees/
+
+# Project-local parallel worktrees (feature work, never repo content)
+.worktrees/

--- a/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
@@ -17,10 +17,10 @@ public struct DriverDetailViewState: Equatable, Sendable {
 
     // MARK: - Status
 
-    /// Human-readable status label: "Available", "On a ride", "Offline", "Pending approval".
+    /// Human-readable status label: "Available", "On a ride", "Offline", "Pending approval", "Key outdated".
     public let statusLabel: String
 
-    /// Whether the "Request Ride" button should be shown (driver is online and has a key).
+    /// Whether the "Request Ride" button should be shown (driver is online, has a key, and the key is not stale).
     public let canRequestRide: Bool
 
     // MARK: - Driver Info section
@@ -56,25 +56,29 @@ public struct DriverDetailViewState: Equatable, Sendable {
     ///
     /// - Parameters:
     ///   - driver: The canonical driver model (should be the freshest copy from the repo).
-    ///   - displayName: Best-available name already resolved by the repository.
+    ///   - displayName: Display name from the repository if known; the factory falls back to driver.name then a short pubkey prefix.
     ///   - location: The driver's latest cached location broadcast, if any.
     ///   - profile: The driver's cached Kind 0 profile, if available.
+    ///   - isKeyStale: Whether this driver's key has been flagged as stale.
     ///   - referenceDate: Used for relative timestamp formatting (injectable for testing).
     public static func from(
         _ driver: FollowedDriver,
         displayName: String?,
         location: CachedDriverLocation?,
         profile: UserProfileContent?,
+        isKeyStale: Bool,
         referenceDate: Date = .now
     ) -> DriverDetailViewState {
         let resolvedName = displayName
             ?? driver.name
             ?? (String(driver.pubkey.prefix(8)) + "...")
 
-        let canRequestRide = driver.hasKey && location?.status == "online"
+        let canRequestRide = driver.hasKey && !isKeyStale && location?.status == "online"
 
         let statusLabel: String
-        if !driver.hasKey {
+        if isKeyStale {
+            statusLabel = "Key outdated"
+        } else if !driver.hasKey {
             statusLabel = "Pending approval"
         } else if let loc = location {
             switch loc.status {

--- a/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
@@ -1,0 +1,112 @@
+import Foundation
+import RidestrSDK
+
+/// Display-ready state for the driver detail sheet.
+///
+/// All strings are pre-resolved so the view doesn't need to touch any
+/// SDK repository or derive logic.
+public struct DriverDetailViewState: Equatable, Sendable {
+
+    // MARK: - Identity
+
+    /// Hex public key — used as a stable identifier for actions.
+    public let pubkey: String
+
+    /// Best available display name shown as the sheet title.
+    public let displayName: String
+
+    // MARK: - Status
+
+    /// Human-readable status label: "Available", "On a ride", "Offline", "Pending approval".
+    public let statusLabel: String
+
+    /// Whether the "Request Ride" button should be shown (driver is online and has a key).
+    public let canRequestRide: Bool
+
+    // MARK: - Driver Info section
+
+    /// Vehicle description (e.g. "Black Tesla Model S"), or nil if unknown.
+    public let vehicleDescription: String?
+
+    // MARK: - RoadFlare Key section
+
+    /// Whether the driver has shared their RoadFlare key (follow approved).
+    public let hasKey: Bool
+
+    /// The key's version number, if a key is present.
+    public let keyVersion: Int?
+
+    // MARK: - Last Known Location section
+
+    /// Raw status string from the last location broadcast (e.g. "online"), or nil if no location.
+    public let lastLocationStatus: String?
+
+    /// Human-readable relative time string for the last location update, or nil if no location.
+    /// Example: "3 min ago"
+    public let lastLocationTimestampLabel: String?
+
+    // MARK: - Personal Note
+
+    /// The rider's personal note for this driver (may be empty string).
+    public let note: String
+
+    // MARK: - Factory
+
+    /// Project a `FollowedDriver` + repository context into a `DriverDetailViewState`.
+    ///
+    /// - Parameters:
+    ///   - driver: The canonical driver model (should be the freshest copy from the repo).
+    ///   - displayName: Best-available name already resolved by the repository.
+    ///   - location: The driver's latest cached location broadcast, if any.
+    ///   - profile: The driver's cached Kind 0 profile, if available.
+    ///   - referenceDate: Used for relative timestamp formatting (injectable for testing).
+    public static func from(
+        _ driver: FollowedDriver,
+        displayName: String?,
+        location: CachedDriverLocation?,
+        profile: UserProfileContent?,
+        referenceDate: Date = .now
+    ) -> DriverDetailViewState {
+        let resolvedName = displayName
+            ?? driver.name
+            ?? (String(driver.pubkey.prefix(8)) + "...")
+
+        let canRequestRide = driver.hasKey && location?.status == "online"
+
+        let statusLabel: String
+        if !driver.hasKey {
+            statusLabel = "Pending approval"
+        } else if let loc = location {
+            switch loc.status {
+            case "online":  statusLabel = "Available"
+            case "on_ride": statusLabel = "On a ride"
+            default:        statusLabel = "Offline"
+            }
+        } else {
+            statusLabel = "Offline"
+        }
+
+        let lastLocationTimestampLabel: String?
+        if let loc = location {
+            let date = Date(timeIntervalSince1970: TimeInterval(loc.timestamp))
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .abbreviated
+            lastLocationTimestampLabel = formatter.localizedString(for: date, relativeTo: referenceDate)
+        } else {
+            lastLocationTimestampLabel = nil
+        }
+
+        return DriverDetailViewState(
+            pubkey: driver.pubkey,
+            displayName: resolvedName,
+            statusLabel: statusLabel,
+            canRequestRide: canRequestRide,
+            vehicleDescription: profile?.vehicleDescription,
+            hasKey: driver.hasKey,
+            keyVersion: driver.roadflareKey?.version,
+            lastLocationStatus: location?.status,
+            lastLocationTimestampLabel: lastLocationTimestampLabel,
+            note: driver.note ?? ""
+        )
+    }
+}

--- a/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
@@ -5,12 +5,15 @@ import RidestrSDK
 ///
 /// All strings are pre-resolved so the view doesn't need to touch any
 /// SDK repository or derive logic.
-public struct DriverDetailViewState: Equatable, Sendable {
+public struct DriverDetailViewState: Equatable, Sendable, Identifiable {
 
     // MARK: - Identity
 
     /// Hex public key — used as a stable identifier for actions.
     public let pubkey: String
+
+    /// `Identifiable` conformance keyed on `pubkey`.
+    public var id: String { pubkey }
 
     /// Best available display name shown as the sheet title.
     public let displayName: String
@@ -70,6 +73,8 @@ public struct DriverDetailViewState: Equatable, Sendable {
     ///   - isKeyStale: Whether this driver's key has been flagged as stale.
     ///   - canPing: Whether the ping action is currently available for this driver.
     ///   - referenceDate: Used for relative timestamp formatting (injectable for testing).
+    ///   - locale: Locale used for the relative timestamp. Defaults to `.current` so
+    ///     production output follows the device locale; tests may inject a fixed locale.
     public static func from(
         _ driver: FollowedDriver,
         displayName: String?,
@@ -77,34 +82,28 @@ public struct DriverDetailViewState: Equatable, Sendable {
         profile: UserProfileContent?,
         isKeyStale: Bool,
         canPing: Bool,
-        referenceDate: Date = .now
+        referenceDate: Date = .now,
+        locale: Locale = .current
     ) -> DriverDetailViewState {
         let resolvedName = displayName
             ?? driver.name
             ?? (String(driver.pubkey.prefix(8)) + "...")
 
         let canRequestRide = driver.hasKey && !isKeyStale && location?.status == "online"
+        let status = resolveDriverPresentationStatus(
+            hasKey: driver.hasKey, isKeyStale: isKeyStale, location: location
+        )
+        let statusLabel = status.detailLabel
 
-        let statusLabel: String
-        if isKeyStale {
-            statusLabel = "Key outdated"
-        } else if !driver.hasKey {
-            statusLabel = "Pending approval"
-        } else if let loc = location {
-            switch loc.status {
-            case "online":  statusLabel = "Available"
-            case "on_ride": statusLabel = "On a ride"
-            default:        statusLabel = "Offline"
-            }
-        } else {
-            statusLabel = "Offline"
-        }
-
+        // Suppress the raw location fields when the key is stale — showing "3 min ago"
+        // next to "Key outdated" contradicts itself, since that broadcast was decrypted
+        // with the pre-rotation key and no longer reflects the driver's current state.
         let lastLocationTimestampLabel: String?
-        if let loc = location {
+        if let loc = location, !isKeyStale {
             let date = Date(timeIntervalSince1970: TimeInterval(loc.timestamp))
             let formatter = RelativeDateTimeFormatter()
             formatter.unitsStyle = .abbreviated
+            formatter.locale = locale
             lastLocationTimestampLabel = formatter.localizedString(for: date, relativeTo: referenceDate)
         } else {
             lastLocationTimestampLabel = nil

--- a/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
@@ -25,8 +25,16 @@ public struct DriverDetailViewState: Equatable, Sendable {
 
     // MARK: - Driver Info section
 
+    /// Profile picture URL string, if available.
+    public let pictureURL: String?
+
     /// Vehicle description (e.g. "Black Tesla Model S"), or nil if unknown.
     public let vehicleDescription: String?
+
+    // MARK: - Action availability
+
+    /// `true` when the ping bell should be shown for this driver.
+    public let canPing: Bool
 
     // MARK: - RoadFlare Key section
 
@@ -60,6 +68,7 @@ public struct DriverDetailViewState: Equatable, Sendable {
     ///   - location: The driver's latest cached location broadcast, if any.
     ///   - profile: The driver's cached Kind 0 profile, if available.
     ///   - isKeyStale: Whether this driver's key has been flagged as stale.
+    ///   - canPing: Whether the ping action is currently available for this driver.
     ///   - referenceDate: Used for relative timestamp formatting (injectable for testing).
     public static func from(
         _ driver: FollowedDriver,
@@ -67,6 +76,7 @@ public struct DriverDetailViewState: Equatable, Sendable {
         location: CachedDriverLocation?,
         profile: UserProfileContent?,
         isKeyStale: Bool,
+        canPing: Bool,
         referenceDate: Date = .now
     ) -> DriverDetailViewState {
         let resolvedName = displayName
@@ -105,10 +115,12 @@ public struct DriverDetailViewState: Equatable, Sendable {
             displayName: resolvedName,
             statusLabel: statusLabel,
             canRequestRide: canRequestRide,
+            pictureURL: profile?.picture,
             vehicleDescription: profile?.vehicleDescription,
+            canPing: canPing,
             hasKey: driver.hasKey,
             keyVersion: driver.roadflareKey?.version,
-            lastLocationStatus: location?.status,
+            lastLocationStatus: isKeyStale ? nil : location?.status,
             lastLocationTimestampLabel: lastLocationTimestampLabel,
             note: driver.note ?? ""
         )

--- a/RoadFlare/RoadFlareCore/Presentation/DriverListItem.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverListItem.swift
@@ -5,14 +5,18 @@ import RidestrSDK
 ///
 /// Projected from `FollowedDriver` + live `FollowedDriversRepository` state.
 /// Does not expose raw Nostr keypair material or the `RoadflareKey` struct.
-public struct DriverListItem: Equatable, Sendable {
+public struct DriverListItem: Equatable, Sendable, Identifiable {
 
     // MARK: - Identity
 
     /// Hex public key — used as a stable identifier for navigation and actions.
     public let pubkey: String
 
-    /// Best available display name: profile name > follow-time name > short pubkey.
+    /// `Identifiable` conformance keyed on `pubkey`.
+    public var id: String { pubkey }
+
+    /// Best available display name: caller-resolved `displayName` if set,
+    /// otherwise `FollowedDriver.name`, otherwise a short pubkey prefix.
     public let displayName: String
 
     // MARK: - Status
@@ -71,20 +75,9 @@ public struct DriverListItem: Equatable, Sendable {
             ?? driver.name
             ?? (String(driver.pubkey.prefix(8)) + "...")
 
-        let status: Status
-        if isKeyStale {
-            status = .keyStale
-        } else if !driver.hasKey {
-            status = .pendingApproval
-        } else if let loc = location {
-            switch loc.status {
-            case "online":  status = .online
-            case "on_ride": status = .onRide
-            default:        status = .offline
-            }
-        } else {
-            status = .offline
-        }
+        let status = resolveDriverPresentationStatus(
+            hasKey: driver.hasKey, isKeyStale: isKeyStale, location: location
+        )
 
         return DriverListItem(
             pubkey: driver.pubkey,

--- a/RoadFlare/RoadFlareCore/Presentation/DriverListItem.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverListItem.swift
@@ -54,7 +54,7 @@ public struct DriverListItem: Equatable, Sendable {
     ///
     /// - Parameters:
     ///   - driver: The followed driver domain model.
-    ///   - displayName: Best-available name already resolved by the repository.
+    ///   - displayName: Display name from the repository if known; the factory falls back to driver.name then a short pubkey prefix.
     ///   - location: The driver's latest cached location broadcast, if any.
     ///   - profile: The driver's cached Kind 0 profile, if available.
     ///   - isKeyStale: Whether this driver's key has been flagged as stale.
@@ -97,7 +97,7 @@ public struct DriverListItem: Equatable, Sendable {
     }
 
     // MARK: - Convenience: sort order for the drivers list
-    // Lower value = higher in list (online first, then on_ride, then pending, then offline).
+    // Lower value = higher in list (online, onRide, keyStale, pendingApproval, offline).
 
     public var sortOrder: Int {
         switch status {

--- a/RoadFlare/RoadFlareCore/Presentation/DriverListItem.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverListItem.swift
@@ -1,0 +1,111 @@
+import Foundation
+import RidestrSDK
+
+/// Display-ready representation of a followed driver for list/card views.
+///
+/// Projected from `FollowedDriver` + live `FollowedDriversRepository` state.
+/// Does not expose raw Nostr keypair material or the `RoadflareKey` struct.
+public struct DriverListItem: Equatable, Sendable {
+
+    // MARK: - Identity
+
+    /// Hex public key — used as a stable identifier for navigation and actions.
+    public let pubkey: String
+
+    /// Best available display name: profile name > follow-time name > short pubkey.
+    public let displayName: String
+
+    // MARK: - Status
+
+    public enum Status: Equatable, Sendable {
+        /// Driver has shared their key and is broadcasting "online".
+        case online
+        /// Driver is currently on a ride.
+        case onRide
+        /// Driver has a key but is not broadcasting (or broadcasting another status).
+        case offline
+        /// Driver has not yet approved the follow request (no key received).
+        case pendingApproval
+        /// Driver's key has been flagged as stale and needs refresh.
+        case keyStale
+    }
+
+    public let status: Status
+
+    /// `true` when the rider can tap "Request Now" for this driver.
+    public var canRequestRide: Bool { status == .online }
+
+    // MARK: - Profile extras (from cached Kind 0)
+
+    /// Profile picture URL string, if available.
+    public let pictureURL: String?
+
+    /// Vehicle description string (e.g. "Black Tesla Model S"), if available.
+    public let vehicleDescription: String?
+
+    // MARK: - Action availability
+
+    /// `true` when the ping bell should be shown for this driver.
+    public let canPing: Bool
+
+    // MARK: - Factory
+
+    /// Project a `FollowedDriver` + its repository context into a `DriverListItem`.
+    ///
+    /// - Parameters:
+    ///   - driver: The followed driver domain model.
+    ///   - displayName: Best-available name already resolved by the repository.
+    ///   - location: The driver's latest cached location broadcast, if any.
+    ///   - profile: The driver's cached Kind 0 profile, if available.
+    ///   - isKeyStale: Whether this driver's key has been flagged as stale.
+    ///   - canPing: Whether the ping action is currently available.
+    public static func from(
+        _ driver: FollowedDriver,
+        displayName: String?,
+        location: CachedDriverLocation?,
+        profile: UserProfileContent?,
+        isKeyStale: Bool,
+        canPing: Bool
+    ) -> DriverListItem {
+        let resolvedName = displayName
+            ?? driver.name
+            ?? (String(driver.pubkey.prefix(8)) + "...")
+
+        let status: Status
+        if isKeyStale {
+            status = .keyStale
+        } else if !driver.hasKey {
+            status = .pendingApproval
+        } else if let loc = location {
+            switch loc.status {
+            case "online":  status = .online
+            case "on_ride": status = .onRide
+            default:        status = .offline
+            }
+        } else {
+            status = .offline
+        }
+
+        return DriverListItem(
+            pubkey: driver.pubkey,
+            displayName: resolvedName,
+            status: status,
+            pictureURL: profile?.picture,
+            vehicleDescription: profile?.vehicleDescription,
+            canPing: canPing
+        )
+    }
+
+    // MARK: - Convenience: sort order for the drivers list
+    // Lower value = higher in list (online first, then on_ride, then pending, then offline).
+
+    public var sortOrder: Int {
+        switch status {
+        case .online:          return 0
+        case .onRide:          return 1
+        case .keyStale:        return 2
+        case .pendingApproval: return 3
+        case .offline:         return 4
+        }
+    }
+}

--- a/RoadFlare/RoadFlareCore/Presentation/DriverPresentationStatus.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverPresentationStatus.swift
@@ -1,0 +1,41 @@
+import Foundation
+import RidestrSDK
+
+/// Shared resolver for the driver-status priority ladder used by both
+/// `DriverListItem` and `DriverDetailViewState`.
+///
+/// Keeping the logic in one place means a new status string or precondition
+/// only needs to be added in one spot.
+func resolveDriverPresentationStatus(
+    hasKey: Bool,
+    isKeyStale: Bool,
+    location: CachedDriverLocation?
+) -> DriverListItem.Status {
+    if isKeyStale {
+        return .keyStale
+    }
+    if !hasKey {
+        return .pendingApproval
+    }
+    guard let loc = location else {
+        return .offline
+    }
+    switch loc.status {
+    case "online":  return .online
+    case "on_ride": return .onRide
+    default:        return .offline
+    }
+}
+
+extension DriverListItem.Status {
+    /// Human-readable label used by the driver detail sheet.
+    var detailLabel: String {
+        switch self {
+        case .online:          return "Available"
+        case .onRide:          return "On a ride"
+        case .offline:         return "Offline"
+        case .pendingApproval: return "Pending approval"
+        case .keyStale:        return "Key outdated"
+        }
+    }
+}

--- a/RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift
@@ -54,11 +54,16 @@ public struct RideHistoryRow: Equatable, Sendable, Identifiable {
     /// Project a `RideHistoryEntry` into a display-ready row.
     public static func from(_ entry: RideHistoryEntry) -> RideHistoryRow {
         let fareLabel: String
-        let fareDouble = NSDecimalNumber(decimal: entry.fare).doubleValue
-        if fareDouble == 0 {
+        if entry.fare == 0 {
             fareLabel = "–"
         } else {
-            fareLabel = String(format: "$%.2f", fareDouble)
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .currency
+            formatter.currencyCode = "USD"
+            formatter.locale = Locale(identifier: "en_US")
+            formatter.maximumFractionDigits = 2
+            formatter.minimumFractionDigits = 2
+            fareLabel = formatter.string(from: entry.fare as NSDecimalNumber) ?? "$\(entry.fare)"
         }
 
         let distanceLabel = entry.distance.map { String(format: "%.1f mi", $0) }

--- a/RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift
@@ -1,0 +1,80 @@
+import Foundation
+import RidestrSDK
+
+/// Display-ready representation of a ride history entry for list rows.
+///
+/// All display strings are pre-derived so the view only needs to render
+/// plain text and a `Date` (for SwiftUI's `Text(_:style:)` which formats
+/// dates itself).
+public struct RideHistoryRow: Equatable, Sendable, Identifiable {
+
+    // MARK: - Identity
+
+    public let id: String
+
+    // MARK: - Date
+
+    /// The ride's date, used with SwiftUI's `Text(ride.date, style: .date)`.
+    public let date: Date
+
+    // MARK: - Counterparty
+
+    /// Driver name or nil if unknown.
+    public let counterpartyName: String?
+
+    // MARK: - Route
+
+    /// Pickup address string, or nil if unavailable.
+    public let pickupAddress: String?
+
+    /// Destination address string, or nil if unavailable.
+    public let destinationAddress: String?
+
+    // MARK: - Fare & Stats
+
+    /// Formatted fare string, e.g. "$12.50".
+    public let fareLabel: String
+
+    /// Distance label, e.g. "4.2 mi", or nil.
+    public let distanceLabel: String?
+
+    /// Duration label, e.g. "18 min", or nil.
+    public let durationLabel: String?
+
+    /// Human-readable payment method label, e.g. "Cash App".
+    public let paymentMethodLabel: String
+
+    // MARK: - Status
+
+    /// Whether the ride completed successfully (vs. cancelled/failed).
+    public let isCompleted: Bool
+
+    // MARK: - Factory
+
+    /// Project a `RideHistoryEntry` into a display-ready row.
+    public static func from(_ entry: RideHistoryEntry) -> RideHistoryRow {
+        let fareLabel: String
+        let fareDouble = NSDecimalNumber(decimal: entry.fare).doubleValue
+        if fareDouble == 0 {
+            fareLabel = "–"
+        } else {
+            fareLabel = String(format: "$%.2f", fareDouble)
+        }
+
+        let distanceLabel = entry.distance.map { String(format: "%.1f mi", $0) }
+        let durationLabel = entry.duration.map { "\($0) min" }
+
+        return RideHistoryRow(
+            id: entry.id,
+            date: entry.date,
+            counterpartyName: entry.counterpartyName,
+            pickupAddress: entry.pickup.address,
+            destinationAddress: entry.destination.address,
+            fareLabel: fareLabel,
+            distanceLabel: distanceLabel,
+            durationLabel: durationLabel,
+            paymentMethodLabel: PaymentMethod.displayName(for: entry.paymentMethod),
+            isCompleted: entry.status == "completed"
+        )
+    }
+}

--- a/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
@@ -55,12 +55,13 @@ public struct RideRequestDriverOption: Equatable, Sendable, Identifiable {
     ///   - drivers: All followed drivers.
     ///   - driverNames: Cached display name map from the repository.
     ///   - driverLocations: Cached location map from the repository.
-    ///   - staleKeyPubkeys: Set of pubkeys whose keys are currently stale (from `FollowedDriversRepository`).
+    ///   - staleKeyPubkeys: Set of pubkeys whose keys are currently stale (from `FollowedDriversRepository.staleKeyPubkeys`).
+    ///     Always pass this — omitting it silently includes stale-key drivers in the result.
     public static func onlineOptions(
         from drivers: [FollowedDriver],
         driverNames: [String: String],
         driverLocations: [String: CachedDriverLocation],
-        staleKeyPubkeys: Set<String> = []
+        staleKeyPubkeys: Set<String>
     ) -> [RideRequestDriverOption] {
         drivers.compactMap { driver in
             from(

--- a/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
@@ -1,0 +1,69 @@
+import Foundation
+import RidestrSDK
+
+/// Display-ready representation of an online driver option in the ride request flow.
+///
+/// Only drivers that are online (have a key and are broadcasting "online") should
+/// be projected into this type — the factory enforces that precondition.
+public struct RideRequestDriverOption: Equatable, Sendable, Identifiable {
+
+    // MARK: - Identity
+
+    /// Hex public key — used as the selection key and action identifier.
+    public var id: String { pubkey }
+    public let pubkey: String
+
+    /// Display name for the driver option row.
+    public let displayName: String
+
+    // MARK: - Factory
+
+    /// Project an online `FollowedDriver` into a ride-request driver option.
+    ///
+    /// Returns `nil` if the driver is not eligible (no key or not online).
+    ///
+    /// - Parameters:
+    ///   - driver: The followed driver domain model.
+    ///   - displayName: Best-available name already resolved by the repository.
+    ///   - location: The driver's latest cached location broadcast.
+    public static func from(
+        _ driver: FollowedDriver,
+        displayName: String?,
+        location: CachedDriverLocation?
+    ) -> RideRequestDriverOption? {
+        guard driver.hasKey, location?.status == "online" else { return nil }
+
+        let resolvedName = displayName
+            ?? driver.name
+            ?? (String(driver.pubkey.prefix(8)) + "...")
+
+        return RideRequestDriverOption(
+            pubkey: driver.pubkey,
+            displayName: resolvedName
+        )
+    }
+
+    // MARK: - Convenience
+
+    /// Build the full list of available driver options from a repository snapshot.
+    ///
+    /// Drivers are included only when they have a key and are broadcasting "online".
+    ///
+    /// - Parameters:
+    ///   - drivers: All followed drivers.
+    ///   - driverNames: Cached display name map from the repository.
+    ///   - driverLocations: Cached location map from the repository.
+    public static func onlineOptions(
+        from drivers: [FollowedDriver],
+        driverNames: [String: String],
+        driverLocations: [String: CachedDriverLocation]
+    ) -> [RideRequestDriverOption] {
+        drivers.compactMap { driver in
+            from(
+                driver,
+                displayName: driverNames[driver.pubkey],
+                location: driverLocations[driver.pubkey]
+            )
+        }
+    }
+}

--- a/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
@@ -20,18 +20,20 @@ public struct RideRequestDriverOption: Equatable, Sendable, Identifiable {
 
     /// Project an online `FollowedDriver` into a ride-request driver option.
     ///
-    /// Returns `nil` if the driver is not eligible (no key or not online).
+    /// Returns `nil` if the driver is not eligible (no key, stale key, or not online).
     ///
     /// - Parameters:
     ///   - driver: The followed driver domain model.
-    ///   - displayName: Best-available name already resolved by the repository.
+    ///   - displayName: Display name from the repository if known; the factory falls back to driver.name then a short pubkey prefix.
     ///   - location: The driver's latest cached location broadcast.
+    ///   - isKeyStale: Whether this driver's key has been flagged as stale.
     public static func from(
         _ driver: FollowedDriver,
         displayName: String?,
-        location: CachedDriverLocation?
+        location: CachedDriverLocation?,
+        isKeyStale: Bool
     ) -> RideRequestDriverOption? {
-        guard driver.hasKey, location?.status == "online" else { return nil }
+        guard driver.hasKey, !isKeyStale, location?.status == "online" else { return nil }
 
         let resolvedName = displayName
             ?? driver.name
@@ -47,22 +49,25 @@ public struct RideRequestDriverOption: Equatable, Sendable, Identifiable {
 
     /// Build the full list of available driver options from a repository snapshot.
     ///
-    /// Drivers are included only when they have a key and are broadcasting "online".
+    /// Drivers are included only when they have a key, the key is not stale, and they are broadcasting "online".
     ///
     /// - Parameters:
     ///   - drivers: All followed drivers.
     ///   - driverNames: Cached display name map from the repository.
     ///   - driverLocations: Cached location map from the repository.
+    ///   - staleKeyPubkeys: Set of pubkeys whose keys are currently stale (from `FollowedDriversRepository`).
     public static func onlineOptions(
         from drivers: [FollowedDriver],
         driverNames: [String: String],
-        driverLocations: [String: CachedDriverLocation]
+        driverLocations: [String: CachedDriverLocation],
+        staleKeyPubkeys: Set<String> = []
     ) -> [RideRequestDriverOption] {
         drivers.compactMap { driver in
             from(
                 driver,
                 displayName: driverNames[driver.pubkey],
-                location: driverLocations[driver.pubkey]
+                location: driverLocations[driver.pubkey],
+                isKeyStale: staleKeyPubkeys.contains(driver.pubkey)
             )
         }
     }

--- a/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
@@ -3,8 +3,9 @@ import RidestrSDK
 
 /// Display-ready representation of an online driver option in the ride request flow.
 ///
-/// Only drivers that are online (have a key and are broadcasting "online") should
-/// be projected into this type — the factory enforces that precondition.
+/// Only drivers that are requestable — have a key, the key is not stale, and
+/// they are broadcasting "online" — should be projected into this type.
+/// The factory enforces that precondition and returns `nil` otherwise.
 public struct RideRequestDriverOption: Equatable, Sendable, Identifiable {
 
     // MARK: - Identity

--- a/RoadFlare/RoadFlareCore/Presentation/SavedLocationRow.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/SavedLocationRow.swift
@@ -1,0 +1,71 @@
+import Foundation
+import RidestrSDK
+
+/// Display-ready representation of a saved location for list rows.
+///
+/// Covers both favorites (isPinned = true) and recents.
+public struct SavedLocationRow: Equatable, Sendable, Identifiable {
+
+    // MARK: - Identity
+
+    /// Stable ID matching `SavedLocation.id` — used for delete actions.
+    public let id: String
+
+    // MARK: - Display
+
+    /// Primary label: nickname if set (e.g. "Home"), otherwise `displayName`.
+    public let label: String
+
+    /// The raw display name from the location (place name or searched text).
+    public let displayName: String
+
+    /// Street-level address string for the subtitle row.
+    public let addressLine: String
+
+    // MARK: - Category
+
+    /// Whether this is a pinned favorite vs. a recent.
+    public let isFavorite: Bool
+
+    /// SF Symbol name appropriate for the location label.
+    public var iconSystemName: String {
+        switch label.lowercased() {
+        case "home": return "house.fill"
+        case "work": return "briefcase.fill"
+        default:     return isFavorite ? "star.fill" : "clock"
+        }
+    }
+
+    // MARK: - Coordinates (for address-fill actions)
+
+    public let latitude: Double
+    public let longitude: Double
+
+    // MARK: - Factory
+
+    /// Project a `SavedLocation` into a display-ready row.
+    public static func from(_ location: SavedLocation) -> SavedLocationRow {
+        SavedLocationRow(
+            id: location.id,
+            label: location.nickname ?? location.displayName,
+            displayName: location.displayName,
+            addressLine: location.addressLine,
+            isFavorite: location.isPinned,
+            latitude: location.latitude,
+            longitude: location.longitude
+        )
+    }
+
+    /// Build rows for the favorites section.
+    public static func favorites(from locations: [SavedLocation]) -> [SavedLocationRow] {
+        locations.filter(\.isPinned).map { from($0) }
+    }
+
+    /// Build rows for the recents section (up to `limit` items).
+    public static func recents(from locations: [SavedLocation], limit: Int = 5) -> [SavedLocationRow] {
+        locations
+            .filter { !$0.isPinned }
+            .prefix(limit)
+            .map { from($0) }
+    }
+}

--- a/RoadFlare/RoadFlareCore/Presentation/SavedLocationRow.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/SavedLocationRow.swift
@@ -61,10 +61,14 @@ public struct SavedLocationRow: Equatable, Sendable, Identifiable {
         locations.filter(\.isPinned).map { from($0) }
     }
 
-    /// Build rows for the recents section (up to `limit` items).
+    /// Build rows for the recents section (up to `limit` most-recent items).
+    ///
+    /// Sorts by `SavedLocation.timestampMs` descending so the newest visits
+    /// appear first regardless of the input array's order.
     public static func recents(from locations: [SavedLocation], limit: Int = 5) -> [SavedLocationRow] {
         locations
             .filter { !$0.isPinned }
+            .sorted { $0.timestampMs > $1.timestampMs }
             .prefix(limit)
             .map { from($0) }
     }

--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -1,0 +1,504 @@
+import Testing
+import Foundation
+@testable import RoadFlareCore
+@testable import RidestrSDK
+
+// MARK: - Shared test helpers
+
+private let fakePubkey = String(repeating: "a", count: 64)
+private let fakeKey = RoadflareKey(
+    privateKeyHex: String(repeating: "b", count: 64),
+    publicKeyHex:  String(repeating: "c", count: 64),
+    version: 3, keyUpdatedAt: nil
+)
+
+private func makeDriver(
+    pubkey: String = fakePubkey,
+    name: String? = nil,
+    note: String? = nil,
+    key: RoadflareKey? = fakeKey
+) -> FollowedDriver {
+    FollowedDriver(pubkey: pubkey, name: name, note: note, roadflareKey: key)
+}
+
+/// Create a `CachedDriverLocation` via the repository's `updateDriverLocation` method,
+/// then extract it, since `CachedDriverLocation.init` is internal to the SDK.
+private func makeLocation(
+    pubkey: String = fakePubkey,
+    status: String,
+    timestamp: Int = 1_000_000
+) -> CachedDriverLocation {
+    let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+    let driver = FollowedDriver(pubkey: pubkey)
+    repo.addDriver(driver)
+    _ = repo.updateDriverLocation(
+        pubkey: pubkey, latitude: 37.7, longitude: -122.4,
+        status: status, timestamp: timestamp, keyVersion: 1
+    )
+    return repo.driverLocations[pubkey]!
+}
+
+// MARK: - DriverListItem
+
+@Suite("DriverListItem")
+struct DriverListItemTests {
+
+    @Test func mapsDisplayNameFromExplicitOverride() {
+        let driver = makeDriver(name: "Alice")
+        let item = DriverListItem.from(driver, displayName: "Alice (cached)", location: nil,
+                                       profile: nil, isKeyStale: false, canPing: false)
+        #expect(item.displayName == "Alice (cached)")
+    }
+
+    @Test func fallsBackToDriverNameWhenNoOverride() {
+        let driver = makeDriver(name: "Bob")
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: nil, isKeyStale: false, canPing: false)
+        #expect(item.displayName == "Bob")
+    }
+
+    @Test func fallsBackToShortPubkeyWhenNoName() {
+        let driver = makeDriver(name: nil)
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: nil, isKeyStale: false, canPing: false)
+        #expect(item.displayName == String(fakePubkey.prefix(8)) + "...")
+    }
+
+    @Test func onlineStatus() {
+        let driver = makeDriver()
+        let loc = makeLocation(status: "online")
+        let item = DriverListItem.from(driver, displayName: nil, location: loc,
+                                       profile: nil, isKeyStale: false, canPing: false)
+        #expect(item.status == .online)
+        #expect(item.canRequestRide == true)
+    }
+
+    @Test func onRideStatus() {
+        let driver = makeDriver()
+        let loc = makeLocation(status: "on_ride")
+        let item = DriverListItem.from(driver, displayName: nil, location: loc,
+                                       profile: nil, isKeyStale: false, canPing: false)
+        #expect(item.status == .onRide)
+        #expect(item.canRequestRide == false)
+    }
+
+    @Test func offlineWhenNoLocation() {
+        let driver = makeDriver()
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: nil, isKeyStale: false, canPing: false)
+        #expect(item.status == .offline)
+    }
+
+    @Test func pendingApprovalWhenNoKey() {
+        let driver = makeDriver(key: nil)
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: nil, isKeyStale: false, canPing: false)
+        #expect(item.status == .pendingApproval)
+        #expect(item.canRequestRide == false)
+    }
+
+    @Test func keyStaleStatusTakesPrecedenceOverLocation() {
+        let driver = makeDriver()
+        let loc = makeLocation(status: "online")
+        let item = DriverListItem.from(driver, displayName: nil, location: loc,
+                                       profile: nil, isKeyStale: true, canPing: false)
+        #expect(item.status == .keyStale)
+        #expect(item.canRequestRide == false)
+    }
+
+    @Test func vehicleDescriptionFromProfile() {
+        let driver = makeDriver()
+        let profile = UserProfileContent(carMake: "Tesla", carModel: "Model 3", carColor: "Black")
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: profile, isKeyStale: false, canPing: false)
+        #expect(item.vehicleDescription == "Black Tesla Model 3")
+    }
+
+    @Test func canPingPropagated() {
+        let driver = makeDriver()
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: nil, isKeyStale: false, canPing: true)
+        #expect(item.canPing == true)
+    }
+
+    @Test func sortOrderOnlineFirst() {
+        let online = DriverListItem.from(makeDriver(), displayName: nil,
+                                          location: makeLocation(status: "online"),
+                                          profile: nil, isKeyStale: false, canPing: false)
+        let onRide = DriverListItem.from(makeDriver(), displayName: nil,
+                                          location: makeLocation(status: "on_ride"),
+                                          profile: nil, isKeyStale: false, canPing: false)
+        let offline = DriverListItem.from(makeDriver(), displayName: nil,
+                                           location: nil,
+                                           profile: nil, isKeyStale: false, canPing: false)
+        let pending = DriverListItem.from(makeDriver(key: nil), displayName: nil,
+                                           location: nil,
+                                           profile: nil, isKeyStale: false, canPing: false)
+        #expect(online.sortOrder < onRide.sortOrder)
+        #expect(onRide.sortOrder < offline.sortOrder)
+        #expect(pending.sortOrder < offline.sortOrder)
+    }
+}
+
+// MARK: - DriverDetailViewState
+
+@Suite("DriverDetailViewState")
+struct DriverDetailViewStateTests {
+
+    @Test func displayNameResolution() {
+        let driver = makeDriver(name: "Carol")
+        let state = DriverDetailViewState.from(driver, displayName: "Carol (repo)",
+                                               location: nil, profile: nil)
+        #expect(state.displayName == "Carol (repo)")
+    }
+
+    @Test func statusLabelAvailableWhenOnline() {
+        let driver = makeDriver()
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: makeLocation(status: "online"), profile: nil)
+        #expect(state.statusLabel == "Available")
+        #expect(state.canRequestRide == true)
+    }
+
+    @Test func statusLabelOnRide() {
+        let driver = makeDriver()
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: makeLocation(status: "on_ride"), profile: nil)
+        #expect(state.statusLabel == "On a ride")
+        #expect(state.canRequestRide == false)
+    }
+
+    @Test func statusLabelOfflineWhenNoLocation() {
+        let driver = makeDriver()
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil)
+        #expect(state.statusLabel == "Offline")
+        #expect(state.canRequestRide == false)
+    }
+
+    @Test func statusLabelPendingWhenNoKey() {
+        let driver = makeDriver(key: nil)
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil)
+        #expect(state.statusLabel == "Pending approval")
+        #expect(state.hasKey == false)
+    }
+
+    @Test func keyVersionExposesSdkVersion() {
+        let driver = makeDriver()  // fakeKey has version 3
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil)
+        #expect(state.hasKey == true)
+        #expect(state.keyVersion == 3)
+    }
+
+    @Test func noKeyVersionWhenNoKey() {
+        let driver = makeDriver(key: nil)
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil)
+        #expect(state.keyVersion == nil)
+    }
+
+    @Test func lastLocationTimestampLabelIsNilWhenNoLocation() {
+        let driver = makeDriver()
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil)
+        #expect(state.lastLocationTimestampLabel == nil)
+        #expect(state.lastLocationStatus == nil)
+    }
+
+    @Test func lastLocationTimestampLabelIsRelativeString() throws {
+        let driver = makeDriver()
+        let referenceDate = Date(timeIntervalSince1970: 1_000_000 + 180)  // 3 min after timestamp
+        let loc = makeLocation(status: "online", timestamp: 1_000_000)
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: loc, profile: nil,
+                                               referenceDate: referenceDate)
+        // Relative formatter should produce something non-empty
+        let label = try #require(state.lastLocationTimestampLabel)
+        #expect(!label.isEmpty)
+    }
+
+    @Test func noteDefaultsToEmptyString() {
+        let driver = makeDriver(note: nil)
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil)
+        #expect(state.note == "")
+    }
+
+    @Test func notePreserved() {
+        let driver = makeDriver(note: "Great driver!")
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil)
+        #expect(state.note == "Great driver!")
+    }
+}
+
+// MARK: - RideRequestDriverOption
+
+@Suite("RideRequestDriverOption")
+struct RideRequestDriverOptionTests {
+
+    @Test func returnsNilWhenNoKey() {
+        let driver = makeDriver(key: nil)
+        let result = RideRequestDriverOption.from(driver, displayName: nil,
+                                                   location: makeLocation(status: "online"))
+        #expect(result == nil)
+    }
+
+    @Test func returnsNilWhenOffline() {
+        let driver = makeDriver()
+        let result = RideRequestDriverOption.from(driver, displayName: nil,
+                                                   location: makeLocation(status: "offline"))
+        #expect(result == nil)
+    }
+
+    @Test func returnsNilWhenNoLocation() {
+        let driver = makeDriver()
+        let result = RideRequestDriverOption.from(driver, displayName: nil, location: nil)
+        #expect(result == nil)
+    }
+
+    @Test func returnsOptionWhenOnline() throws {
+        let driver = makeDriver(name: "Dave")
+        let result = RideRequestDriverOption.from(driver, displayName: "Dave (cached)",
+                                                   location: makeLocation(status: "online"))
+        let option = try #require(result)
+        #expect(option.pubkey == fakePubkey)
+        #expect(option.displayName == "Dave (cached)")
+    }
+
+    @Test func idMatchesPubkey() throws {
+        let driver = makeDriver()
+        let option = try #require(
+            RideRequestDriverOption.from(driver, displayName: nil,
+                                          location: makeLocation(status: "online"))
+        )
+        #expect(option.id == option.pubkey)
+    }
+
+    @Test func onlineOptionsFiltersOfflineDrivers() {
+        let pubkey2 = String(repeating: "d", count: 64)
+        let onlineDriver  = makeDriver(pubkey: fakePubkey)
+        let offlineDriver = makeDriver(pubkey: pubkey2)
+        let names: [String: String] = [:]
+        let locations: [String: CachedDriverLocation] = [
+            fakePubkey: makeLocation(pubkey: fakePubkey, status: "online"),
+            pubkey2:    makeLocation(pubkey: pubkey2, status: "offline"),
+        ]
+        let options = RideRequestDriverOption.onlineOptions(
+            from: [onlineDriver, offlineDriver],
+            driverNames: names,
+            driverLocations: locations
+        )
+        #expect(options.count == 1)
+        #expect(options.first?.pubkey == fakePubkey)
+    }
+}
+
+// MARK: - RideHistoryRow
+
+@Suite("RideHistoryRow")
+struct RideHistoryRowTests {
+
+    private func makeEntry(
+        id: String = "ride-1",
+        date: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        status: String = "completed",
+        counterpartyName: String? = "Eve",
+        pickupAddress: String? = "123 Main St",
+        destAddress: String? = "456 Oak Ave",
+        fare: Decimal = Decimal(string: "14.50")!,
+        paymentMethod: String = "cash_app",
+        distance: Double? = 4.2,
+        duration: Int? = 18
+    ) -> RideHistoryEntry {
+        let pickup = Location(latitude: 37.7, longitude: -122.4, address: pickupAddress)
+        let dest   = Location(latitude: 37.8, longitude: -122.5, address: destAddress)
+        return RideHistoryEntry(
+            id: id, date: date, status: status,
+            counterpartyPubkey: fakePubkey, counterpartyName: counterpartyName,
+            pickupGeohash: "9q8yy", dropoffGeohash: "9q8yz",
+            pickup: pickup, destination: dest,
+            fare: fare, paymentMethod: paymentMethod,
+            distance: distance, duration: duration
+        )
+    }
+
+    @Test func idPreserved() {
+        let row = RideHistoryRow.from(makeEntry(id: "ride-42"))
+        #expect(row.id == "ride-42")
+    }
+
+    @Test func datePreserved() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let row = RideHistoryRow.from(makeEntry(date: date))
+        #expect(row.date == date)
+    }
+
+    @Test func fareLabelFormattedCorrectly() {
+        let row = RideHistoryRow.from(makeEntry(fare: Decimal(string: "14.50")!))
+        #expect(row.fareLabel == "$14.50")
+    }
+
+    @Test func fareLabelZeroShowsDash() {
+        let row = RideHistoryRow.from(makeEntry(fare: 0))
+        #expect(row.fareLabel == "–")
+    }
+
+    @Test func distanceLabelFormatted() {
+        let row = RideHistoryRow.from(makeEntry(distance: 4.2))
+        #expect(row.distanceLabel == "4.2 mi")
+    }
+
+    @Test func distanceLabelNilWhenAbsent() {
+        let row = RideHistoryRow.from(makeEntry(distance: nil))
+        #expect(row.distanceLabel == nil)
+    }
+
+    @Test func durationLabelFormatted() {
+        let row = RideHistoryRow.from(makeEntry(duration: 18))
+        #expect(row.durationLabel == "18 min")
+    }
+
+    @Test func durationLabelNilWhenAbsent() {
+        let row = RideHistoryRow.from(makeEntry(duration: nil))
+        #expect(row.durationLabel == nil)
+    }
+
+    @Test func paymentMethodLabelResolvesKnownMethod() {
+        let row = RideHistoryRow.from(makeEntry(paymentMethod: "cash_app"))
+        #expect(row.paymentMethodLabel == "Cash App")
+    }
+
+    @Test func paymentMethodLabelPassesThroughUnknown() {
+        let row = RideHistoryRow.from(makeEntry(paymentMethod: "custom_rail"))
+        #expect(row.paymentMethodLabel == "custom_rail")
+    }
+
+    @Test func isCompletedTrueForCompletedStatus() {
+        let row = RideHistoryRow.from(makeEntry(status: "completed"))
+        #expect(row.isCompleted == true)
+    }
+
+    @Test func isCompletedFalseForCancelledStatus() {
+        let row = RideHistoryRow.from(makeEntry(status: "cancelled"))
+        #expect(row.isCompleted == false)
+    }
+
+    @Test func counterpartyNamePreserved() {
+        let row = RideHistoryRow.from(makeEntry(counterpartyName: "Eve"))
+        #expect(row.counterpartyName == "Eve")
+    }
+
+    @Test func nilCounterpartyNamePreserved() {
+        let row = RideHistoryRow.from(makeEntry(counterpartyName: nil))
+        #expect(row.counterpartyName == nil)
+    }
+
+    @Test func addressesPreserved() {
+        let row = RideHistoryRow.from(makeEntry(pickupAddress: "123 Main St",
+                                                destAddress: "456 Oak Ave"))
+        #expect(row.pickupAddress == "123 Main St")
+        #expect(row.destinationAddress == "456 Oak Ave")
+    }
+}
+
+// MARK: - SavedLocationRow
+
+@Suite("SavedLocationRow")
+struct SavedLocationRowTests {
+
+    private func makeLocation(
+        id: String = "loc-1",
+        displayName: String = "Home",
+        addressLine: String = "100 Maple Ave",
+        isPinned: Bool = true,
+        nickname: String? = "Home",
+        lat: Double = 37.7,
+        lon: Double = -122.4
+    ) -> SavedLocation {
+        SavedLocation(
+            id: id, latitude: lat, longitude: lon,
+            displayName: displayName, addressLine: addressLine,
+            isPinned: isPinned, nickname: nickname
+        )
+    }
+
+    @Test func idPreserved() {
+        let row = SavedLocationRow.from(makeLocation(id: "loc-99"))
+        #expect(row.id == "loc-99")
+    }
+
+    @Test func labelUsesNicknameWhenPresent() {
+        let row = SavedLocationRow.from(makeLocation(displayName: "123 Main", nickname: "Home"))
+        #expect(row.label == "Home")
+    }
+
+    @Test func labelFallsBackToDisplayNameWhenNoNickname() {
+        let row = SavedLocationRow.from(makeLocation(displayName: "Coffee Shop", nickname: nil))
+        #expect(row.label == "Coffee Shop")
+    }
+
+    @Test func isFavoriteMatchesPinned() {
+        let pinned = SavedLocationRow.from(makeLocation(isPinned: true))
+        let recent  = SavedLocationRow.from(makeLocation(isPinned: false, nickname: nil))
+        #expect(pinned.isFavorite == true)
+        #expect(recent.isFavorite == false)
+    }
+
+    @Test func iconForHome() {
+        let row = SavedLocationRow.from(makeLocation(nickname: "Home"))
+        #expect(row.iconSystemName == "house.fill")
+    }
+
+    @Test func iconForWork() {
+        let row = SavedLocationRow.from(makeLocation(displayName: "Work HQ", nickname: "Work"))
+        #expect(row.iconSystemName == "briefcase.fill")
+    }
+
+    @Test func iconForFavoriteFallback() {
+        let row = SavedLocationRow.from(makeLocation(displayName: "Gym", nickname: "Gym"))
+        #expect(row.iconSystemName == "star.fill")
+    }
+
+    @Test func iconForRecentFallback() {
+        let row = SavedLocationRow.from(makeLocation(displayName: "Airport", isPinned: false, nickname: nil))
+        #expect(row.iconSystemName == "clock")
+    }
+
+    @Test func coordinatesPreserved() {
+        let row = SavedLocationRow.from(makeLocation(lat: 40.7128, lon: -74.0060))
+        #expect(row.latitude == 40.7128)
+        #expect(row.longitude == -74.0060)
+    }
+
+    @Test func addressLinePreserved() {
+        let row = SavedLocationRow.from(makeLocation(addressLine: "100 Maple Ave"))
+        #expect(row.addressLine == "100 Maple Ave")
+    }
+
+    @Test func favoritesFilterFunction() {
+        let fav = makeLocation(id: "f1", isPinned: true)
+        let rec = makeLocation(id: "r1", isPinned: false, nickname: nil)
+        let rows = SavedLocationRow.favorites(from: [fav, rec])
+        #expect(rows.count == 1)
+        #expect(rows.first?.id == "f1")
+    }
+
+    @Test func recentsFilterFunction() {
+        let fav = makeLocation(id: "f1", isPinned: true)
+        let rec = makeLocation(id: "r1", isPinned: false, nickname: nil)
+        let rows = SavedLocationRow.recents(from: [fav, rec])
+        #expect(rows.count == 1)
+        #expect(rows.first?.id == "r1")
+    }
+
+    @Test func recentsLimitRespected() {
+        let locs = (1...10).map { i in
+            makeLocation(id: "r\(i)", isPinned: false, nickname: nil)
+        }
+        let rows = SavedLocationRow.recents(from: locs, limit: 3)
+        #expect(rows.count == 3)
+    }
+}

--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -203,9 +203,11 @@ struct DriverDetailViewStateTests {
                                                isKeyStale: true, canPing: false)
         #expect(state.statusLabel == "Key outdated")
         #expect(state.canRequestRide == false)
-        // lastLocationStatus must be nil for stale keys — the raw "online" string
-        // would contradict the "Key outdated" label if shown in the detail sheet.
+        // Both last-location fields must be nil when the key is stale — the
+        // raw "online" status and the "3 min ago" timestamp were both derived
+        // from a broadcast decrypted with the pre-rotation key.
         #expect(state.lastLocationStatus == nil)
+        #expect(state.lastLocationTimestampLabel == nil)
     }
 
     @Test func pictureURLFromProfile() {
@@ -263,12 +265,15 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let referenceDate = Date(timeIntervalSince1970: 1_000_000 + 180)  // 3 min after timestamp
         let loc = makeLocation(status: "online", timestamp: 1_000_000)
+        // Locale pinned to en_US so the assertion is deterministic across CI hosts —
+        // production callers use the default `.current` locale.
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: loc, profile: nil,
                                                isKeyStale: false, canPing: false,
-                                               referenceDate: referenceDate)
+                                               referenceDate: referenceDate,
+                                               locale: Locale(identifier: "en_US"))
         let label = try #require(state.lastLocationTimestampLabel)
-        #expect(label.contains("min") || label.contains("minute") || label.contains("3"))
+        #expect(label.contains("min"))
     }
 
     @Test func noteDefaultsToEmptyString() {

--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -152,7 +152,8 @@ struct DriverDetailViewStateTests {
     @Test func displayNameResolution() {
         let driver = makeDriver(name: "Carol")
         let state = DriverDetailViewState.from(driver, displayName: "Carol (repo)",
-                                               location: nil, profile: nil, isKeyStale: false)
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: false)
         #expect(state.displayName == "Carol (repo)")
     }
 
@@ -160,24 +161,27 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: makeLocation(status: "online"),
-                                               profile: nil, isKeyStale: false)
+                                               profile: nil, isKeyStale: false, canPing: false)
         #expect(state.statusLabel == "Available")
         #expect(state.canRequestRide == true)
+        #expect(state.lastLocationStatus == "online")
     }
 
     @Test func statusLabelOnRide() {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: makeLocation(status: "on_ride"),
-                                               profile: nil, isKeyStale: false)
+                                               profile: nil, isKeyStale: false, canPing: false)
         #expect(state.statusLabel == "On a ride")
         #expect(state.canRequestRide == false)
+        #expect(state.lastLocationStatus == "on_ride")
     }
 
     @Test func statusLabelOfflineWhenNoLocation() {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil, isKeyStale: false)
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: false)
         #expect(state.statusLabel == "Offline")
         #expect(state.canRequestRide == false)
     }
@@ -185,7 +189,8 @@ struct DriverDetailViewStateTests {
     @Test func statusLabelPendingWhenNoKey() {
         let driver = makeDriver(key: nil)
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil, isKeyStale: false)
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: false)
         #expect(state.statusLabel == "Pending approval")
         #expect(state.hasKey == false)
     }
@@ -194,15 +199,45 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let online = makeLocation(status: "online")
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: online, profile: nil, isKeyStale: true)
+                                               location: online, profile: nil,
+                                               isKeyStale: true, canPing: false)
         #expect(state.statusLabel == "Key outdated")
         #expect(state.canRequestRide == false)
+        // lastLocationStatus must be nil for stale keys — the raw "online" string
+        // would contradict the "Key outdated" label if shown in the detail sheet.
+        #expect(state.lastLocationStatus == nil)
+    }
+
+    @Test func pictureURLFromProfile() {
+        let driver = makeDriver()
+        let profile = UserProfileContent(picture: "https://example.com/pic.jpg")
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: profile,
+                                               isKeyStale: false, canPing: false)
+        #expect(state.pictureURL == "https://example.com/pic.jpg")
+    }
+
+    @Test func pictureURLNilWhenNoProfile() {
+        let driver = makeDriver()
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: false)
+        #expect(state.pictureURL == nil)
+    }
+
+    @Test func canPingPropagated() {
+        let driver = makeDriver()
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: true)
+        #expect(state.canPing == true)
     }
 
     @Test func keyVersionExposesSdkVersion() {
         let driver = makeDriver()  // fakeKey has version 3
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil, isKeyStale: false)
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: false)
         #expect(state.hasKey == true)
         #expect(state.keyVersion == 3)
     }
@@ -210,14 +245,16 @@ struct DriverDetailViewStateTests {
     @Test func noKeyVersionWhenNoKey() {
         let driver = makeDriver(key: nil)
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil, isKeyStale: false)
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: false)
         #expect(state.keyVersion == nil)
     }
 
     @Test func lastLocationTimestampLabelIsNilWhenNoLocation() {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil, isKeyStale: false)
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: false)
         #expect(state.lastLocationTimestampLabel == nil)
         #expect(state.lastLocationStatus == nil)
     }
@@ -228,23 +265,25 @@ struct DriverDetailViewStateTests {
         let loc = makeLocation(status: "online", timestamp: 1_000_000)
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: loc, profile: nil,
-                                               isKeyStale: false, referenceDate: referenceDate)
-        // Relative formatter should produce something non-empty
+                                               isKeyStale: false, canPing: false,
+                                               referenceDate: referenceDate)
         let label = try #require(state.lastLocationTimestampLabel)
-        #expect(!label.isEmpty)
+        #expect(label.contains("min") || label.contains("minute") || label.contains("3"))
     }
 
     @Test func noteDefaultsToEmptyString() {
         let driver = makeDriver(note: nil)
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil, isKeyStale: false)
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: false)
         #expect(state.note == "")
     }
 
     @Test func notePreserved() {
         let driver = makeDriver(note: "Great driver!")
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil, isKeyStale: false)
+                                               location: nil, profile: nil,
+                                               isKeyStale: false, canPing: false)
         #expect(state.note == "Great driver!")
     }
 }
@@ -317,7 +356,26 @@ struct RideRequestDriverOptionTests {
         let options = RideRequestDriverOption.onlineOptions(
             from: [onlineDriver, offlineDriver],
             driverNames: names,
-            driverLocations: locations
+            driverLocations: locations,
+            staleKeyPubkeys: []
+        )
+        #expect(options.count == 1)
+        #expect(options.first?.pubkey == fakePubkey)
+    }
+
+    @Test func onlineOptionsFiltersOnRideDrivers() {
+        let pubkey2 = String(repeating: "d", count: 64)
+        let onlineDriver = makeDriver(pubkey: fakePubkey)
+        let onRideDriver = makeDriver(pubkey: pubkey2)
+        let locations: [String: CachedDriverLocation] = [
+            fakePubkey: makeLocation(pubkey: fakePubkey, status: "online"),
+            pubkey2:    makeLocation(pubkey: pubkey2, status: "on_ride"),
+        ]
+        let options = RideRequestDriverOption.onlineOptions(
+            from: [onlineDriver, onRideDriver],
+            driverNames: [:],
+            driverLocations: locations,
+            staleKeyPubkeys: []
         )
         #expect(options.count == 1)
         #expect(options.first?.pubkey == fakePubkey)
@@ -546,5 +604,20 @@ struct SavedLocationRowTests {
         }
         let rows = SavedLocationRow.recents(from: locs, limit: 3)
         #expect(rows.count == 3)
+    }
+
+    @Test func recentsSortedByTimestampDescending() {
+        let oldest = SavedLocation(id: "old", latitude: 0, longitude: 0,
+                                   displayName: "Old Place", addressLine: "1 Old St",
+                                   isPinned: false, timestampMs: 1_000_000)
+        let newest = SavedLocation(id: "new", latitude: 0, longitude: 0,
+                                   displayName: "New Place", addressLine: "2 New St",
+                                   isPinned: false, timestampMs: 3_000_000)
+        let middle = SavedLocation(id: "mid", latitude: 0, longitude: 0,
+                                   displayName: "Mid Place", addressLine: "3 Mid St",
+                                   isPinned: false, timestampMs: 2_000_000)
+        // Input is intentionally out of order to verify sorting, not just filtering.
+        let rows = SavedLocationRow.recents(from: [oldest, newest, middle])
+        #expect(rows.map(\.id) == ["new", "mid", "old"])
     }
 }

--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -106,6 +106,19 @@ struct DriverListItemTests {
         #expect(item.canRequestRide == false)
     }
 
+    // Pins the short-circuit in resolveDriverPresentationStatus: isKeyStale must
+    // win over any location state. If the priority ladder is ever reordered, these
+    // assertions catch it regardless of which location.status string is present.
+    @Test(arguments: ["on_ride", "offline", "unknown_status"])
+    func keyStalePrecedenceAcrossLocationStates(status: String) {
+        let driver = makeDriver()
+        let loc = makeLocation(status: status)
+        let item = DriverListItem.from(driver, displayName: nil, location: loc,
+                                       profile: nil, isKeyStale: true, canPing: false)
+        #expect(item.status == .keyStale)
+        #expect(item.canRequestRide == false)
+    }
+
     @Test func vehicleDescriptionFromProfile() {
         let driver = makeDriver()
         let profile = UserProfileContent(carMake: "Tesla", carModel: "Model 3", carColor: "Black")
@@ -206,6 +219,22 @@ struct DriverDetailViewStateTests {
         // Both last-location fields must be nil when the key is stale — the
         // raw "online" status and the "3 min ago" timestamp were both derived
         // from a broadcast decrypted with the pre-rotation key.
+        #expect(state.lastLocationStatus == nil)
+        #expect(state.lastLocationTimestampLabel == nil)
+    }
+
+    // Mirrors the DriverListItem precedence test: stale wins over any location
+    // status. Also verifies lastLocationStatus stays nil regardless of the raw
+    // value, so views can't accidentally render a pre-rotation status string.
+    @Test(arguments: ["on_ride", "offline", "unknown_status"])
+    func keyStalePrecedenceAcrossLocationStates(status: String) {
+        let driver = makeDriver()
+        let loc = makeLocation(status: status)
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: loc, profile: nil,
+                                               isKeyStale: true, canPing: false)
+        #expect(state.statusLabel == "Key outdated")
+        #expect(state.canRequestRide == false)
         #expect(state.lastLocationStatus == nil)
         #expect(state.lastLocationTimestampLabel == nil)
     }
@@ -453,6 +482,15 @@ struct RideHistoryRowTests {
     @Test func fareLabelZeroShowsDash() {
         let row = RideHistoryRow.from(makeEntry(fare: 0))
         #expect(row.fareLabel == "–")
+    }
+
+    @Test func fareLabelNegativeShowsMinusSign() {
+        // Pins the NumberFormatter behavior the pass-2 fix was made for:
+        // the previous Double-conversion path could render "$-0.00" for very
+        // small negative values. NumberFormatter puts the sign in the correct
+        // position ("-$5.00"), which is what we want to show for refunds.
+        let row = RideHistoryRow.from(makeEntry(fare: Decimal(string: "-5.00")!))
+        #expect(row.fareLabel == "-$5.00")
     }
 
     @Test func distanceLabelFormatted() {

--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -128,14 +128,18 @@ struct DriverListItemTests {
         let onRide = DriverListItem.from(makeDriver(), displayName: nil,
                                           location: makeLocation(status: "on_ride"),
                                           profile: nil, isKeyStale: false, canPing: false)
-        let offline = DriverListItem.from(makeDriver(), displayName: nil,
-                                           location: nil,
-                                           profile: nil, isKeyStale: false, canPing: false)
+        let keyStale = DriverListItem.from(makeDriver(), displayName: nil,
+                                            location: makeLocation(status: "online"),
+                                            profile: nil, isKeyStale: true, canPing: false)
         let pending = DriverListItem.from(makeDriver(key: nil), displayName: nil,
                                            location: nil,
                                            profile: nil, isKeyStale: false, canPing: false)
+        let offline = DriverListItem.from(makeDriver(), displayName: nil,
+                                           location: nil,
+                                           profile: nil, isKeyStale: false, canPing: false)
         #expect(online.sortOrder < onRide.sortOrder)
-        #expect(onRide.sortOrder < offline.sortOrder)
+        #expect(onRide.sortOrder < keyStale.sortOrder)
+        #expect(keyStale.sortOrder < pending.sortOrder)
         #expect(pending.sortOrder < offline.sortOrder)
     }
 }
@@ -148,14 +152,15 @@ struct DriverDetailViewStateTests {
     @Test func displayNameResolution() {
         let driver = makeDriver(name: "Carol")
         let state = DriverDetailViewState.from(driver, displayName: "Carol (repo)",
-                                               location: nil, profile: nil)
+                                               location: nil, profile: nil, isKeyStale: false)
         #expect(state.displayName == "Carol (repo)")
     }
 
     @Test func statusLabelAvailableWhenOnline() {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: makeLocation(status: "online"), profile: nil)
+                                               location: makeLocation(status: "online"),
+                                               profile: nil, isKeyStale: false)
         #expect(state.statusLabel == "Available")
         #expect(state.canRequestRide == true)
     }
@@ -163,7 +168,8 @@ struct DriverDetailViewStateTests {
     @Test func statusLabelOnRide() {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: makeLocation(status: "on_ride"), profile: nil)
+                                               location: makeLocation(status: "on_ride"),
+                                               profile: nil, isKeyStale: false)
         #expect(state.statusLabel == "On a ride")
         #expect(state.canRequestRide == false)
     }
@@ -171,7 +177,7 @@ struct DriverDetailViewStateTests {
     @Test func statusLabelOfflineWhenNoLocation() {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil)
+                                               location: nil, profile: nil, isKeyStale: false)
         #expect(state.statusLabel == "Offline")
         #expect(state.canRequestRide == false)
     }
@@ -179,15 +185,24 @@ struct DriverDetailViewStateTests {
     @Test func statusLabelPendingWhenNoKey() {
         let driver = makeDriver(key: nil)
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil)
+                                               location: nil, profile: nil, isKeyStale: false)
         #expect(state.statusLabel == "Pending approval")
         #expect(state.hasKey == false)
+    }
+
+    @Test func keyStaleStatusLabelAndBlocksRequest() {
+        let driver = makeDriver()
+        let online = makeLocation(status: "online")
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: online, profile: nil, isKeyStale: true)
+        #expect(state.statusLabel == "Key outdated")
+        #expect(state.canRequestRide == false)
     }
 
     @Test func keyVersionExposesSdkVersion() {
         let driver = makeDriver()  // fakeKey has version 3
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil)
+                                               location: nil, profile: nil, isKeyStale: false)
         #expect(state.hasKey == true)
         #expect(state.keyVersion == 3)
     }
@@ -195,14 +210,14 @@ struct DriverDetailViewStateTests {
     @Test func noKeyVersionWhenNoKey() {
         let driver = makeDriver(key: nil)
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil)
+                                               location: nil, profile: nil, isKeyStale: false)
         #expect(state.keyVersion == nil)
     }
 
     @Test func lastLocationTimestampLabelIsNilWhenNoLocation() {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil)
+                                               location: nil, profile: nil, isKeyStale: false)
         #expect(state.lastLocationTimestampLabel == nil)
         #expect(state.lastLocationStatus == nil)
     }
@@ -213,7 +228,7 @@ struct DriverDetailViewStateTests {
         let loc = makeLocation(status: "online", timestamp: 1_000_000)
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: loc, profile: nil,
-                                               referenceDate: referenceDate)
+                                               isKeyStale: false, referenceDate: referenceDate)
         // Relative formatter should produce something non-empty
         let label = try #require(state.lastLocationTimestampLabel)
         #expect(!label.isEmpty)
@@ -222,14 +237,14 @@ struct DriverDetailViewStateTests {
     @Test func noteDefaultsToEmptyString() {
         let driver = makeDriver(note: nil)
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil)
+                                               location: nil, profile: nil, isKeyStale: false)
         #expect(state.note == "")
     }
 
     @Test func notePreserved() {
         let driver = makeDriver(note: "Great driver!")
         let state = DriverDetailViewState.from(driver, displayName: nil,
-                                               location: nil, profile: nil)
+                                               location: nil, profile: nil, isKeyStale: false)
         #expect(state.note == "Great driver!")
     }
 }
@@ -242,27 +257,39 @@ struct RideRequestDriverOptionTests {
     @Test func returnsNilWhenNoKey() {
         let driver = makeDriver(key: nil)
         let result = RideRequestDriverOption.from(driver, displayName: nil,
-                                                   location: makeLocation(status: "online"))
+                                                   location: makeLocation(status: "online"),
+                                                   isKeyStale: false)
         #expect(result == nil)
     }
 
     @Test func returnsNilWhenOffline() {
         let driver = makeDriver()
         let result = RideRequestDriverOption.from(driver, displayName: nil,
-                                                   location: makeLocation(status: "offline"))
+                                                   location: makeLocation(status: "offline"),
+                                                   isKeyStale: false)
         #expect(result == nil)
     }
 
     @Test func returnsNilWhenNoLocation() {
         let driver = makeDriver()
-        let result = RideRequestDriverOption.from(driver, displayName: nil, location: nil)
+        let result = RideRequestDriverOption.from(driver, displayName: nil,
+                                                   location: nil, isKeyStale: false)
+        #expect(result == nil)
+    }
+
+    @Test func returnsNilWhenKeyIsStale() {
+        let driver = makeDriver()
+        let result = RideRequestDriverOption.from(driver, displayName: nil,
+                                                   location: makeLocation(status: "online"),
+                                                   isKeyStale: true)
         #expect(result == nil)
     }
 
     @Test func returnsOptionWhenOnline() throws {
         let driver = makeDriver(name: "Dave")
         let result = RideRequestDriverOption.from(driver, displayName: "Dave (cached)",
-                                                   location: makeLocation(status: "online"))
+                                                   location: makeLocation(status: "online"),
+                                                   isKeyStale: false)
         let option = try #require(result)
         #expect(option.pubkey == fakePubkey)
         #expect(option.displayName == "Dave (cached)")
@@ -272,7 +299,8 @@ struct RideRequestDriverOptionTests {
         let driver = makeDriver()
         let option = try #require(
             RideRequestDriverOption.from(driver, displayName: nil,
-                                          location: makeLocation(status: "online"))
+                                          location: makeLocation(status: "online"),
+                                          isKeyStale: false)
         )
         #expect(option.id == option.pubkey)
     }
@@ -290,6 +318,24 @@ struct RideRequestDriverOptionTests {
             from: [onlineDriver, offlineDriver],
             driverNames: names,
             driverLocations: locations
+        )
+        #expect(options.count == 1)
+        #expect(options.first?.pubkey == fakePubkey)
+    }
+
+    @Test func onlineOptionsFiltersStaleKeyDrivers() {
+        let pubkey2 = String(repeating: "d", count: 64)
+        let freshDriver = makeDriver(pubkey: fakePubkey)
+        let staleDriver = makeDriver(pubkey: pubkey2)
+        let locations: [String: CachedDriverLocation] = [
+            fakePubkey: makeLocation(pubkey: fakePubkey, status: "online"),
+            pubkey2:    makeLocation(pubkey: pubkey2, status: "online"),
+        ]
+        let options = RideRequestDriverOption.onlineOptions(
+            from: [freshDriver, staleDriver],
+            driverNames: [:],
+            driverLocations: locations,
+            staleKeyPubkeys: [pubkey2]
         )
         #expect(options.count == 1)
         #expect(options.first?.pubkey == fakePubkey)

--- a/decisions/0011-presentation-projection-layer.md
+++ b/decisions/0011-presentation-projection-layer.md
@@ -1,0 +1,46 @@
+# ADR-0011: Presentation Projection Layer in RoadFlareCore
+
+**Status:** Active
+**Created:** 2026-04-17
+**Tags:** architecture, refactor, view-layer
+
+## Context
+
+Views were importing `RidestrSDK` domain models directly and computing display logic inline (status label strings, `canRequestRide` booleans, relative timestamps, formatted fares). This scattered identical business-of-display decisions across multiple SwiftUI files, made views harder to unit-test without the SDK, and blurred the boundary between protocol-layer concerns (what a `FollowedDriver` is) and display-layer concerns (how to show it).
+
+The coordinator-boundary refactor (ADR-0001, PR #58) introduced `AppState` as the single facade for view data. To complete the boundary, views need to receive pre-projected, display-ready values rather than raw SDK types.
+
+## Decision
+
+Introduce an app-owned `Presentation/` sublayer inside `RoadFlareCore` containing immutable `Sendable` structs with static `from(...)` factory methods. Each type projects one SDK domain aggregate + repository context into a view-ready value with all display strings and booleans pre-computed.
+
+Initial types: `DriverListItem`, `DriverDetailViewState`, `RideRequestDriverOption`, `RideHistoryRow`, `SavedLocationRow`.
+
+## Rationale
+
+- **Immutable value types** (`struct`) are safe across Swift Concurrency boundaries without locks.
+- **Static factory** keeps construction logic out of views and out of the SDK. Views stay dumb; the SDK stays protocol-clean.
+- **`RoadFlareCore` (not `RidestrSDK`)** is the right home: these types encode iOS display decisions (SF Symbol names, `RelativeDateTimeFormatter`, fare string format) that have no business in the protocol SDK.
+- **Pre-computation at factory time** means SwiftUI's diffing compares only `Equatable` value types, not live repository state.
+
+## Alternatives Considered
+
+- **Pass SDK models directly to views** — rejected: views would import `RidestrSDK`, mix display logic with protocol logic, and become untestable without the full SDK stack.
+- **`@Observable` ViewModels per screen** — rejected: each ViewModel would duplicate the same status-label / canRequestRide logic; cross-screen consistency harder to guarantee; harder to test in isolation.
+- **Projection inside `AppState` as computed properties** — rejected: `AppState` is a coordinator, not a display transformer; mixing both concerns would grow it unboundedly.
+
+## Consequences
+
+- All new screen state types follow this pattern: `public struct Foo: Equatable, Sendable` with `static func from(...)`.
+- Views import `RoadFlareCore` only; zero direct `RidestrSDK` imports in view files.
+- Factory signatures are the contract: adding a new display field means adding a parameter (or deriving it from existing ones), keeping the call site explicit about what data each type needs.
+- Callers must supply `isKeyStale:` for driver-facing types; this comes from `FollowedDriversRepository.staleKeyPubkeys`.
+
+## Affected Files
+
+- `RoadFlare/RoadFlareCore/Presentation/DriverListItem.swift`
+- `RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift`
+- `RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift`
+- `RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift`
+- `RoadFlare/RoadFlareCore/Presentation/SavedLocationRow.swift`
+- `RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift`


### PR DESCRIPTION
## Summary

Introduces app-owned presentation types so SwiftUI views render app-layer screen data instead of raw SDK domain models (closes #49).

## Scope

**New types in `RoadFlare/RoadFlareCore/Presentation/`:**
- `DriverListItem`
- `DriverDetailViewState`
- `RideRequestDriverOption`
- `RideHistoryRow`
- `SavedLocationRow`

**View refactors** (after #58 merges and this branch rebases):
- `DriversTab`, `DriverDetailSheet`, `AddDriverSheet` → `DriverListItem` / `DriverDetailViewState`
- `RideRequestView` → `RideRequestDriverOption`
- `HistoryTab` → `RideHistoryRow`
- `SavedLocationsView` → `SavedLocationRow`

## Dependencies

Presentation type definitions are independent and can land immediately. View hookup work rebases onto `refactor/coordinator-boundary-and-facade` (#58) once it merges.

## Test plan

- [ ] Unit tests for computed display properties on all new presentation types
- [ ] `xcodebuild` clean build passes
- [ ] Major views have materially fewer direct `RidestrSDK` imports

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)