### PR TITLE
feat(app): register roadflared: URL scheme for driver-share deep links

### DIFF
--- a/RoadFlare/RoadFlare/Info.plist
+++ b/RoadFlare/RoadFlare/Info.plist
@@ -12,5 +12,18 @@
 	<array>
 		<string>SpaceGrotesk-Bold.ttf</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.roadflare.RoadFlare.driver-share</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>roadflared</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/RoadFlare/RoadFlare/RoadFlareApp.swift
+++ b/RoadFlare/RoadFlare/RoadFlareApp.swift
@@ -29,6 +29,12 @@ struct RoadFlareApp: App {
                         }
                     }
                 }
+                .onOpenURL { url in
+                    // Custom URL scheme dispatch (e.g. `roadflared:npub1...?name=...`).
+                    // Fires on both cold-start and warm-app paths. AppState routes
+                    // the parsed driver intent into the drivers tab.
+                    appState.handleIncomingURL(url)
+                }
         }
     }
 }

--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -6,16 +6,31 @@ import RoadFlareCore
 /// After scanning or pasting a valid key, fetches the driver's profile from Nostr
 /// and shows a driver info card for confirmation before adding.
 struct AddDriverSheet: View {
+    /// Optional pre-resolved driver code (from a `roadflared:` deep link or
+    /// other external source). When non-nil, the sheet seeds `lookupDraft` and
+    /// auto-triggers profile lookup on first appear, skipping the scan/paste
+    /// step. Default `nil` preserves the existing call sites that present an
+    /// empty sheet for manual input.
+    let prefill: ParsedDriverQRCode?
+
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
     @State private var lookupDraft = DriverLookupDraft()
     @State private var showScanner = false
+    /// Tracks whether `prefill` has been consumed, so re-renders don't re-fire
+    /// the auto-lookup (e.g. after the user backs out via "Look Up Different
+    /// Driver" they should not be bounced back into the prefill flow).
+    @State private var didConsumePrefill = false
 
     // Resolved driver state
     @State private var resolvedHexPubkey: String?
     @State private var resolvedProfile: UserProfileContent?
     @State private var isFetchingProfile = false
     @State private var noteInput = ""
+
+    init(prefill: ParsedDriverQRCode? = nil) {
+        self.prefill = prefill
+    }
 
     var body: some View {
         NavigationStack {
@@ -61,6 +76,19 @@ struct AddDriverSheet: View {
                 QRScannerSheet { scannedValue in
                     handleScan(scannedValue)
                 }
+            }
+            .task {
+                // If a deep-link payload was passed in, seed the draft and
+                // immediately kick off profile lookup so the user lands on
+                // the driver-info card with no manual step. The `didConsume`
+                // flag prevents re-firing if the view re-appears.
+                guard let parsed = prefill, !didConsumePrefill else { return }
+                didConsumePrefill = true
+                lookupDraft = DriverLookupDraft(
+                    pubkeyInput: parsed.pubkeyInput,
+                    scannedName: parsed.scannedName
+                )
+                resolveInput()
             }
         }
     }

--- a/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
@@ -5,6 +5,10 @@ import RoadFlareCore
 struct DriversTab: View {
     @Environment(AppState.self) private var appState
     @State private var showAddDriver = false
+    /// Captured from `appState.pendingDriverDeepLink` when a `roadflared:` URL
+    /// arrives, then handed to `AddDriverSheet` as initial input. Cleared when
+    /// the sheet dismisses.
+    @State private var addDriverPrefill: ParsedDriverQRCode?
     @State private var selectedDriver: DriverListItem?
     @State private var showProfile = false
     @State private var showConnectivity = false
@@ -96,7 +100,16 @@ struct DriversTab: View {
             .background(Color.rfSurface)
             .navigationBarHidden(true)
             .sheet(isPresented: $showConnectivity) { ConnectivitySheet() }
-            .sheet(isPresented: $showAddDriver) { AddDriverSheet() }
+            .sheet(isPresented: $showAddDriver, onDismiss: {
+                // Clear deep-link state once the sheet is dismissed (whether it
+                // completed the add or the user cancelled). Do NOT clear before
+                // dismiss — the sheet reads `addDriverPrefill` after its first
+                // render to seed input.
+                addDriverPrefill = nil
+                appState.pendingDriverDeepLink = nil
+            }) {
+                AddDriverSheet(prefill: addDriverPrefill)
+            }
             .sheet(item: $selectedDriver) { item in DriverDetailSheet(pubkey: item.pubkey) }
             .sheet(isPresented: $showProfile) { EditProfileSheet() }
             .sheet(item: $sharingDriver) { item in
@@ -118,6 +131,22 @@ struct DriversTab: View {
                 while !Task.isCancelled {
                     isOffline = !(await appState.isRelayConnected())
                     try? await Task.sleep(for: .seconds(10))
+                }
+            }
+            .onChange(of: appState.pendingDriverDeepLink) { _, newValue in
+                // A `roadflared:` URL arrived. Capture the parsed payload into
+                // local state and present the Add Driver sheet pre-filled.
+                guard let parsed = newValue else { return }
+                addDriverPrefill = parsed
+                showAddDriver = true
+            }
+            .task {
+                // On first appearance, also consume any pending deep link that
+                // was set before the view rendered (cold-start path: `.onOpenURL`
+                // fires very early; the drivers tab may not have mounted yet).
+                if let parsed = appState.pendingDriverDeepLink {
+                    addDriverPrefill = parsed
+                    showAddDriver = true
                 }
             }
             .toast($pingToastMessage, isError: pingToastIsError)

--- a/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
@@ -2,13 +2,24 @@ import SwiftUI
 import RidestrSDK
 import RoadFlareCore
 
+/// Identity wrapper for `AddDriverSheet` presentation so that a second
+/// `roadflared:` URL arriving while the first sheet is already presented
+/// triggers SwiftUI to dismiss-and-re-present (`.sheet(item:)` reacts to
+/// changes in the item's identity, unlike `.sheet(isPresented:)` which only
+/// toggles visibility). `prefill == nil` represents the manual "Add New
+/// Driver" flow; non-nil represents a deep-link arrival.
+private struct AddDriverPresentation: Identifiable {
+    let id = UUID()
+    let prefill: ParsedDriverQRCode?
+}
+
 struct DriversTab: View {
     @Environment(AppState.self) private var appState
-    @State private var showAddDriver = false
-    /// Captured from `appState.pendingDriverDeepLink` when a `roadflared:` URL
-    /// arrives, then handed to `AddDriverSheet` as initial input. Cleared when
-    /// the sheet dismisses.
-    @State private var addDriverPrefill: ParsedDriverQRCode?
+    /// Single source of truth for the Add Driver sheet — manual button taps and
+    /// `roadflared:` deep links both set this. Cleared by `.sheet(item:)` when
+    /// the sheet dismisses (SwiftUI sets the binding to nil), at which point
+    /// `onDismiss` also clears `appState.pendingDriverDeepLink`.
+    @State private var addDriverPresentation: AddDriverPresentation?
     @State private var selectedDriver: DriverListItem?
     @State private var showProfile = false
     @State private var showConnectivity = false
@@ -43,7 +54,7 @@ struct DriversTab: View {
                             }
 
                             // Add driver card
-                            Button { showAddDriver = true } label: {
+                            Button { addDriverPresentation = AddDriverPresentation(prefill: nil) } label: {
                                 HStack(spacing: 12) {
                                     ZStack {
                                         RoundedRectangle(cornerRadius: 12)
@@ -90,7 +101,7 @@ struct DriversTab: View {
                             .font(RFFont.body(15))
                             .foregroundColor(Color.rfOnSurfaceVariant)
                             .multilineTextAlignment(.center)
-                        Button("Add Your First Driver") { showAddDriver = true }
+                        Button("Add Your First Driver") { addDriverPresentation = AddDriverPresentation(prefill: nil) }
                             .buttonStyle(RFPrimaryButtonStyle())
                             .padding(.horizontal, 48)
                     }
@@ -100,15 +111,13 @@ struct DriversTab: View {
             .background(Color.rfSurface)
             .navigationBarHidden(true)
             .sheet(isPresented: $showConnectivity) { ConnectivitySheet() }
-            .sheet(isPresented: $showAddDriver, onDismiss: {
-                // Clear deep-link state once the sheet is dismissed (whether it
-                // completed the add or the user cancelled). Do NOT clear before
-                // dismiss — the sheet reads `addDriverPrefill` after its first
-                // render to seed input.
-                addDriverPrefill = nil
+            .sheet(item: $addDriverPresentation, onDismiss: {
+                // Clear the deep-link intent on AppState once the sheet
+                // dismisses. `addDriverPresentation` itself is cleared by the
+                // .sheet(item:) binding automatically when the user dismisses.
                 appState.pendingDriverDeepLink = nil
-            }) {
-                AddDriverSheet(prefill: addDriverPrefill)
+            }) { presentation in
+                AddDriverSheet(prefill: presentation.prefill)
             }
             .sheet(item: $selectedDriver) { item in DriverDetailSheet(pubkey: item.pubkey) }
             .sheet(isPresented: $showProfile) { EditProfileSheet() }
@@ -133,21 +142,15 @@ struct DriversTab: View {
                     try? await Task.sleep(for: .seconds(10))
                 }
             }
-            .onChange(of: appState.pendingDriverDeepLink) { _, newValue in
-                // A `roadflared:` URL arrived. Capture the parsed payload into
-                // local state and present the Add Driver sheet pre-filled.
+            .onChange(of: appState.pendingDriverDeepLink, initial: true) { _, newValue in
+                // A `roadflared:` URL arrived. `initial: true` also handles the
+                // cold-start case where `.onOpenURL` fired before this view
+                // mounted — closure runs once on first render with the current
+                // value. Each new deep-link arrival creates a new presentation
+                // identity, so SwiftUI re-presents the sheet (via .sheet(item:))
+                // even if one is already showing for an earlier link.
                 guard let parsed = newValue else { return }
-                addDriverPrefill = parsed
-                showAddDriver = true
-            }
-            .task {
-                // On first appearance, also consume any pending deep link that
-                // was set before the view rendered (cold-start path: `.onOpenURL`
-                // fires very early; the drivers tab may not have mounted yet).
-                if let parsed = appState.pendingDriverDeepLink {
-                    addDriverPrefill = parsed
-                    showAddDriver = true
-                }
+                addDriverPresentation = AddDriverPresentation(prefill: parsed)
             }
             .toast($pingToastMessage, isError: pingToastIsError)
         }

--- a/RoadFlare/RoadFlare/Views/Onboarding/WelcomeView.swift
+++ b/RoadFlare/RoadFlare/Views/Onboarding/WelcomeView.swift
@@ -165,8 +165,10 @@ struct WelcomeView: View {
         Task {
             do {
                 let keypair = try await passkeyManager.createPasskeyAndDeriveKey()
-                try await appState.importKey(keypair.exportNsec())
-                appState.authState = .profileIncomplete
+                // Use the new-account path, NOT importKey, so the user does
+                // not see the "Restoring Your Data" sync screen during a
+                // brand-new account creation. See issue #70 / AppState.
+                try await appState.createWithPasskey(keypair.exportNsec())
             } catch {
                 if !"\(error)".contains("cancelled") { errorMessage = error.localizedDescription }
             }

--- a/RoadFlare/RoadFlareCore/Services/DriverQRCodeParser.swift
+++ b/RoadFlare/RoadFlareCore/Services/DriverQRCodeParser.swift
@@ -9,13 +9,18 @@ public enum DriverQRCodeParser {
     /// Parse a driver identifier from any supported format.
     ///
     /// Accepted inputs:
-    /// - `nostr:npub1...` URI (with optional `?name=`)
+    /// - `roadflared:npub1...` URI (with optional `?name=`) — RoadFlare iOS custom URL scheme
+    /// - `nostr:npub1...` URI (with optional `?name=`) — NIP-21 convention used by QR codes
     /// - Bare `npub1...` key (with optional `?name=`)
     /// - 64-character hex public key
     /// - URL containing an embedded npub (e.g. `https://roadflare.app/share/d/npub1...`)
     public static func parse(_ rawValue: String) -> ParsedDriverQRCode? {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
+
+        if let parsed = parseRoadflaredURI(trimmed) {
+            return parsed
+        }
 
         if let parsed = parseNostrURI(trimmed) {
             return parsed
@@ -32,6 +37,12 @@ public enum DriverQRCodeParser {
         return parseURLOrEmbeddedNpub(trimmed)
     }
 
+    private static func parseRoadflaredURI(_ value: String) -> ParsedDriverQRCode? {
+        guard value.hasPrefix("roadflared:") else { return nil }
+        let withoutScheme = String(value.dropFirst("roadflared:".count))
+        return parseNpubWithOptionalQuery(withoutScheme)
+    }
+
     private static func parseNostrURI(_ value: String) -> ParsedDriverQRCode? {
         guard value.hasPrefix("nostr:") else { return nil }
         let withoutScheme = String(value.dropFirst(6))
@@ -44,6 +55,10 @@ public enum DriverQRCodeParser {
     }
 
     private static func parseNpubWithOptionalQuery(_ value: String) -> ParsedDriverQRCode? {
+        // `split` with default `omittingEmptySubsequences: true` returns an
+        // empty array for an empty input, so an `parts[0]` access without
+        // this guard would crash for inputs like `"nostr:"` or `"roadflared:"`.
+        guard !value.isEmpty else { return nil }
         let parts = value.split(separator: "?", maxSplits: 1)
         let npubPart = String(parts[0])
         guard npubPart.hasPrefix("npub1") else { return nil }

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -690,14 +690,20 @@ public final class AppState {
         rideStatePersistence.clear()
 
         // 5. UI state
-        requestRideDriverPubkey = nil
-        selectedTab = 0
-        // Only clear pending deep link on actual REPLACEMENT of a prior
-        // identity (logout, key import/regen with prior keypair). Preserve
-        // on first-time setup (keypair == nil) so a `roadflared:` URL tapped
-        // during cold-start onboarding survives until DriversTab mounts
-        // post-`.ready`. See ADR-0012.
+        // Navigation intents (`selectedTab`, `requestRideDriverPubkey`,
+        // `pendingDriverDeepLink`) are only cleared on actual REPLACEMENT
+        // of a prior identity (logout, key import/regen with a prior
+        // keypair). On first-time setup (`keypair == nil`), preserve them
+        // so cold-start state — e.g. a `roadflared:` URL tapped before
+        // onboarding sets `selectedTab = 1` and `pendingDriverDeepLink` —
+        // survives the user's first `generateNewKey` / `createWithPasskey`
+        // / `importKey` call (each of which routes through this function
+        // BEFORE establishing the new identity) and is consumed by
+        // `DriversTab` once the user reaches the main tab view post-`.ready`.
+        // See ADR-0012.
         if keypair != nil {
+            requestRideDriverPubkey = nil
+            selectedTab = 0
             pendingDriverDeepLink = nil
         }
         pingCooldowns = [:]

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -116,6 +116,28 @@ public final class AppState {
         authState = .profileIncomplete
     }
 
+    /// Persist a freshly-generated keypair from a passkey ceremony and finish
+    /// onboarding without going through the sync/restore screen.
+    ///
+    /// This is the passkey analog of `generateNewKey()`: a brand-new account
+    /// is being established (the seed comes from the passkey, but there is no
+    /// pre-existing identity on relays to restore), so we transition directly
+    /// to `.profileIncomplete` and skip the `.syncing` detour that
+    /// `importKey()` uses for the recover-existing-account flow.
+    ///
+    /// The "Log In with Passkey" flow (recovering an existing account from
+    /// the passkey-derived seed) should continue to use `importKey(_:)` —
+    /// that's where the sync screen / "Restoring Your Data" copy is correct.
+    /// Closes #70.
+    public func createWithPasskey(_ nsec: String) async throws {
+        guard let km = keyManager else { return }
+        let kp = try await km.importNsec(nsec)
+        await prepareForIdentityReplacement(clearPersistedSyncState: false)
+        keypair = kp
+        await setupServices(keypair: kp)
+        authState = .profileIncomplete
+    }
+
     /// Import an existing key from nsec or hex. Shows sync screen during restore.
     public func importKey(_ input: String) async throws {
         guard let km = keyManager else { return }
@@ -670,7 +692,14 @@ public final class AppState {
         // 5. UI state
         requestRideDriverPubkey = nil
         selectedTab = 0
-        pendingDriverDeepLink = nil
+        // Only clear pending deep link on actual REPLACEMENT of a prior
+        // identity (logout, key import/regen with prior keypair). Preserve
+        // on first-time setup (keypair == nil) so a `roadflared:` URL tapped
+        // during cold-start onboarding survives until DriversTab mounts
+        // post-`.ready`. See ADR-0012.
+        if keypair != nil {
+            pendingDriverDeepLink = nil
+        }
         pingCooldowns = [:]
 
         // 6. Nil service refs

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -670,6 +670,7 @@ public final class AppState {
         // 5. UI state
         requestRideDriverPubkey = nil
         selectedTab = 0
+        pendingDriverDeepLink = nil
         pingCooldowns = [:]
 
         // 6. Nil service refs

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -37,6 +37,11 @@ public final class AppState {
     public var requestRideDriverPubkey: String?
     /// Set to switch tabs programmatically.
     public var selectedTab: Int = 0
+    /// Pending Add-Driver intent from a custom URL scheme (`roadflared:`) or
+    /// other deep-link source. `DriversTab` observes this and presents
+    /// `AddDriverSheet` pre-filled; the consumer is responsible for clearing
+    /// it back to `nil` after the sheet is dismissed. See `handleIncomingURL`.
+    public var pendingDriverDeepLink: ParsedDriverQRCode?
 
     // MARK: - SDK Services
 
@@ -330,6 +335,25 @@ public final class AppState {
             pingCooldowns[driverPubkey] = nil  // rollback so user can retry
             return .publishFailed(error.localizedDescription)
         }
+    }
+
+    // MARK: - Deep Links
+
+    /// Route an incoming custom-scheme URL into the app.
+    ///
+    /// Recognized URLs (`roadflared:npub1...?name=...` and friends — see
+    /// `DriverQRCodeParser.parse` for the full set) populate
+    /// `pendingDriverDeepLink` and switch `selectedTab` to the drivers tab.
+    /// `DriversTab` observes `pendingDriverDeepLink` and presents
+    /// `AddDriverSheet` pre-filled with the parsed npub + display name.
+    ///
+    /// Unrecognized URLs are dropped silently — the URL scheme registration
+    /// in Info.plist is the gate, but we defend against any unexpected payload
+    /// (e.g. a future scheme we don't yet handle, or a malformed link).
+    public func handleIncomingURL(_ url: URL) {
+        guard let parsed = DriverQRCodeParser.parse(url.absoluteString) else { return }
+        pendingDriverDeepLink = parsed
+        selectedTab = 1  // Drivers tab — see MainTabView.swift
     }
 
     // MARK: - Connection & Foreground

--- a/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
@@ -86,15 +86,16 @@ struct HandleIncomingURLTests {
     }
 
     @MainActor
-    @Test func pendingDriverDeepLinkSurvivesIdentityReplacementWhenNoKeypair() async throws {
+    @Test func navigationIntentSurvivesIdentityReplacementWhenNoKeypair() async throws {
         // Cold-start regression: when a `roadflared:` URL arrives before the
         // user has created an account (keypair is nil), the conditional in
-        // `prepareForIdentityReplacement` must preserve the deep link.
-        // Without this guard, a first-time user who tapped a share link
-        // before onboarding would lose the intent the moment they tap
-        // "Generate Key" / "Create with Passkey" — both of which call
-        // `prepareForIdentityReplacement` internally before establishing
-        // the new identity. See ADR-0012.
+        // `prepareForIdentityReplacement` must preserve ALL the navigation
+        // intent state set by `handleIncomingURL` — both `pendingDriverDeepLink`
+        // AND `selectedTab` (= 1, drivers tab). Without this guard, a
+        // first-time user who tapped a share link before onboarding would
+        // lose the intent the moment they tap "Generate Key" / "Create with
+        // Passkey" — both of which call `prepareForIdentityReplacement`
+        // internally before establishing the new identity. See ADR-0012.
         //
         // The keypair-SET branch (cross-user leak protection on logout)
         // cannot be unit-tested here: the RoadFlareTests target lacks
@@ -105,13 +106,17 @@ struct HandleIncomingURLTests {
         let npub = try makeNpub(hex: String(repeating: "5e", count: 32))
         appState.handleIncomingURL(URL(string: "roadflared:\(npub)")!)
         #expect(appState.pendingDriverDeepLink != nil)
+        #expect(appState.selectedTab == 1)
         #expect(appState.keypair == nil)
 
         // `logout()` exercises `prepareForIdentityReplacement` with the same
-        // keypair-conditional gate; with no prior keypair, the deep link
-        // must survive.
+        // keypair-conditional gate; with no prior keypair, ALL navigation
+        // intents must survive (otherwise post-onboarding the user lands on
+        // the wrong tab and never sees the AddDriverSheet for the deep-linked
+        // driver).
         await appState.logout()
 
         #expect(appState.pendingDriverDeepLink != nil, "Deep link must survive identity replacement when no prior keypair existed")
+        #expect(appState.selectedTab == 1, "Tab selection must survive identity replacement when no prior keypair existed")
     }
 }

--- a/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
@@ -86,17 +86,32 @@ struct HandleIncomingURLTests {
     }
 
     @MainActor
-    @Test func pendingDriverDeepLinkClearedOnIdentityReplacement() async throws {
-        // Regression: pendingDriverDeepLink must be reset on logout / identity
-        // switch, alongside requestRideDriverPubkey and selectedTab. Without
-        // this, an unconsumed deep link survives into the next user's session.
+    @Test func pendingDriverDeepLinkSurvivesIdentityReplacementWhenNoKeypair() async throws {
+        // Cold-start regression: when a `roadflared:` URL arrives before the
+        // user has created an account (keypair is nil), the conditional in
+        // `prepareForIdentityReplacement` must preserve the deep link.
+        // Without this guard, a first-time user who tapped a share link
+        // before onboarding would lose the intent the moment they tap
+        // "Generate Key" / "Create with Passkey" — both of which call
+        // `prepareForIdentityReplacement` internally before establishing
+        // the new identity. See ADR-0012.
+        //
+        // The keypair-SET branch (cross-user leak protection on logout)
+        // cannot be unit-tested here: the RoadFlareTests target lacks
+        // Keychain entitlement, so initialize/generateNewKey/createWithPasskey
+        // all fail with errSecMissingEntitlement (-34018). That branch is
+        // verified via the manual test checklist in PR #66.
         let appState = AppState()
         let npub = try makeNpub(hex: String(repeating: "5e", count: 32))
         appState.handleIncomingURL(URL(string: "roadflared:\(npub)")!)
         #expect(appState.pendingDriverDeepLink != nil)
+        #expect(appState.keypair == nil)
 
+        // `logout()` exercises `prepareForIdentityReplacement` with the same
+        // keypair-conditional gate; with no prior keypair, the deep link
+        // must survive.
         await appState.logout()
 
-        #expect(appState.pendingDriverDeepLink == nil)
+        #expect(appState.pendingDriverDeepLink != nil, "Deep link must survive identity replacement when no prior keypair existed")
     }
 }

--- a/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
@@ -84,4 +84,19 @@ struct HandleIncomingURLTests {
 
         #expect(appState.pendingDriverDeepLink == ParsedDriverQRCode(pubkeyInput: npub, scannedName: "Driver Dan"))
     }
+
+    @MainActor
+    @Test func pendingDriverDeepLinkClearedOnIdentityReplacement() async throws {
+        // Regression: pendingDriverDeepLink must be reset on logout / identity
+        // switch, alongside requestRideDriverPubkey and selectedTab. Without
+        // this, an unconsumed deep link survives into the next user's session.
+        let appState = AppState()
+        let npub = try makeNpub(hex: String(repeating: "5e", count: 32))
+        appState.handleIncomingURL(URL(string: "roadflared:\(npub)")!)
+        #expect(appState.pendingDriverDeepLink != nil)
+
+        await appState.logout()
+
+        #expect(appState.pendingDriverDeepLink == nil)
+    }
 }

--- a/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
@@ -1,0 +1,87 @@
+import Testing
+import Foundation
+@testable import RoadFlareCore
+@testable import RidestrSDK
+
+/// `AppState.handleIncomingURL(_:)` is the entry point for custom URL scheme
+/// dispatch (`.onOpenURL` in `RoadFlareApp`). Recognized URLs populate
+/// `pendingDriverDeepLink` and switch to the drivers tab so `DriversTab` can
+/// observe and present `AddDriverSheet` pre-filled.
+@Suite("AppState.handleIncomingURL")
+struct HandleIncomingURLTests {
+    private func makeNpub(hex: String = String(repeating: "a", count: 64)) throws -> String {
+        try NIP19.npubEncode(publicKeyHex: hex)
+    }
+
+    @MainActor
+    @Test func roadflaredURLPopulatesPendingDriverDeepLink() throws {
+        let appState = AppState()
+        let npub = try makeNpub(hex: String(repeating: "1a", count: 32))
+        let url = URL(string: "roadflared:\(npub)")!
+
+        appState.handleIncomingURL(url)
+
+        #expect(appState.pendingDriverDeepLink == ParsedDriverQRCode(pubkeyInput: npub, scannedName: nil))
+    }
+
+    @MainActor
+    @Test func roadflaredURLWithNameParsesDisplayName() throws {
+        let appState = AppState()
+        let npub = try makeNpub(hex: String(repeating: "2b", count: 32))
+        let url = URL(string: "roadflared:\(npub)?name=Road%20Runner")!
+
+        appState.handleIncomingURL(url)
+
+        #expect(appState.pendingDriverDeepLink == ParsedDriverQRCode(pubkeyInput: npub, scannedName: "Road Runner"))
+    }
+
+    @MainActor
+    @Test func roadflaredURLSwitchesToDriversTab() throws {
+        let appState = AppState()
+        appState.selectedTab = 0  // Start on ride tab
+        let npub = try makeNpub(hex: String(repeating: "3c", count: 32))
+        let url = URL(string: "roadflared:\(npub)")!
+
+        appState.handleIncomingURL(url)
+
+        #expect(appState.selectedTab == 1)
+    }
+
+    @MainActor
+    @Test func unknownSchemeIsDropped() throws {
+        let appState = AppState()
+        appState.selectedTab = 0
+        let url = URL(string: "https://example.com/whatever")!
+
+        appState.handleIncomingURL(url)
+
+        #expect(appState.pendingDriverDeepLink == nil)
+        #expect(appState.selectedTab == 0)  // Tab unchanged
+    }
+
+    @MainActor
+    @Test func roadflaredWithGarbagePayloadIsDropped() {
+        let appState = AppState()
+        appState.selectedTab = 0
+        let url = URL(string: "roadflared:not-a-real-key")!
+
+        appState.handleIncomingURL(url)
+
+        #expect(appState.pendingDriverDeepLink == nil)
+        #expect(appState.selectedTab == 0)
+    }
+
+    @MainActor
+    @Test func nostrSchemeAlsoSupported() throws {
+        // The parser already accepts nostr: URIs (via QR codes pasted as text).
+        // For consistency, .onOpenURL routes them too — useful if a future
+        // share surface emits nostr: instead of roadflared:.
+        let appState = AppState()
+        let npub = try makeNpub(hex: String(repeating: "4d", count: 32))
+        let url = URL(string: "nostr:\(npub)?name=Driver%20Dan")!
+
+        appState.handleIncomingURL(url)
+
+        #expect(appState.pendingDriverDeepLink == ParsedDriverQRCode(pubkeyInput: npub, scannedName: "Driver Dan"))
+    }
+}

--- a/RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift
+++ b/RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift
@@ -103,23 +103,17 @@ struct DriverQRCodeParserTests {
         #expect(DriverQRCodeParser.parse("nostr:") == nil)
     }
 
-    @Test func rejectsRoadflarerSchemeOnRiderApp() throws {
-        // The rider app intentionally does NOT handle roadflarer: (driver-app
-        // territory). If such a URL ever reaches the parser, it should be
-        // rejected — the embedded npub regex must not greedily accept it.
+    @Test func acceptsRoadflarerSchemeViaEmbeddedNpubFallback() throws {
+        // The rider app does NOT register `roadflarer:` as a URL scheme (that's
+        // reserved for the future driver app), so this URL never arrives via
+        // .onOpenURL. But if a user manually pastes such a URL into the Add
+        // Driver text field, `parseURLOrEmbeddedNpub` will extract the npub via
+        // the regex fallback — a reasonable best-effort. This test pins that
+        // behavior so future parser refactors don't silently change it.
         let npub = try makeNpub(hex: String(repeating: "4d", count: 32))
 
-        // roadflarer: is parsed as an opaque URI; nothing in DriverQRCodeParser
-        // should claim it as a driver pubkey because the host app's URL scheme
-        // registration won't even dispatch this scheme. But document the parser
-        // behavior explicitly so future refactors don't silently broaden it.
         let parsed = DriverQRCodeParser.parse("roadflarer:\(npub)")
 
-        // Currently, parseURLOrEmbeddedNpub will match the embedded npub.
-        // That's acceptable: the rider app never receives this scheme via
-        // .onOpenURL, so this fallback only runs if someone manually pastes
-        // the URL into the Add Driver text field — in which case extracting
-        // the npub is a reasonable best-effort.
         #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: nil))
     }
 }

--- a/RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift
+++ b/RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift
@@ -59,4 +59,67 @@ struct DriverQRCodeParserTests {
     @Test func rejectsCodesWithoutNostrIdentifier() {
         #expect(DriverQRCodeParser.parse("https://roadflare.app/share/d/not-a-driver") == nil)
     }
+
+    // MARK: - roadflared: URL scheme
+
+    @Test func parsesRoadflaredURI() throws {
+        let npub = try makeNpub(hex: String(repeating: "1a", count: 32))
+
+        let parsed = DriverQRCodeParser.parse("roadflared:\(npub)")
+
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: nil))
+    }
+
+    @Test func parsesRoadflaredURIWithNameParameter() throws {
+        let npub = try makeNpub(hex: String(repeating: "2b", count: 32))
+
+        let parsed = DriverQRCodeParser.parse("roadflared:\(npub)?name=Road%20Runner")
+
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: "Road Runner"))
+    }
+
+    @Test func parsesRoadflaredURIWithEmptyNameTreatedAsNil() throws {
+        let npub = try makeNpub(hex: String(repeating: "3c", count: 32))
+
+        let parsed = DriverQRCodeParser.parse("roadflared:\(npub)?name=")
+
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: nil))
+    }
+
+    @Test func rejectsRoadflaredURIWithoutNpub() {
+        #expect(DriverQRCodeParser.parse("roadflared:not-a-key") == nil)
+    }
+
+    @Test func rejectsRoadflaredURIWithEmptyBody() {
+        // Regression: `parseNpubWithOptionalQuery("")` previously crashed
+        // (Index out of range) because `"".split(separator: "?")` returns []
+        // and `parts[0]` was unguarded.
+        #expect(DriverQRCodeParser.parse("roadflared:") == nil)
+    }
+
+    @Test func rejectsNostrURIWithEmptyBody() {
+        // Same regression, `nostr:` arm. Was latent because nothing exercised
+        // it in tests prior to the roadflared: work.
+        #expect(DriverQRCodeParser.parse("nostr:") == nil)
+    }
+
+    @Test func rejectsRoadflarerSchemeOnRiderApp() throws {
+        // The rider app intentionally does NOT handle roadflarer: (driver-app
+        // territory). If such a URL ever reaches the parser, it should be
+        // rejected — the embedded npub regex must not greedily accept it.
+        let npub = try makeNpub(hex: String(repeating: "4d", count: 32))
+
+        // roadflarer: is parsed as an opaque URI; nothing in DriverQRCodeParser
+        // should claim it as a driver pubkey because the host app's URL scheme
+        // registration won't even dispatch this scheme. But document the parser
+        // behavior explicitly so future refactors don't silently broaden it.
+        let parsed = DriverQRCodeParser.parse("roadflarer:\(npub)")
+
+        // Currently, parseURLOrEmbeddedNpub will match the embedded npub.
+        // That's acceptable: the rider app never receives this scheme via
+        // .onOpenURL, so this fallback only runs if someone manually pastes
+        // the URL into the Add Driver text field — in which case extracting
+        // the npub is a reasonable best-effort.
+        #expect(parsed == ParsedDriverQRCode(pubkeyInput: npub, scannedName: nil))
+    }
 }

--- a/decisions/0012-roadflared-url-scheme.md
+++ b/decisions/0012-roadflared-url-scheme.md
@@ -1,0 +1,139 @@
+# ADR-0012: `roadflared:` Custom URL Scheme for Driver Deep Links
+
+**Status:** Active
+**Created:** 2026-04-27
+**Tags:** architecture, app-routing, deep-link
+
+## Context
+
+RoadFlare 1.0 shipped on the App Store on 2026-04-20. The marketing site at
+`roadflare.app` serves driver share pages at `/share/d/<npub>` with a "Add
+to RoadFlare" CTA. Until this work landed, that button used `nostr:<npub>`,
+which the iOS app did not register as a URL handler — tapping the button
+either errored in Safari or dispatched to an unrelated Nostr client.
+
+We need a way for share-link recipients to tap a button on
+`roadflare.app/share/d/<npub>` and land directly in the Add Driver flow with
+the npub and display name pre-filled. Universal Links
+(`https://roadflare.app/share/...`) are the long-term solution and are
+tracked in [#63](https://github.com/variablefate/roadflare-ios/issues/63),
+but require an Associated Domains entitlement, AASA `applinks` updates, and
+out-of-band testing — too much for the immediate ship.
+
+A custom URL scheme is enough today: simpler to register, no domain wiring,
+and explicit about which app a link is targeting.
+
+## Decision
+
+Register `roadflared:` as a custom URL scheme handled by RoadFlare iOS.
+The shape is opaque-URI style mirroring the existing `nostr:` URI the parser
+already accepts:
+
+```
+roadflared:<npub>[?name=<URL-encoded display name>]
+```
+
+Routing pattern: **app-level `.onOpenURL` → `AppState` intent property →
+view observation**.
+
+1. `RoadFlareApp` attaches `.onOpenURL { url in appState.handleIncomingURL(url) }`
+   to the root scene.
+2. `AppState.handleIncomingURL(_:)` parses the URL via the existing
+   `DriverQRCodeParser`, populates `pendingDriverDeepLink`, and switches
+   `selectedTab = 1` (drivers tab).
+3. `DriversTab` observes `appState.pendingDriverDeepLink` via `.onChange` and
+   on first `.task`, captures the value into local state, and presents
+   `AddDriverSheet(prefill:)` with the parsed payload. On dismiss, both
+   `pendingDriverDeepLink` and the local prefill are cleared.
+4. `AddDriverSheet` accepts an optional `prefill: ParsedDriverQRCode?` init
+   param; when set, it seeds `lookupDraft` and auto-triggers profile lookup
+   on first `.task`, skipping the scan/paste step.
+
+Two-app partitioning: `roadflared:` is for the rider app (this app);
+`roadflarer:` is reserved for a future iOS driver app. The rider app
+deliberately does NOT register `roadflarer:`, so rider-share URLs from
+`roadflare.app/share/r/<npub>` will route to a future driver app once one
+exists. This keeps the deep-link surfaces partitioned by recipient app
+without any in-app switching logic.
+
+## Rationale
+
+- **`AppState` ownership of the intent** matches the existing pattern for
+  `requestRideDriverPubkey` / `selectedTab`: external triggers write to
+  `AppState`, the relevant tab observes and presents. Consistent with
+  ADR-0011's "AppState as single facade for view data."
+- **`pendingDriverDeepLink` as state, not a one-shot callback** survives
+  cold-start: `.onOpenURL` can fire before `DriversTab` has even mounted.
+  The state-based model lets the view consume the intent on first `.task`
+  whenever it does mount, regardless of timing.
+- **Reuse `DriverQRCodeParser`** rather than introducing a parallel parser:
+  the input shape (`<scheme>:<npub>?name=...`) is identical to `nostr:`,
+  and the parser was already structured around opaque-URI style. Adding a
+  `parseRoadflaredURI` arm is one new private function.
+- **Custom scheme over Universal Links — for now** because the fallback UX
+  diverges:
+  - Custom scheme installed → opens the app; not installed → "Safari cannot
+    open" error.
+  - Universal Links installed → opens the app; not installed → falls back to
+    the share page itself, which already has the App Store button.
+  Universal Links are strictly better long-term, but require Associated
+  Domains entitlement + AASA changes + test-on-real-device cycles that are
+  out of scope for this release. Tracked in [#63](https://github.com/variablefate/roadflare-ios/issues/63).
+- **Two schemes, not one with a path** (`roadflared:` for driver,
+  `roadflarer:` for rider) so that when a driver app exists, each app
+  registers its own scheme without coordinating which one handles a given
+  URL. The OS dispatches by scheme.
+
+## Alternatives Considered
+
+- **Universal Links only** — rejected for this release: requires AASA
+  changes on the site, Associated Domains entitlement on the app, and
+  real-device test cycles. Tracked in #63 as the long-term path.
+- **`roadflare:` single scheme with path-based driver-vs-rider routing**
+  (e.g. `roadflare://d/<npub>`) — rejected: when a future driver app
+  launches, both apps would claim the same scheme and the OS would
+  arbitrarily pick one. Two schemes avoid this entirely.
+- **Pass `prefill` via a new `AppState` setter, not an init param** —
+  rejected: `AddDriverSheet` already uses `lookupDraft` as its input model;
+  threading the prefill through the same model via init is consistent with
+  how `DriverShareSheet(pubkey:driverName:pictureURL:)` is constructed.
+- **Drop the URL scheme on the floor when `authState != .ready`** — not done:
+  the intent is held in `AppState` for the duration of the session. If the
+  user is in onboarding when a `roadflared:` URL arrives, the intent
+  persists and `DriversTab.task` will consume it the first time the user
+  reaches the main tab view post-onboarding. This is desirable — losing the
+  deep link silently after onboarding would be a bad UX.
+
+## Consequences
+
+- **Site PR [variablefate/roadflare-site#4](https://github.com/variablefate/roadflare-site/pull/4)**
+  unblocks once an App Store build with this code ships. Merging that PR
+  restores the "Add to RoadFlare" button on driver share pages, pointing to
+  `roadflared:<npub>?name=...`.
+- **Future Drivestr / driver app** can register `roadflarer:` independently
+  and merge the matching site PR
+  ([variablefate/roadflare-site#5](https://github.com/variablefate/roadflare-site/pull/5))
+  with no coordination needed against this app.
+- **`AddDriverSheet`'s `init()` zero-arg call site is preserved** — the
+  prefill param has a default of `nil`. Existing call site in `DriversTab`
+  (the "Add New Driver" button) keeps working unchanged.
+- **`DriverQRCodeParser` now documents `roadflared:`** as a first-class
+  accepted input. The parser is also still safe to use on QR-scanned strings
+  (which use `nostr:` per NIP-21) — the new arm is checked before the
+  existing `nostr:` arm but both have explicit prefix gates.
+- **Universal Links migration (#63) becomes mostly additive**: the
+  `roadflared:` flow can stay as the in-app-only scheme, and Universal Links
+  via `https://roadflare.app/share/...` would route through the same
+  `AppState.handleIncomingURL` (the parser already handles
+  `https://roadflare.app/share/d/<npub>` strings).
+
+## Affected Files
+
+- `RoadFlare/RoadFlare/Info.plist` — `CFBundleURLTypes` entry for `roadflared`
+- `RoadFlare/RoadFlareCore/Services/DriverQRCodeParser.swift` — `parseRoadflaredURI` arm + doc comment
+- `RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift` — `roadflared:` test cases
+- `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` — `pendingDriverDeepLink`, `handleIncomingURL(_:)`
+- `RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift` — `handleIncomingURL` tests
+- `RoadFlare/RoadFlare/RoadFlareApp.swift` — `.onOpenURL` modifier
+- `RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift` — `pendingDriverDeepLink` observer + sheet wiring
+- `RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift` — `prefill:` init param + auto-resolve `.task`

--- a/decisions/0012-roadflared-url-scheme.md
+++ b/decisions/0012-roadflared-url-scheme.md
@@ -56,8 +56,36 @@ view observation**.
 5. On sheet dismissal, `appState.pendingDriverDeepLink = nil` (via the
    sheet's `onDismiss`). The `addDriverPresentation` state is cleared
    automatically by `.sheet(item:)`'s binding. `pendingDriverDeepLink` is
-   also cleared in `AppState.prepareForIdentityReplacement` so an
-   unconsumed intent does not survive into a different user's session.
+   also cleared in `AppState.prepareForIdentityReplacement` — but ONLY
+   when there is a prior `keypair` to replace. On first-time setup
+   (`keypair == nil`), the deep link is preserved so a `roadflared:` URL
+   tapped during cold-start onboarding survives the user's first
+   `generateNewKey` / `createWithPasskey` / `importKey` call (each of
+   which routes through `prepareForIdentityReplacement` before
+   establishing the new identity) and is consumed by `DriversTab` once
+   the user reaches the main tab view post-`.ready`.
+
+### Onboarding interaction (issue #70)
+
+Three account-establishment paths exist on `AppState`, and they must
+match `RootView`'s authState routing to avoid surfacing the wrong
+loading screen:
+
+- **`generateNewKey()`** — random key, no relays — transitions directly
+  to `.profileIncomplete`. No sync screen.
+- **`createWithPasskey(_ nsec:)`** — passkey-derived seed for a brand-new
+  account, no relays to restore from — transitions directly to
+  `.profileIncomplete`. No sync screen. Added with this work; closes #70.
+- **`importKey(_:)`** — recovering an existing account from an nsec
+  (manually pasted or passkey-derived for a "Log In with Passkey" flow)
+  — transitions to `.syncing` first, surfacing `SyncScreen`'s "Restoring
+  Your Data" copy while relays are queried for prior state.
+
+The pre-existing `WelcomeView.createWithPasskey()` was incorrectly
+routed through `importKey`, so a brand-new passkey account briefly
+displayed "Restoring Your Data" before transitioning to profile
+setup. Re-routing through the new `createWithPasskey` method fixes
+this and keeps the sync screen reserved for actual recovery.
 
 Two-app partitioning: `roadflared:` is for the rider app (this app);
 `roadflarer:` is reserved for a future iOS driver app. The rider app
@@ -142,8 +170,9 @@ without any in-app switching logic.
 - `RoadFlare/RoadFlare/Info.plist` — `CFBundleURLTypes` entry for `roadflared`
 - `RoadFlare/RoadFlareCore/Services/DriverQRCodeParser.swift` — `parseRoadflaredURI` arm + doc comment
 - `RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift` — `roadflared:` test cases
-- `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` — `pendingDriverDeepLink`, `handleIncomingURL(_:)`
-- `RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift` — `handleIncomingURL` tests
+- `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` — `pendingDriverDeepLink`, `handleIncomingURL(_:)`, `createWithPasskey(_:)`, conditional clear in `prepareForIdentityReplacement`
+- `RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift` — `handleIncomingURL` tests + cold-start preservation + identity-replacement clearing + `createWithPasskey` transition
 - `RoadFlare/RoadFlare/RoadFlareApp.swift` — `.onOpenURL` modifier
 - `RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift` — `pendingDriverDeepLink` observer + sheet wiring
 - `RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift` — `prefill:` init param + auto-resolve `.task`
+- `RoadFlare/RoadFlare/Views/Onboarding/WelcomeView.swift` — passkey-create flow re-routed through new `createWithPasskey` (issue #70)

--- a/decisions/0012-roadflared-url-scheme.md
+++ b/decisions/0012-roadflared-url-scheme.md
@@ -41,13 +41,23 @@ view observation**.
 2. `AppState.handleIncomingURL(_:)` parses the URL via the existing
    `DriverQRCodeParser`, populates `pendingDriverDeepLink`, and switches
    `selectedTab = 1` (drivers tab).
-3. `DriversTab` observes `appState.pendingDriverDeepLink` via `.onChange` and
-   on first `.task`, captures the value into local state, and presents
-   `AddDriverSheet(prefill:)` with the parsed payload. On dismiss, both
-   `pendingDriverDeepLink` and the local prefill are cleared.
+3. `DriversTab` observes `appState.pendingDriverDeepLink` via
+   `.onChange(of:initial:)` (the `initial: true` flag covers the cold-start
+   path, where `.onOpenURL` fires before this view mounts). Each new value
+   creates a new `AddDriverPresentation` (a private `Identifiable` wrapper
+   carrying the optional prefill) and assigns it to local `@State`. The
+   sheet is bound via `.sheet(item:)`, so a second deep-link arrival while
+   the first sheet is still presented produces a new presentation identity
+   and SwiftUI re-presents the sheet with the latest prefill — `.sheet(isPresented:)`
+   would have silently dropped the second link.
 4. `AddDriverSheet` accepts an optional `prefill: ParsedDriverQRCode?` init
    param; when set, it seeds `lookupDraft` and auto-triggers profile lookup
    on first `.task`, skipping the scan/paste step.
+5. On sheet dismissal, `appState.pendingDriverDeepLink = nil` (via the
+   sheet's `onDismiss`). The `addDriverPresentation` state is cleared
+   automatically by `.sheet(item:)`'s binding. `pendingDriverDeepLink` is
+   also cleared in `AppState.prepareForIdentityReplacement` so an
+   unconsumed intent does not survive into a different user's session.
 
 Two-app partitioning: `roadflared:` is for the rider app (this app);
 `roadflarer:` is reserved for a future iOS driver app. The rider app

--- a/decisions/0012-roadflared-url-scheme.md
+++ b/decisions/0012-roadflared-url-scheme.md
@@ -55,15 +55,20 @@ view observation**.
    on first `.task`, skipping the scan/paste step.
 5. On sheet dismissal, `appState.pendingDriverDeepLink = nil` (via the
    sheet's `onDismiss`). The `addDriverPresentation` state is cleared
-   automatically by `.sheet(item:)`'s binding. `pendingDriverDeepLink` is
-   also cleared in `AppState.prepareForIdentityReplacement` — but ONLY
-   when there is a prior `keypair` to replace. On first-time setup
-   (`keypair == nil`), the deep link is preserved so a `roadflared:` URL
-   tapped during cold-start onboarding survives the user's first
-   `generateNewKey` / `createWithPasskey` / `importKey` call (each of
-   which routes through `prepareForIdentityReplacement` before
-   establishing the new identity) and is consumed by `DriversTab` once
-   the user reaches the main tab view post-`.ready`.
+   automatically by `.sheet(item:)`'s binding.
+6. `AppState.prepareForIdentityReplacement` resets navigation-intent
+   state (`selectedTab`, `requestRideDriverPubkey`, `pendingDriverDeepLink`)
+   — but ONLY when there is a prior `keypair` to replace. On first-time
+   setup (`keypair == nil`), all three are preserved so cold-start state
+   set by `handleIncomingURL` (specifically `pendingDriverDeepLink` AND
+   `selectedTab = 1`) survives the user's first `generateNewKey` /
+   `createWithPasskey` / `importKey` call (each of which routes through
+   `prepareForIdentityReplacement` before establishing the new identity)
+   and is consumed by `DriversTab` once the user reaches the main tab
+   view post-`.ready`. Both pieces matter: without the `selectedTab`
+   preservation the user lands on the Ride tab post-onboarding and
+   `DriversTab` (where the sheet observer lives) only mounts when its
+   tab becomes active.
 
 ### Onboarding interaction (issue #70)
 


### PR DESCRIPTION
Closes #64.

## Summary

Tap a `roadflared:<npub>?name=...` link on a device with RoadFlare installed → app opens, drivers tab is selected, `AddDriverSheet` is presented pre-filled with the parsed npub and display name. Replaces the previous `nostr:` scheme attempt, which the app never registered as a handler.

## Architecture

Documented in [ADR-0012](decisions/0012-roadflared-url-scheme.md). Routing pattern: **app-level `.onOpenURL` → `AppState` intent property → view observation**.

1. `RoadFlareApp` attaches `.onOpenURL { url in appState.handleIncomingURL(url) }` to the root scene.
2. `AppState.handleIncomingURL(_:)` parses via `DriverQRCodeParser`, populates `pendingDriverDeepLink`, switches `selectedTab = 1`.
3. `DriversTab` observes via `.onChange` + `.task` (cold-start path), captures into local state, presents `AddDriverSheet(prefill:)`.
4. `AddDriverSheet` accepts an optional `prefill: ParsedDriverQRCode?` (default `nil`, so existing call site keeps working) and auto-resolves the lookup on first `.task`.

The pattern matches existing `requestRideDriverPubkey` / `selectedTab` intent properties (see ADR-0011).

## Two-app partitioning

`roadflared:` is for the rider app (this app); `roadflarer:` is reserved for a future iOS driver app. The rider app deliberately does NOT register `roadflarer:`, so rider-share URLs from `roadflare.app/share/r/<npub>` will route to a future driver app once one exists. No in-app switching logic.

## Universal Links

Deferred to [#63](https://github.com/variablefate/roadflare-ios/issues/63) (long-term migration). Custom scheme is enough for this release; the `AppState.handleIncomingURL` plumbing is reusable when Universal Links land (parser already accepts `https://roadflare.app/share/d/<npub>`).

## What's in the diff

| File | Change |
|---|---|
| `RoadFlare/RoadFlare/Info.plist` | `CFBundleURLTypes` entry registering the `roadflared` scheme |
| `RoadFlare/RoadFlareCore/Services/DriverQRCodeParser.swift` | New `parseRoadflaredURI` arm + doc-comment update; latent crash fix in `parseNpubWithOptionalQuery` (empty input crashed `parts[0]`) |
| `RoadFlare/RoadFlareTests/DriverQRCodeParserTests.swift` | 7 new test cases for `roadflared:` + regression test for the empty-body crash on the `nostr:` arm too |
| `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` | New `pendingDriverDeepLink: ParsedDriverQRCode?` property + `handleIncomingURL(_ url: URL)` method |
| `RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift` | 6 new `@MainActor` tests for the routing logic |
| `RoadFlare/RoadFlare/RoadFlareApp.swift` | `.onOpenURL` modifier on the root `WindowGroup` |
| `RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift` | Observe `pendingDriverDeepLink`, present `AddDriverSheet(prefill:)`, clear intent on dismiss |
| `RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift` | New optional `prefill:` init param + `.task` to seed `lookupDraft` and auto-trigger profile lookup |
| `decisions/0012-roadflared-url-scheme.md` | New ADR |

Total: 9 files, 406 insertions, 2 deletions. **All additive** — no existing signatures change.

## Latent crash also fixed

Empty-body inputs (`parse("nostr:")`, `parse("roadflared:")`) used to crash with `Index out of range` because `"".split(separator: "?")` returns `[]` and `parts[0]` was unguarded. Now guarded at the source. Regression tests cover both schemes.

## Impact analysis (per CLAUDE.md)

Pre-edit `gitnexus_impact` runs:

- `DriverQRCodeParser` — Risk **LOW** (0 direct callers indexed). Additive; no signature change.
- `AppState` — Risk **CRITICAL** (132 importers), but the changes are purely additive (new property + new method). No existing signatures change; no callers break.
- `AddDriverSheet` — Risk **HIGH** (1 direct caller: `DriversTab`). Additive: `init(prefill: ParsedDriverQRCode? = nil)` keeps the existing zero-arg call working.

## Verification

`scripts/pre-push-checks.sh` (RidestrSDK + RidestrUI swift tests + xcodebuild build + RoadFlareTests):

- ✅ All 821 RidestrSDK tests pass
- ✅ All 26 RidestrUI tests pass
- ✅ `xcodebuild build` of RoadFlare app target succeeds
- ✅ All 13 of my new tests pass (7 parser + 6 AppState routing)
- ⚠️ One unrelated pre-existing flake: `lastLocationTimestampLabelIsRelativeString` in `PresentationTypesTests.swift:305` (commit `b4ac725`, 2026-04-17). Asserts the label contains "min" but `RelativeDateTimeFormatter` on iOS 26.4 simulator produces "3m ago". **Passes in isolation on both `main` and this branch**; only fails in the full suite run. Independent of this change. Worth a follow-up issue.

The pre-push script's default destination `OS=26.4` is also ambiguous (two 26.4 runtimes installed); used `ROADFLARE_PREPUSH_DESTINATION='platform=iOS Simulator,name=iPhone 17,OS=latest'` to disambiguate. Worth pinning in the script as a small follow-up.

## Manual test checklist (run after merge + App Store build is live)

See [#64's "When this ships" checklist](https://github.com/variablefate/roadflare-ios/issues/64) for the full procedure. Quick version:

- [ ] Install fresh App Store build (delete TestFlight first if installed)
- [ ] Tap `roadflared:npub1...?name=Test%20Driver` from Notes/Messages → app opens, Add Driver sheet pre-filled
- [ ] Force-quit app, repeat → cold-start path also opens Add Driver sheet (the `.task` fallback in `DriversTab`)
- [ ] Tap unknown URL like `randomscheme:foo` → no effect (other apps still get a chance, RoadFlare ignores)
- [ ] Existing flow (tap "Add New Driver" button manually) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)