### PR TITLE
fix: persist cancelled rides + fix $0 force-end fare (#65)

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift
+++ b/RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift
@@ -536,6 +536,19 @@ public struct RideHistoryEntry: Codable, Identifiable, Sendable, Hashable {
     }
 }
 
+public extension RideHistoryEntry {
+    /// Type-safe projection of `status`. Two known cases; unrecognized
+    /// values fail-open to `.completed` so a future cross-platform status
+    /// addition (e.g. `"ended_early"`) doesn't redact fare data on old clients.
+    enum Status: String, Sendable {
+        case completed
+        case cancelled
+    }
+
+    /// Typed projection of the raw `status` string. Fails open to `.completed`.
+    var statusEnum: Status { Status(rawValue: status) ?? .completed }
+}
+
 // MARK: - Ride History Backup (Kind 30174)
 
 /// Content of a ride history backup event (Kind 30174, encrypted to self).

--- a/RidestrSDK/Tests/RidestrSDKTests/Models/RoadflareModelsTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/Models/RoadflareModelsTests.swift
@@ -450,4 +450,43 @@ struct RoadflareModelsTests {
         let decoded = try JSONDecoder().decode(SavedLocation.self, from: data)
         #expect(decoded.displayName == "Test")
     }
+
+    // MARK: - RideHistoryEntry.Status
+
+    @Test func statusEnumProjectsCompleted() {
+        let entry = RideHistoryEntry(
+            id: "r1", date: Date(timeIntervalSince1970: 0), status: "completed",
+            counterpartyPubkey: String(repeating: "a", count: 64),
+            pickupGeohash: "g1", dropoffGeohash: "g2",
+            pickup: Location(latitude: 0, longitude: 0),
+            destination: Location(latitude: 0, longitude: 0),
+            fare: 10, paymentMethod: "cash"
+        )
+        #expect(entry.statusEnum == .completed)
+    }
+
+    @Test func statusEnumProjectsCancelled() {
+        let entry = RideHistoryEntry(
+            id: "r2", date: Date(timeIntervalSince1970: 0), status: "cancelled",
+            counterpartyPubkey: String(repeating: "a", count: 64),
+            pickupGeohash: "g1", dropoffGeohash: "g2",
+            pickup: Location(latitude: 0, longitude: 0),
+            destination: Location(latitude: 0, longitude: 0),
+            fare: 0, paymentMethod: "cash"
+        )
+        #expect(entry.statusEnum == .cancelled)
+    }
+
+    @Test func statusEnumFailsOpenForUnknownStatus() {
+        // Forward-compat: unrecognized statuses don't redact fare data
+        let entry = RideHistoryEntry(
+            id: "r3", date: Date(timeIntervalSince1970: 0), status: "ended_early_v3",
+            counterpartyPubkey: String(repeating: "a", count: 64),
+            pickupGeohash: "g1", dropoffGeohash: "g2",
+            pickup: Location(latitude: 0, longitude: 0),
+            destination: Location(latitude: 0, longitude: 0),
+            fare: 25, paymentMethod: "cash"
+        )
+        #expect(entry.statusEnum == .completed)
+    }
 }

--- a/RoadFlare/RoadFlare/Views/History/HistoryTab.swift
+++ b/RoadFlare/RoadFlare/Views/History/HistoryTab.swift
@@ -82,7 +82,7 @@ struct RideHistoryCard: View {
                     Spacer()
                     Text(row.fareLabel)
                         .font(RFFont.headline(18))
-                        .foregroundColor(Color.rfPrimary)
+                        .foregroundColor(row.isCancelled ? Color.rfError : Color.rfPrimary)
                 }
 
                 if let name = row.counterpartyName {

--- a/RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift
@@ -46,24 +46,36 @@ public struct RideHistoryRow: Equatable, Sendable, Identifiable {
 
     // MARK: - Status
 
-    /// Whether the ride completed successfully (vs. cancelled/failed).
-    public let isCompleted: Bool
+    /// Underlying status used to drive UI branches.
+    public let status: RideHistoryEntry.Status
+
+    /// True if `status == .completed`. Computed for backward compat with
+    /// existing callers (`HistoryTab`, presentation tests).
+    public var isCompleted: Bool { status == .completed }
+
+    /// True if `status == .cancelled`. Drives red "Cancelled" rendering.
+    public var isCancelled: Bool { status == .cancelled }
 
     // MARK: - Factory
 
     /// Project a `RideHistoryEntry` into a display-ready row.
     public static func from(_ entry: RideHistoryEntry) -> RideHistoryRow {
         let fareLabel: String
-        if entry.fare == 0 {
-            fareLabel = "–"
-        } else {
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .currency
-            formatter.currencyCode = "USD"
-            formatter.locale = Locale(identifier: "en_US")
-            formatter.maximumFractionDigits = 2
-            formatter.minimumFractionDigits = 2
-            fareLabel = formatter.string(from: entry.fare as NSDecimalNumber) ?? "$\(entry.fare)"
+        switch entry.statusEnum {
+        case .cancelled:
+            fareLabel = "Cancelled"
+        case .completed:
+            if entry.fare == 0 {
+                fareLabel = "–"
+            } else {
+                let formatter = NumberFormatter()
+                formatter.numberStyle = .currency
+                formatter.currencyCode = "USD"
+                formatter.locale = Locale(identifier: "en_US")
+                formatter.maximumFractionDigits = 2
+                formatter.minimumFractionDigits = 2
+                fareLabel = formatter.string(from: entry.fare as NSDecimalNumber) ?? "$\(entry.fare)"
+            }
         }
 
         let distanceLabel = entry.distance.map { String(format: "%.1f mi", $0) }
@@ -79,7 +91,7 @@ public struct RideHistoryRow: Equatable, Sendable, Identifiable {
             distanceLabel: distanceLabel,
             durationLabel: durationLabel,
             paymentMethodLabel: PaymentMethod.displayName(for: entry.paymentMethod),
-            isCompleted: entry.status == "completed"
+            status: entry.statusEnum
         )
     }
 }

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift
@@ -61,9 +61,13 @@ extension AppState {
         return repo.drivers.contains(where: { repo.canPingDriver($0) })
     }
 
-    /// Ride history as display-ready rows.
+    /// Ride history as display-ready rows. Filters by `appOrigin == "roadflare"`
+    /// so that entries synced from a sibling app (e.g. Ridestr Android on the
+    /// same account) are merged into the local store but hidden from this view.
     public var rideHistoryRows: [RideHistoryRow] {
-        rideHistory.rides.map { RideHistoryRow.from($0) }
+        rideHistory.rides
+            .filter { $0.appOrigin == "roadflare" }
+            .map { RideHistoryRow.from($0) }
     }
 
     /// Favorite saved locations as display-ready rows.

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -350,6 +350,26 @@ public final class RideCoordinator {
         chat.reset()
     }
 
+    /// Records a ride history entry from the current coordinator state.
+    ///
+    /// **Call ordering — load-bearing:** must be called BEFORE `clearCoordinatorUIState()`
+    /// at any terminal site. The function reads `pickupLocation`, `destinationLocation`,
+    /// and `currentFareEstimate` from coordinator instance state; `clearCoordinatorUIState`
+    /// zeroes those fields. Reordering would silently produce history entries with zeroed
+    /// coordinates and `fare = 0`. The cancel branches in `sessionDidReachTerminal` and
+    /// `forceEndRide()` both record-then-clear; if a future refactor extracts a shared
+    /// terminal helper, it must preserve this order.
+    ///
+    /// **Identity source:** prefers live `session.confirmationEventId`/`driverPubkey`
+    /// (set for `.completed` and `forceEndRide`, where the SDK has not reset the state
+    /// machine). Falls back to `lastActiveRideIdentity` (populated in `sessionDidChangeStage`
+    /// and `restoreRideState`) for `.cancelledByRider`/`.cancelledByDriver`, where the
+    /// SDK clears state machine context before firing the terminal callback. See
+    /// `decisions/0012-coordinator-ride-identity-cache.md`.
+    ///
+    /// Returns silently (no entry written) if neither live nor cached identity is
+    /// available — typically a pre-confirmation cancellation, which has no canonical
+    /// `confirmationEventId` to use as a ride ID.
     private func recordRideHistory(status: RideHistoryEntry.Status = .completed) {
         let confirmationId: String
         let driverPubkey: String

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -39,6 +39,17 @@ public final class RideCoordinator {
     public var destinationLocation: Location?
     public var lastError: String?
 
+    /// Snapshot of the most recently active ride's identity, captured while
+    /// the session still holds it (in `sessionDidChangeStage` and on session
+    /// restore). Used to record cancelled-ride history entries after the SDK
+    /// has reset state. Cleared on every terminal outcome.
+    private var lastActiveRideIdentity: ActiveRideIdentity?
+
+    private struct ActiveRideIdentity {
+        let confirmationEventId: String
+        let driverPubkey: String
+    }
+
     var driversRepository: FollowedDriversRepository { location.driversRepository }
     public var chatMessages: [(id: String, text: String, isMine: Bool, timestamp: Int)] { chat.chatMessages }
     public var activeRidePaymentMethods: [String] {
@@ -158,6 +169,14 @@ public final class RideCoordinator {
                 distanceMiles: saved.fareDistanceMiles ?? 0,
                 durationMinutes: saved.fareDurationMinutes ?? 0,
                 fareUSD: fareDecimal
+            )
+        }
+        if session.stage.isActiveRide,
+           let confirmationId = session.confirmationEventId,
+           let driverPubkey = session.driverPubkey {
+            lastActiveRideIdentity = ActiveRideIdentity(
+                confirmationEventId: confirmationId,
+                driverPubkey: driverPubkey
             )
         }
     }
@@ -408,6 +427,7 @@ extension RideCoordinator: RiderRideSessionDelegate {
             clearCoordinatorUIState(clearError: message == nil)
             lastError = message
         }
+        lastActiveRideIdentity = nil
     }
 
     public func sessionDidEncounterError(_ error: Error) {
@@ -415,6 +435,14 @@ extension RideCoordinator: RiderRideSessionDelegate {
     }
 
     public func sessionDidChangeStage(from: RiderStage, to: RiderStage) {
+        if to.isActiveRide,
+           let confirmationId = session.confirmationEventId,
+           let driverPubkey = session.driverPubkey {
+            lastActiveRideIdentity = ActiveRideIdentity(
+                confirmationEventId: confirmationId,
+                driverPubkey: driverPubkey
+            )
+        }
         if !from.isActiveRide && to.isActiveRide,
            let driverPubkey = session.driverPubkey,
            let confirmationId = session.confirmationEventId {

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -350,27 +350,37 @@ public final class RideCoordinator {
         chat.reset()
     }
 
-    private func recordRideHistory() {
-        guard let driverPubkey = session.driverPubkey,
-              let confirmationId = session.confirmationEventId else {
-            return
+    private func recordRideHistory(status: RideHistoryEntry.Status = .completed) {
+        let confirmationId: String
+        let driverPubkey: String
+        if let live = session.confirmationEventId, let livePubkey = session.driverPubkey {
+            confirmationId = live
+            driverPubkey = livePubkey
+        } else if let cached = lastActiveRideIdentity {
+            confirmationId = cached.confirmationEventId
+            driverPubkey = cached.driverPubkey
+        } else {
+            return  // pre-confirmation cancellation or untracked state — drop silently
         }
 
         let pickup = pickupLocation ?? session.precisePickup ?? Location(latitude: 0, longitude: 0)
         let destination = destinationLocation ?? session.preciseDestination ?? Location(latitude: 0, longitude: 0)
+        let isCancelled = (status == .cancelled)
+
         let entry = RideHistoryEntry(
             id: confirmationId,
             date: .now,
+            status: status.rawValue,
             counterpartyPubkey: driverPubkey,
             counterpartyName: driversRepository.cachedDriverName(pubkey: driverPubkey),
             pickupGeohash: ProgressiveReveal.historyGeohash(for: pickup),
             dropoffGeohash: ProgressiveReveal.historyGeohash(for: destination),
             pickup: pickup,
             destination: destination,
-            fare: currentFareEstimate?.fareUSD ?? 0,
+            fare: isCancelled ? 0 : (currentFareEstimate?.fareUSD ?? 0),
             paymentMethod: session.paymentMethod ?? selectedPaymentMethod ?? PaymentMethod.cash.rawValue,
-            distance: currentFareEstimate?.distanceMiles,
-            duration: currentFareEstimate.map { Int($0.durationMinutes) }
+            distance: isCancelled ? nil : currentFareEstimate?.distanceMiles,
+            duration: isCancelled ? nil : currentFareEstimate.map { Int($0.durationMinutes) }
         )
         rideHistory.addRide(entry)
         backupRideHistory()
@@ -420,9 +430,15 @@ public final class RideCoordinator {
 
 extension RideCoordinator: RiderRideSessionDelegate {
     public func sessionDidReachTerminal(_ outcome: RideSessionTerminalOutcome) {
-        if case .completed = outcome {
+        switch outcome {
+        case .completed:
             recordRideHistory()
-        } else {
+        case .cancelledByRider, .cancelledByDriver:
+            recordRideHistory(status: .cancelled)
+            let message = terminalMessage(for: outcome)
+            clearCoordinatorUIState(clearError: message == nil)
+            lastError = message
+        case .expired, .bruteForcePin:
             let message = terminalMessage(for: outcome)
             clearCoordinatorUIState(clearError: message == nil)
             lastError = message

--- a/RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift
@@ -264,6 +264,43 @@ struct AppStateRideHistoryRowsTests {
         #expect(rows[0].fareLabel == "$12.00")
         #expect(rows[0].isCompleted == true)
     }
+
+    @Test func filtersOutNonRoadflareAppOriginEntries() {
+        let (appState, rideHistory, _) = makeAppStateWithInMemoryStores()
+
+        // Roadflare-origin entry: should appear.
+        let roadflareEntry = RideHistoryEntry(
+            id: "roadflare-1",
+            date: Date(timeIntervalSince1970: 1_000),
+            counterpartyPubkey: fakePubkeyA,
+            counterpartyName: "Driver A",
+            pickupGeohash: "abc", dropoffGeohash: "def",
+            pickup: Location(latitude: 0, longitude: 0),
+            destination: Location(latitude: 1, longitude: 1),
+            fare: Decimal(10),
+            paymentMethod: "cash"
+            // appOrigin defaults to "roadflare"
+        )
+        // Ridestr-origin entry (synced from Android rider app): should be hidden.
+        let ridestrEntry = RideHistoryEntry(
+            id: "ridestr-1",
+            date: Date(timeIntervalSince1970: 2_000),
+            counterpartyPubkey: fakePubkeyA,
+            counterpartyName: "Driver B",
+            pickupGeohash: "abc", dropoffGeohash: "def",
+            pickup: Location(latitude: 0, longitude: 0),
+            destination: Location(latitude: 1, longitude: 1),
+            fare: Decimal(20),
+            paymentMethod: "cash",
+            appOrigin: "ridestr"
+        )
+        rideHistory.addRide(roadflareEntry)
+        rideHistory.addRide(ridestrEntry)
+
+        let rows = appState.rideHistoryRows
+        #expect(rows.count == 1)
+        #expect(rows.first?.id == "roadflare-1")
+    }
 }
 
 // MARK: - AppState.favoriteLocationRows / recentLocationRows

--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -533,6 +533,37 @@ struct RideHistoryRowTests {
         #expect(row.isCompleted == false)
     }
 
+    @Test func cancelledStatusProducesCancelledFareLabel() {
+        let row = RideHistoryRow.from(makeEntry(status: "cancelled", fare: 0, distance: nil, duration: nil))
+        #expect(row.fareLabel == "Cancelled")
+    }
+
+    @Test func cancelledStatusProducesNilDistanceAndDuration() {
+        let row = RideHistoryRow.from(makeEntry(status: "cancelled", fare: 0, distance: nil, duration: nil))
+        #expect(row.distanceLabel == nil)
+        #expect(row.durationLabel == nil)
+    }
+
+    @Test func cancelledStatusSetsIsCancelledTrue() {
+        let row = RideHistoryRow.from(makeEntry(status: "cancelled", fare: 0))
+        #expect(row.isCancelled == true)
+        #expect(row.isCompleted == false)
+    }
+
+    @Test func completedStatusSetsIsCancelledFalse() {
+        let row = RideHistoryRow.from(makeEntry(status: "completed"))
+        #expect(row.isCancelled == false)
+        #expect(row.isCompleted == true)
+    }
+
+    @Test func completedZeroFarePreservesEmDashFallback() {
+        // Legacy synced entries may have fare=0 with status=completed.
+        // Behavior preserved: shown as em-dash, not "Cancelled".
+        let row = RideHistoryRow.from(makeEntry(status: "completed", fare: 0))
+        #expect(row.fareLabel == "–")
+        #expect(row.isCancelled == false)
+    }
+
     @Test func counterpartyNamePreserved() {
         let row = RideHistoryRow.from(makeEntry(counterpartyName: "Eve"))
         #expect(row.counterpartyName == "Eve")

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -893,6 +893,185 @@ struct RideCoordinatorTests {
     }
 
     @MainActor
+    @Test func cancelByRiderPostConfirmationRecordsCancelledHistory() async throws {
+        let (coordinator, _, _, history, _) = try await makeCoordinator()
+        coordinator.session.restore(
+            stage: .rideConfirmed,
+            offerEventId: "offer",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: rideCoordinatorConfirmationEventId,
+            driverPubkey: String(repeating: "d", count: 64),
+            pin: "1234",
+            pinVerified: true,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.pickupLocation = Location(latitude: 40.71, longitude: -74.01, address: "Penn Station")
+        coordinator.destinationLocation = Location(latitude: 40.76, longitude: -73.98, address: "Central Park")
+        coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+        // Production fires this when entering an active stage; mimicking it here.
+        coordinator.sessionDidChangeStage(from: .driverAccepted, to: .rideConfirmed)
+
+        coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "Changed plans"))
+
+        #expect(history.rides.count == 1)
+        let entry = try #require(history.rides.first)
+        #expect(entry.id == rideCoordinatorConfirmationEventId)
+        #expect(entry.status == "cancelled")
+        #expect(entry.fare == 0)
+        #expect(entry.distance == nil)
+        #expect(entry.duration == nil)
+    }
+
+    @MainActor
+    @Test func cancelByRiderPreConfirmationRecordsNothing() async throws {
+        let (coordinator, _, _, history, _) = try await makeCoordinator()
+        // No confirmationEventId → no cache populate, even if stage-change fires
+        coordinator.session.restore(
+            stage: .waitingForAcceptance,
+            offerEventId: "offer",
+            acceptanceEventId: nil,
+            confirmationEventId: nil,
+            driverPubkey: String(repeating: "d", count: 64),
+            pin: nil,
+            pinVerified: false,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.sessionDidChangeStage(from: .idle, to: .waitingForAcceptance)
+
+        coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "Changed plans"))
+
+        #expect(history.rides.isEmpty)
+    }
+
+    @MainActor
+    @Test func cancelByDriverPostConfirmationRecordsCancelledHistory() async throws {
+        let (coordinator, _, _, history, _) = try await makeCoordinator()
+        coordinator.session.restore(
+            stage: .rideConfirmed,
+            offerEventId: "offer",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: rideCoordinatorConfirmationEventId,
+            driverPubkey: String(repeating: "d", count: 64),
+            pin: "1234",
+            pinVerified: true,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.pickupLocation = Location(latitude: 40.71, longitude: -74.01, address: "Penn Station")
+        coordinator.destinationLocation = Location(latitude: 40.76, longitude: -73.98, address: "Central Park")
+        coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+        coordinator.sessionDidChangeStage(from: .driverAccepted, to: .rideConfirmed)
+
+        coordinator.sessionDidReachTerminal(.cancelledByDriver(reason: "Driver unavailable"))
+
+        #expect(history.rides.count == 1)
+        let entry = try #require(history.rides.first)
+        #expect(entry.status == "cancelled")
+        #expect(entry.fare == 0)
+        // Driver-cancel surfaces a toast — verify that still works alongside the new persistence
+        #expect(coordinator.lastError == "Driver cancelled the ride: Driver unavailable")
+    }
+
+    @MainActor
+    @Test func forceEndRideRecordsCompletedWithEstimate() async throws {
+        let (coordinator, _, _, history, _) = try await makeCoordinator()
+        coordinator.session.restore(
+            stage: .inProgress,
+            offerEventId: "offer",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: rideCoordinatorConfirmationEventId,
+            driverPubkey: String(repeating: "d", count: 64),
+            pin: "1234",
+            pinVerified: true,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.pickupLocation = Location(latitude: 40.71, longitude: -74.01, address: "Penn Station")
+        coordinator.destinationLocation = Location(latitude: 40.76, longitude: -73.98, address: "Central Park")
+        coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+
+        await coordinator.forceEndRide()
+
+        #expect(history.rides.count == 1)
+        let entry = try #require(history.rides.first)
+        #expect(entry.status == "completed")
+        #expect(entry.fare == Decimal(12.5))
+        #expect(entry.distance == 5)
+        #expect(entry.duration == 15)
+    }
+
+    @MainActor
+    @Test func restoreRideStateInActiveStagePopulatesCacheForLaterCancel() async throws {
+        let (coordinator, _, _, history, persistence) = try await makeCoordinator(clearRidePersistence: false)
+        // Seed persistence with an active ride state.
+        let driverPubkey = String(repeating: "d", count: 64)
+        let saved = PersistedRideState(
+            stage: RiderStage.rideConfirmed.rawValue,
+            offerEventId: "offer",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: rideCoordinatorConfirmationEventId,
+            driverPubkey: driverPubkey,
+            pin: "1234",
+            pinVerified: true,
+            paymentMethodRaw: "zelle",
+            fiatPaymentMethodsRaw: ["zelle"],
+            fareUSD: "12.50",
+            fareDistanceMiles: 5,
+            fareDurationMinutes: 15
+        )
+        persistence.saveRaw(saved)
+        coordinator.restoreRideState()
+
+        // Cache should now be populated. Fire a cancel terminal directly.
+        coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "Changed plans"))
+
+        #expect(history.rides.count == 1)
+        #expect(history.rides.first?.status == "cancelled")
+        #expect(history.rides.first?.fare == 0)
+    }
+
+    @MainActor
+    @Test func lastActiveRideIdentityClearedAfterTerminal() async throws {
+        let (coordinator, _, _, history, _) = try await makeCoordinator()
+        // First ride: post-confirmation cancel → records.
+        coordinator.session.restore(
+            stage: .rideConfirmed,
+            offerEventId: "offer-1",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: rideCoordinatorConfirmationEventId,
+            driverPubkey: String(repeating: "d", count: 64),
+            pin: "1234",
+            pinVerified: true,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.sessionDidChangeStage(from: .driverAccepted, to: .rideConfirmed)
+        coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "First cancel"))
+        #expect(history.rides.count == 1)
+
+        // Second "ride": pre-confirmation cancel. Cache must NOT inherit from first ride.
+        coordinator.session.reset()
+        coordinator.session.restore(
+            stage: .waitingForAcceptance,
+            offerEventId: "offer-2",
+            acceptanceEventId: nil,
+            confirmationEventId: nil,
+            driverPubkey: String(repeating: "d", count: 64),
+            pin: nil,
+            pinVerified: false,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.sessionDidChangeStage(from: .idle, to: .waitingForAcceptance)
+        coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "Second cancel"))
+
+        // Still 1 — second ride did not produce an entry from stale cache.
+        #expect(history.rides.count == 1)
+    }
+
+    @MainActor
     @Test func sessionShouldPersistSavesActiveSessionAndClearsIdleOrCompleted() async throws {
         let (coordinator, _, _, _, persistence) = try await makeCoordinator()
         coordinator.session.restore(

--- a/decisions/0012-coordinator-ride-identity-cache.md
+++ b/decisions/0012-coordinator-ride-identity-cache.md
@@ -1,0 +1,64 @@
+# ADR-0012: Coordinator-side ride identity cache
+
+**Status:** Active
+**Created:** 2026-04-28
+**Tags:** architecture, coordinator, sdk-boundary
+
+## Context
+
+When `RiderRideSession` reaches a cancellation terminal outcome (`.cancelledByRider`, `.cancelledByDriver`, `.bruteForcePin`), the SDK clears `confirmationEventId` and `driverPubkey` from the state machine **before** invoking `RiderRideSessionDelegate.sessionDidReachTerminal(_:)`. Concretely:
+
+- `RideStateMachine.swift`'s `.cancel` event handler returns `RideContext(riderPubkey: current.riderPubkey)`, which atomically replaces the context and nils every other field.
+- `RiderRideSession.cancelRide` calls `stateMachine.reset()` (also atomic context replacement) before firing the delegate.
+- `handleDriverStateEvent` and `handleCancellationEvent` rely on `receiveCancellationEvent`/`receiveDriverStateEvent` having already mutated the state machine via the same `.cancel` event.
+
+The `.completed` outcome is the asymmetric exception — the state machine stays at `.completed` (no reset), so session IDs remain readable when the delegate fires. That's why the pre-existing completion path in `RideCoordinator.recordRideHistory` could read `session.confirmationEventId` directly.
+
+This asymmetry blocks a naive implementation of "persist cancelled rides to history" in the coordinator: by the time the cancellation terminal callback reaches the app layer, the IDs needed to construct a `RideHistoryEntry` are already gone.
+
+## Decision
+
+The coordinator caches ride identity (`confirmationEventId`, `driverPubkey`) into a `lastActiveRideIdentity: ActiveRideIdentity?` field while session state still holds it, and uses that cache as a fallback in `recordRideHistory` when the live session fields are nil.
+
+The cache is populated at two sites:
+
+1. **`sessionDidChangeStage(from:to:)`** — when transitioning into a stage where `to.isActiveRide == true` (`.rideConfirmed`, `.enRoute`, `.driverArrived`, `.inProgress`) and both IDs are non-nil.
+2. **`restoreRideState()`** — immediately after `session.restore(...)` if the restored stage is active and both IDs are non-nil. Required because `session.restore` does not call `emitStageChangeIfNeeded`, so `sessionDidChangeStage` is not fired during restore.
+
+The cache is cleared unconditionally at the end of `sessionDidReachTerminal(_:)` for every outcome, preventing a new ride from inheriting stale identity.
+
+`recordRideHistory` reads live session IDs first and falls back to cached identity only when both live fields are nil — preserving the original code path for `.completed` and `forceEndRide`, which both run before any state reset.
+
+## Rationale
+
+The decision deliberately chooses **app-layer caching** over **SDK contract change** for three reasons:
+
+1. **SDK API stability.** Changing `RiderRideSessionDelegate` (e.g., enriching the terminal outcome enum with associated IDs, or adding a `sessionWillReachTerminal` hook) is a breaking change for every conformer. The cache is purely additive coordinator state.
+2. **Smaller blast radius.** The fix touches `RideCoordinator` and three call-site stubs. An SDK ordering change would touch `cancelRide`, both event handlers, every test that asserts post-terminal session state, and any future consumer relying on the documented contract that "session is reset when terminal fires for cancellations."
+3. **Cross-platform symmetry.** The Android Ridestr rider app (`rider-app/src/main/java/com/ridestr/rider/viewmodels/RiderViewModel.kt`) uses the same pattern: capture `session.confirmationEventId` / `session.acceptance?.driverPubKey` into local variables BEFORE invoking cancel, then use the captured values inside the launched coroutine that persists history. Coordinator-level capture is the established cross-platform pattern.
+
+## Alternatives Considered
+
+- **Add `confirmationEventId` and `driverPubkey` to the `RideSessionTerminalOutcome` enum cases.** Cleanest from a contract perspective — terminal outcomes become self-contained — but breaks every pattern-match callsite, requires nilable IDs to handle pre-confirmation cancellation, and the SDK still has to capture the IDs before the reset. The SDK code complexity is similar; the app code is simpler at the cost of every consumer in the callgraph.
+- **Reorder the SDK so `sessionDidReachTerminal` fires BEFORE `stateMachine.reset()` in cancel paths.** Would align cancel with completed semantics. Rejected because the contract change is silent (no compile-time signal) and existing tests in `RideCoordinatorTests.swift` (lines 815-893) implicitly depend on the current ordering — they don't call `session.restore` for cancellation tests precisely because the contract says session state is gone by the time the callback fires.
+- **Move history recording into the SDK.** `RideHistoryRepository` already lives in the SDK, so this isn't a layering violation in principle. Rejected because it conflates protocol semantics (when does a ride happen) with persistence policy (which app's history is this written to, with what `appOrigin`), and `RideHistoryEntry` construction needs UI-level state (`pickupLocation`, `currentFareEstimate`) that the SDK doesn't track.
+
+## Consequences
+
+- **Enables persistence of cancelled rides.** `.cancelledByRider` and `.cancelledByDriver` now flow through `recordRideHistory(status: .cancelled)` and produce history entries with `status="cancelled"`, `fare=0`, distance/duration nil — matching the Ridestr Android pattern.
+- **Pre-confirmation cancellations correctly drop.** `confirmationEventId` is only set when transitioning into `.rideConfirmed`; the cache populate guards `let confirmationId = session.confirmationEventId`, so pre-confirmation stages never populate the cache, and `recordRideHistory`'s "no live IDs and no cache" branch returns early. This matches Ridestr's `shouldSaveCancelledHistory = rideStage in [RIDE_CONFIRMED, DRIVER_ARRIVED, IN_PROGRESS]` gate without an explicit stage check.
+- **`.expired` and `.bruteForcePin` keep no-history behavior.** Mirrors Ridestr precedent. If we want to persist these later, we route them through the same `recordRideHistory(status: .cancelled)` call — the cache machinery already supports it.
+- **Load-bearing call ordering at terminal sites.** `recordRideHistory` reads coordinator state (`pickupLocation`, `destinationLocation`, `currentFareEstimate`); `clearCoordinatorUIState` zeroes those fields. The terminal-handler ordering (record before clear) is now load-bearing. Documented inline at `RideCoordinator.recordRideHistory`'s doc comment.
+- **Tests document the populate path explicitly.** `RideCoordinatorTests` cancellation tests now call `coordinator.sessionDidChangeStage(from: .driverAccepted, to: .rideConfirmed)` after `session.restore` to mimic the production populate point. Existing tests at lines 815-893 that don't call this still pass — they correctly model the "no cache, no record" path.
+
+## Affected Files
+
+- `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift` — cache field + populate sites + `recordRideHistory` refactor + `sessionDidReachTerminal` switch
+- `RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift` — `RideHistoryEntry.Status` enum + `statusEnum` projection (additive; supports both completed and cancelled cases)
+- `RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift` — `status: RideHistoryEntry.Status` stored property + `isCancelled` computed property; `from(_:)` produces "Cancelled" `fareLabel` for cancelled entries
+- `RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift` — `appOrigin == "roadflare"` filter on `rideHistoryRows` for cross-app coexistence
+- `RoadFlare/RoadFlare/Views/History/HistoryTab.swift` — `Color.rfError` foreground when `row.isCancelled`
+- `RoadFlare/RoadFlareTests/RideCoordinatorTests.swift` — six new tests covering rider-cancel post-confirmation, rider-cancel pre-confirmation, driver-cancel post-confirmation, forceEnd-with-estimate, restore-then-cancel, and post-terminal cache clear
+- `RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift` — five new tests for cancelled `fareLabel`, `isCancelled` projection, and em-dash legacy fallback
+- `RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift` — `filtersOutNonRoadflareAppOriginEntries`
+- `RidestrSDK/Tests/RidestrSDKTests/Models/RoadflareModelsTests.swift` — three `statusEnum` projection tests

--- a/docs/superpowers/plans/2026-04-27-ride-history-cancellation.md
+++ b/docs/superpowers/plans/2026-04-27-ride-history-cancellation.md
@@ -1,0 +1,979 @@
+# Ride History Cancellation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist cancelled rides to local + Nostr-backed history with `status="cancelled"` and red "Cancelled" UI; fix `forceEndRide` $0 bug; add `appOrigin` display filter for cross-app coexistence.
+
+**Architecture:** Coordinator-side ride-identity cache populated when transitioning into active stages and on session restore, used as a fallback when the SDK has cleared session state by the time `sessionDidReachTerminal` fires. No SDK changes; only additive `RideHistoryEntry.Status` enum extension. Single fare source: the rider's `currentFareEstimate`.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`@Test`/`@Suite`), `xcodebuild`. Existing `RidestrSDK` + `RoadFlareCore` boundaries unchanged.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-ride-history-cancellation-design.md`
+
+**Tracks:** [roadflare-ios#65](https://github.com/variablefate/roadflare-ios/issues/65)
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift` | Modify (append) | Add `RideHistoryEntry.Status` enum extension + `statusEnum` projection |
+| `RidestrSDK/Tests/RidestrSDKTests/Models/RoadflareModelsTests.swift` | Modify (append) | Test `statusEnum` round-trip + fail-open behavior |
+| `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift` | Modify | Add `lastActiveRideIdentity` cache, populate sites, refactor `recordRideHistory`, update `sessionDidReachTerminal` |
+| `RoadFlare/RoadFlareTests/RideCoordinatorTests.swift` | Modify (append) | New tests for cancellation persistence paths |
+| `RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift` | Modify | Replace stored `isCompleted` with stored `status` + computed `isCompleted`/`isCancelled`; cancelled `fareLabel` |
+| `RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift` | Modify (append) | New tests for cancelled fareLabel + computed properties |
+| `RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift` | Modify | Add `appOrigin == "roadflare"` filter to `rideHistoryRows` |
+| `RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift` | Modify (append) | Test that ridestr-origin entries are filtered out |
+| `RoadFlare/RoadFlare/Views/History/HistoryTab.swift` | Modify (1 line) | Fare-label color override for cancelled rides |
+
+---
+
+## Build verification commands
+
+Per project convention (`.claude/CLAUDE.md` "Build verification"), the canonical test command is `xcodebuild` on the full project. Use this between major tasks:
+
+```bash
+cd ~/Documents/Projects/roadflare-ios
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -quiet 2>&1 | tail -50
+```
+
+For faster iteration on SDK-only changes, `swift test --package-path RidestrSDK` is acceptable but DOES NOT catch app-target concurrency errors.
+
+---
+
+## Task 1: Add `RideHistoryEntry.Status` enum extension to SDK
+
+**Files:**
+- Modify: `RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift` (append after line 533, end of `RideHistoryEntry`)
+- Modify: `RidestrSDK/Tests/RidestrSDKTests/Models/RoadflareModelsTests.swift` (append a new test suite or new tests in the existing suite)
+
+- [ ] **Step 1.1: Write failing tests**
+
+Append to `RoadflareModelsTests.swift` (find an existing `@Suite` or add a new one near the existing `RideHistoryEntry` tests):
+
+```swift
+@Test func statusEnumProjectsCompleted() {
+    let entry = RideHistoryEntry(
+        id: "r1", date: .now, status: "completed",
+        counterpartyPubkey: String(repeating: "a", count: 64),
+        pickupGeohash: "g1", dropoffGeohash: "g2",
+        pickup: Location(latitude: 0, longitude: 0),
+        destination: Location(latitude: 0, longitude: 0),
+        fare: 10, paymentMethod: "cash"
+    )
+    #expect(entry.statusEnum == .completed)
+}
+
+@Test func statusEnumProjectsCancelled() {
+    let entry = RideHistoryEntry(
+        id: "r2", date: .now, status: "cancelled",
+        counterpartyPubkey: String(repeating: "a", count: 64),
+        pickupGeohash: "g1", dropoffGeohash: "g2",
+        pickup: Location(latitude: 0, longitude: 0),
+        destination: Location(latitude: 0, longitude: 0),
+        fare: 0, paymentMethod: "cash"
+    )
+    #expect(entry.statusEnum == .cancelled)
+}
+
+@Test func statusEnumFailsOpenForUnknownStatus() {
+    // Forward-compat: unrecognized statuses don't redact fare data
+    let entry = RideHistoryEntry(
+        id: "r3", date: .now, status: "ended_early_v3",
+        counterpartyPubkey: String(repeating: "a", count: 64),
+        pickupGeohash: "g1", dropoffGeohash: "g2",
+        pickup: Location(latitude: 0, longitude: 0),
+        destination: Location(latitude: 0, longitude: 0),
+        fare: 25, paymentMethod: "cash"
+    )
+    #expect(entry.statusEnum == .completed)
+}
+```
+
+- [ ] **Step 1.2: Run tests, verify failure**
+
+```bash
+swift test --package-path RidestrSDK --filter RoadflareModelsTests/statusEnumProjectsCompleted 2>&1 | tail -20
+```
+
+Expected: compile error — `statusEnum` is not a member of `RideHistoryEntry`. Or `Status` is not a type. That's the failure we want.
+
+- [ ] **Step 1.3: Add the enum extension**
+
+Append to `RoadflareModels.swift` after line 533 (end of the `RideHistoryEntry` struct including `hash(into:)`):
+
+```swift
+public extension RideHistoryEntry {
+    /// Type-safe projection of `status`. Two known cases; unrecognized
+    /// values fail-open to `.completed` so a future cross-platform status
+    /// addition (e.g. `"ended_early"`) doesn't redact fare data on old clients.
+    enum Status: String, Sendable {
+        case completed
+        case cancelled
+    }
+
+    /// Typed projection of the raw `status` string. Fails open to `.completed`.
+    var statusEnum: Status { Status(rawValue: status) ?? .completed }
+}
+```
+
+- [ ] **Step 1.4: Run tests, verify pass**
+
+```bash
+swift test --package-path RidestrSDK --filter RoadflareModelsTests 2>&1 | tail -20
+```
+
+Expected: all three new tests pass; no existing tests regress.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift \
+        RidestrSDK/Tests/RidestrSDKTests/Models/RoadflareModelsTests.swift
+git commit -m "$(cat <<'EOF'
+feat(sdk): add RideHistoryEntry.Status enum projection
+
+Additive: introduces a Status enum (.completed, .cancelled) and a
+statusEnum computed property that fails open to .completed for any
+unrecognized status string. Wire format and Codable shape unchanged.
+
+Issue #65 prep — RideHistoryRow and RideCoordinator will start
+writing/reading "cancelled" via this enum.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `lastActiveRideIdentity` cache to `RideCoordinator`
+
+This task introduces the cache field and its populate/clear sites WITHOUT yet calling `recordRideHistory(status: .cancelled)`. The wiring is mechanical and doesn't change observable behavior — Task 3 is what makes the cache actually do something.
+
+**Files:**
+- Modify: `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift`
+
+- [ ] **Step 2.1: Add the cache type and property**
+
+Add inside the `RideCoordinator` class, near the existing private state declarations (search for `private var stageTimeoutTask` or similar — exact placement is alongside other `private` instance state, before `init`). If no clean spot exists, place it immediately after the existing `currentFareEstimate` line (around `RideCoordinator.swift:36`):
+
+```swift
+/// Snapshot of the most recently active ride's identity, captured while
+/// the session still holds it (in `sessionDidChangeStage` and on session
+/// restore). Used to record cancelled-ride history entries after the SDK
+/// has reset state. Cleared on every terminal outcome.
+private var lastActiveRideIdentity: ActiveRideIdentity?
+
+private struct ActiveRideIdentity {
+    let confirmationEventId: String
+    let driverPubkey: String
+}
+```
+
+- [ ] **Step 2.2: Populate cache from `sessionDidChangeStage`**
+
+Locate `public func sessionDidChangeStage(from: RiderStage, to: RiderStage)` (around line 417). Add a populate block at the very top of the method body, before any existing logic:
+
+```swift
+public func sessionDidChangeStage(from: RiderStage, to: RiderStage) {
+    if to.isActiveRide,
+       let confirmationId = session.confirmationEventId,
+       let driverPubkey = session.driverPubkey {
+        lastActiveRideIdentity = ActiveRideIdentity(
+            confirmationEventId: confirmationId,
+            driverPubkey: driverPubkey
+        )
+    }
+
+    // ... existing chat subscribe / cleanup logic preserved unchanged ...
+    if !from.isActiveRide && to.isActiveRide,
+       let driverPubkey = session.driverPubkey,
+       let confirmationId = session.confirmationEventId {
+        chat.subscribeToChat(driverPubkey: driverPubkey, confirmationEventId: confirmationId)
+    }
+    if to == .idle || to == .completed {
+        chat.cleanupAsync()
+    }
+}
+```
+
+- [ ] **Step 2.3: Populate cache from `restoreRideState`**
+
+Locate `func restoreRideState()` (line 108). After the existing `currentFareEstimate` assignment block (lines 156-162, the `if let fareStr = saved.fareUSD ...` block), append:
+
+```swift
+        if session.stage.isActiveRide,
+           let confirmationId = session.confirmationEventId,
+           let driverPubkey = session.driverPubkey {
+            lastActiveRideIdentity = ActiveRideIdentity(
+                confirmationEventId: confirmationId,
+                driverPubkey: driverPubkey
+            )
+        }
+```
+
+This sits just inside the closing `}` of `restoreRideState`. (`session.restore` does NOT call `emitStageChangeIfNeeded`, so the populate must happen here directly.)
+
+- [ ] **Step 2.4: Clear cache from `sessionDidReachTerminal`**
+
+Locate `public func sessionDidReachTerminal(_ outcome: RideSessionTerminalOutcome)` (around line 403). For now, just add the clear at the end of the method — the body still has its current shape:
+
+```swift
+public func sessionDidReachTerminal(_ outcome: RideSessionTerminalOutcome) {
+    if case .completed = outcome {
+        recordRideHistory()
+    } else {
+        let message = terminalMessage(for: outcome)
+        clearCoordinatorUIState(clearError: message == nil)
+        lastError = message
+    }
+    lastActiveRideIdentity = nil  // NEW
+}
+```
+
+- [ ] **Step 2.5: Run full test suite to confirm nothing regressed**
+
+```bash
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -quiet 2>&1 | tail -50
+```
+
+Expected: all tests pass (this task adds dead-but-harmless cache machinery; behavior is unchanged).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+git commit -m "$(cat <<'EOF'
+refactor(coordinator): add lastActiveRideIdentity cache scaffolding
+
+Introduces ActiveRideIdentity struct and lastActiveRideIdentity
+property, populated from sessionDidChangeStage (active-stage entry)
+and restoreRideState (post-restore active stage), cleared at every
+terminal outcome. Cache is unused so far — Task 3 wires it into
+recordRideHistory to fix the cancellation persistence path.
+
+Issue #65 prep.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Refactor `recordRideHistory` and route cancellations through it
+
+This is the behavioral core of the fix.
+
+**Files:**
+- Modify: `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift`
+- Modify: `RoadFlare/RoadFlareTests/RideCoordinatorTests.swift` (append new tests)
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Append these new `@Test` functions to `RideCoordinatorTests.swift` after the existing `sessionDidReachTerminalBruteForcePinSetsMessage` test (line 893):
+
+```swift
+@MainActor
+@Test func cancelByRiderPostConfirmationRecordsCancelledHistory() async throws {
+    let (coordinator, _, _, history, _) = try await makeCoordinator()
+    coordinator.session.restore(
+        stage: .rideConfirmed,
+        offerEventId: "offer",
+        acceptanceEventId: rideCoordinatorAcceptanceEventId,
+        confirmationEventId: rideCoordinatorConfirmationEventId,
+        driverPubkey: String(repeating: "d", count: 64),
+        pin: "1234",
+        pinVerified: true,
+        paymentMethod: "zelle",
+        fiatPaymentMethods: ["zelle"]
+    )
+    coordinator.pickupLocation = Location(latitude: 40.71, longitude: -74.01, address: "Penn Station")
+    coordinator.destinationLocation = Location(latitude: 40.76, longitude: -73.98, address: "Central Park")
+    coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+    // Production fires this when entering an active stage; mimicking it here.
+    coordinator.sessionDidChangeStage(from: .driverAccepted, to: .rideConfirmed)
+
+    coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "Changed plans"))
+
+    #expect(history.rides.count == 1)
+    let entry = try #require(history.rides.first)
+    #expect(entry.id == rideCoordinatorConfirmationEventId)
+    #expect(entry.status == "cancelled")
+    #expect(entry.fare == 0)
+    #expect(entry.distance == nil)
+    #expect(entry.duration == nil)
+}
+
+@MainActor
+@Test func cancelByRiderPreConfirmationRecordsNothing() async throws {
+    let (coordinator, _, _, history, _) = try await makeCoordinator()
+    // No confirmationEventId → no cache populate, even if stage-change fires
+    coordinator.session.restore(
+        stage: .waitingForAcceptance,
+        offerEventId: "offer",
+        acceptanceEventId: nil,
+        confirmationEventId: nil,
+        driverPubkey: String(repeating: "d", count: 64),
+        pin: nil,
+        pinVerified: false,
+        paymentMethod: "zelle",
+        fiatPaymentMethods: ["zelle"]
+    )
+    coordinator.sessionDidChangeStage(from: .idle, to: .waitingForAcceptance)
+
+    coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "Changed plans"))
+
+    #expect(history.rides.isEmpty)
+}
+
+@MainActor
+@Test func cancelByDriverPostConfirmationRecordsCancelledHistory() async throws {
+    let (coordinator, _, _, history, _) = try await makeCoordinator()
+    coordinator.session.restore(
+        stage: .rideConfirmed,
+        offerEventId: "offer",
+        acceptanceEventId: rideCoordinatorAcceptanceEventId,
+        confirmationEventId: rideCoordinatorConfirmationEventId,
+        driverPubkey: String(repeating: "d", count: 64),
+        pin: "1234",
+        pinVerified: true,
+        paymentMethod: "zelle",
+        fiatPaymentMethods: ["zelle"]
+    )
+    coordinator.pickupLocation = Location(latitude: 40.71, longitude: -74.01, address: "Penn Station")
+    coordinator.destinationLocation = Location(latitude: 40.76, longitude: -73.98, address: "Central Park")
+    coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+    coordinator.sessionDidChangeStage(from: .driverAccepted, to: .rideConfirmed)
+
+    coordinator.sessionDidReachTerminal(.cancelledByDriver(reason: "Driver unavailable"))
+
+    #expect(history.rides.count == 1)
+    let entry = try #require(history.rides.first)
+    #expect(entry.status == "cancelled")
+    #expect(entry.fare == 0)
+    // Driver-cancel surfaces a toast — verify that still works alongside the new persistence
+    #expect(coordinator.lastError == "Driver cancelled the ride: Driver unavailable")
+}
+
+@MainActor
+@Test func forceEndRideRecordsCompletedWithEstimate() async throws {
+    let (coordinator, _, _, history, _) = try await makeCoordinator()
+    coordinator.session.restore(
+        stage: .inProgress,
+        offerEventId: "offer",
+        acceptanceEventId: rideCoordinatorAcceptanceEventId,
+        confirmationEventId: rideCoordinatorConfirmationEventId,
+        driverPubkey: String(repeating: "d", count: 64),
+        pin: "1234",
+        pinVerified: true,
+        paymentMethod: "zelle",
+        fiatPaymentMethods: ["zelle"]
+    )
+    coordinator.pickupLocation = Location(latitude: 40.71, longitude: -74.01, address: "Penn Station")
+    coordinator.destinationLocation = Location(latitude: 40.76, longitude: -73.98, address: "Central Park")
+    coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+
+    await coordinator.forceEndRide()
+
+    #expect(history.rides.count == 1)
+    let entry = try #require(history.rides.first)
+    #expect(entry.status == "completed")
+    #expect(entry.fare == Decimal(12.5))
+    #expect(entry.distance == 5)
+    #expect(entry.duration == 15)
+}
+
+@MainActor
+@Test func restoreRideStateInActiveStagePopulatesCacheForLaterCancel() async throws {
+    let (coordinator, _, _, history, persistence) = try await makeCoordinator(clearRidePersistence: false)
+    // Seed persistence with an active ride state.
+    let driverPubkey = String(repeating: "d", count: 64)
+    let saved = PersistedRideState(
+        stage: RiderStage.rideConfirmed.rawValue,
+        offerEventId: "offer",
+        acceptanceEventId: rideCoordinatorAcceptanceEventId,
+        confirmationEventId: rideCoordinatorConfirmationEventId,
+        driverPubkey: driverPubkey,
+        pin: "1234",
+        pinVerified: true,
+        paymentMethodRaw: "zelle",
+        fiatPaymentMethodsRaw: ["zelle"],
+        fareUSD: "12.50",
+        fareDistanceMiles: 5,
+        fareDurationMinutes: 15
+    )
+    persistence.saveRaw(saved)
+    coordinator.restoreRideState()
+
+    // Cache should now be populated. Fire a cancel terminal directly.
+    coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "Changed plans"))
+
+    #expect(history.rides.count == 1)
+    #expect(history.rides.first?.status == "cancelled")
+    #expect(history.rides.first?.fare == 0)
+}
+
+@MainActor
+@Test func lastActiveRideIdentityClearedAfterTerminal() async throws {
+    let (coordinator, _, _, history, _) = try await makeCoordinator()
+    // First ride: post-confirmation cancel → records.
+    coordinator.session.restore(
+        stage: .rideConfirmed,
+        offerEventId: "offer-1",
+        acceptanceEventId: rideCoordinatorAcceptanceEventId,
+        confirmationEventId: rideCoordinatorConfirmationEventId,
+        driverPubkey: String(repeating: "d", count: 64),
+        pin: "1234",
+        pinVerified: true,
+        paymentMethod: "zelle",
+        fiatPaymentMethods: ["zelle"]
+    )
+    coordinator.sessionDidChangeStage(from: .driverAccepted, to: .rideConfirmed)
+    coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "First cancel"))
+    #expect(history.rides.count == 1)
+
+    // Second "ride": pre-confirmation cancel. Cache must NOT inherit from first ride.
+    coordinator.session.reset()
+    coordinator.session.restore(
+        stage: .waitingForAcceptance,
+        offerEventId: "offer-2",
+        acceptanceEventId: nil,
+        confirmationEventId: nil,
+        driverPubkey: String(repeating: "d", count: 64),
+        pin: nil,
+        pinVerified: false,
+        paymentMethod: "zelle",
+        fiatPaymentMethods: ["zelle"]
+    )
+    coordinator.sessionDidChangeStage(from: .idle, to: .waitingForAcceptance)
+    coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "Second cancel"))
+
+    // Still 1 — second ride did not produce an entry from stale cache.
+    #expect(history.rides.count == 1)
+}
+```
+
+- [ ] **Step 3.2: Run tests, verify failure**
+
+```bash
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -only-testing:RoadFlareTests/RideCoordinatorTests \
+  -quiet 2>&1 | tail -50
+```
+
+Expected: the six new tests fail (cancellation tests because no entry is written; forceEnd test because fare is 0 not estimate; restore test because no entry; lastActive test passes "accidentally" since pre-confirmation cancel was already a no-op — that one may need recheck after Task 3.3).
+
+- [ ] **Step 3.3: Refactor `recordRideHistory`**
+
+Replace the existing `recordRideHistory` body (currently at `RideCoordinator.swift:334`) with:
+
+```swift
+private func recordRideHistory(status: RideHistoryEntry.Status = .completed) {
+    let confirmationId: String
+    let driverPubkey: String
+    if let live = session.confirmationEventId, let livePubkey = session.driverPubkey {
+        confirmationId = live
+        driverPubkey = livePubkey
+    } else if let cached = lastActiveRideIdentity {
+        confirmationId = cached.confirmationEventId
+        driverPubkey = cached.driverPubkey
+    } else {
+        return  // pre-confirmation cancellation or untracked state — drop silently
+    }
+
+    let pickup = pickupLocation ?? session.precisePickup ?? Location(latitude: 0, longitude: 0)
+    let destination = destinationLocation ?? session.preciseDestination ?? Location(latitude: 0, longitude: 0)
+    let isCancelled = (status == .cancelled)
+
+    let entry = RideHistoryEntry(
+        id: confirmationId,
+        date: .now,
+        status: status.rawValue,
+        counterpartyPubkey: driverPubkey,
+        counterpartyName: driversRepository.cachedDriverName(pubkey: driverPubkey),
+        pickupGeohash: ProgressiveReveal.historyGeohash(for: pickup),
+        dropoffGeohash: ProgressiveReveal.historyGeohash(for: destination),
+        pickup: pickup,
+        destination: destination,
+        fare: isCancelled ? 0 : (currentFareEstimate?.fareUSD ?? 0),
+        paymentMethod: session.paymentMethod ?? selectedPaymentMethod ?? PaymentMethod.cash.rawValue,
+        distance: isCancelled ? nil : currentFareEstimate?.distanceMiles,
+        duration: isCancelled ? nil : currentFareEstimate.map { Int($0.durationMinutes) }
+    )
+    rideHistory.addRide(entry)
+    backupRideHistory()
+}
+```
+
+- [ ] **Step 3.4: Update `sessionDidReachTerminal` to dispatch cancellations**
+
+Replace the body of `sessionDidReachTerminal` (the version with the trailing `lastActiveRideIdentity = nil` line added in Task 2) with:
+
+```swift
+public func sessionDidReachTerminal(_ outcome: RideSessionTerminalOutcome) {
+    switch outcome {
+    case .completed:
+        recordRideHistory()
+    case .cancelledByRider, .cancelledByDriver:
+        recordRideHistory(status: .cancelled)
+        let message = terminalMessage(for: outcome)
+        clearCoordinatorUIState(clearError: message == nil)
+        lastError = message
+    case .expired, .bruteForcePin:
+        let message = terminalMessage(for: outcome)
+        clearCoordinatorUIState(clearError: message == nil)
+        lastError = message
+    }
+    lastActiveRideIdentity = nil
+}
+```
+
+- [ ] **Step 3.5: Run tests, verify pass**
+
+```bash
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -only-testing:RoadFlareTests/RideCoordinatorTests \
+  -quiet 2>&1 | tail -50
+```
+
+Expected: all six new tests pass; existing `sessionDidReachTerminal*` tests (lines 758, 815, 836, 856, 876) remain green.
+
+If `sessionDidReachTerminalCancelledByRiderClearsUIAndChatWithoutError` (line 815) or `sessionDidReachTerminalCancelledByDriverSurfacesMessage` (line 836) now fail, debug — they SHOULD remain green because those tests never populate the cache (no `sessionDidChangeStage` call, no restore in active stage), so `recordRideHistory(status: .cancelled)` early-returns without changing observable state.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift \
+        RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+git commit -m "$(cat <<'EOF'
+fix(coordinator): persist cancelled rides + use estimate on forceEnd
+
+Routes .cancelledByRider/.cancelledByDriver through recordRideHistory
+with status="cancelled", fare=0, distance/duration nil — using the
+lastActiveRideIdentity cache (populated in Task 2) since the SDK
+clears session state before the terminal callback fires for cancel
+outcomes.
+
+forceEndRide already runs before session reset, so it still uses live
+session IDs. With currentFareEstimate reliably populated, the
+$0-on-early-end bug is fixed.
+
+.expired and .bruteForcePin keep the no-history behavior, matching
+the Ridestr Android precedent.
+
+Fixes #65.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `RideHistoryRow` status field + cancelled fareLabel
+
+**Files:**
+- Modify: `RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift`
+- Modify: `RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift` (append new tests)
+
+- [ ] **Step 4.1: Write failing tests**
+
+Append to `PresentationTypesTests.swift` after the existing `isCompletedFalseForCancelledStatus` test (line 533):
+
+```swift
+@Test func cancelledStatusProducesCancelledFareLabel() {
+    let row = RideHistoryRow.from(makeEntry(status: "cancelled", fare: 0, distance: nil, duration: nil))
+    #expect(row.fareLabel == "Cancelled")
+}
+
+@Test func cancelledStatusProducesNilDistanceAndDuration() {
+    let row = RideHistoryRow.from(makeEntry(status: "cancelled", fare: 0, distance: nil, duration: nil))
+    #expect(row.distanceLabel == nil)
+    #expect(row.durationLabel == nil)
+}
+
+@Test func cancelledStatusSetsIsCancelledTrue() {
+    let row = RideHistoryRow.from(makeEntry(status: "cancelled", fare: 0))
+    #expect(row.isCancelled == true)
+    #expect(row.isCompleted == false)
+}
+
+@Test func completedStatusSetsIsCancelledFalse() {
+    let row = RideHistoryRow.from(makeEntry(status: "completed"))
+    #expect(row.isCancelled == false)
+    #expect(row.isCompleted == true)
+}
+
+@Test func completedZeroFarePreservesEmDashFallback() {
+    // Legacy synced entries may have fare=0 with status=completed.
+    // Behavior preserved: shown as em-dash, not "Cancelled".
+    let row = RideHistoryRow.from(makeEntry(status: "completed", fare: 0))
+    #expect(row.fareLabel == "–")
+    #expect(row.isCancelled == false)
+}
+```
+
+- [ ] **Step 4.2: Run tests, verify failure**
+
+```bash
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -only-testing:RoadFlareTests/PresentationTypesTests \
+  -quiet 2>&1 | tail -30
+```
+
+Expected: compile error — `isCancelled` is not a member of `RideHistoryRow`. Also: cancelled-status currently produces `"–"` (legacy fare==0 fallback), not `"Cancelled"`.
+
+- [ ] **Step 4.3: Update `RideHistoryRow` shape**
+
+Open `RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift`. Replace the `isCompleted` field (line 50):
+
+**OLD (line 50):**
+```swift
+public let isCompleted: Bool
+```
+
+**NEW (replaces line 50):**
+```swift
+/// Underlying status used to drive UI branches.
+public let status: RideHistoryEntry.Status
+
+/// True if `status == .completed`. Computed for backward compat with
+/// existing callers (`HistoryTab`, presentation tests).
+public var isCompleted: Bool { status == .completed }
+
+/// True if `status == .cancelled`. Drives red "Cancelled" rendering.
+public var isCancelled: Bool { status == .cancelled }
+```
+
+- [ ] **Step 4.4: Update `RideHistoryRow.from(_:)` factory**
+
+Replace the body of `from(_:)` (the `fareLabel` derivation block, lines 64-77, and the entry-construction `isCompleted: entry.status == "completed"` at line 82). The full new factory:
+
+```swift
+public static func from(_ entry: RideHistoryEntry) -> RideHistoryRow {
+    let fareLabel: String
+    switch entry.statusEnum {
+    case .cancelled:
+        fareLabel = "Cancelled"
+    case .completed:
+        if entry.fare == 0 {
+            fareLabel = "–"
+        } else {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .currency
+            formatter.currencyCode = "USD"
+            formatter.locale = Locale(identifier: "en_US")
+            formatter.maximumFractionDigits = 2
+            formatter.minimumFractionDigits = 2
+            fareLabel = formatter.string(from: entry.fare as NSDecimalNumber) ?? "$\(entry.fare)"
+        }
+    }
+
+    let distanceLabel = entry.distance.map { String(format: "%.1f mi", $0) }
+    let durationLabel = entry.duration.map { "\($0) min" }
+
+    return RideHistoryRow(
+        id: entry.id,
+        date: entry.date,
+        counterpartyName: entry.counterpartyName,
+        pickupAddress: entry.pickup.address,
+        destinationAddress: entry.destination.address,
+        fareLabel: fareLabel,
+        distanceLabel: distanceLabel,
+        durationLabel: durationLabel,
+        paymentMethodLabel: PaymentMethod.displayName(for: entry.paymentMethod),
+        status: entry.statusEnum
+    )
+}
+```
+
+(Note the final argument: `status: entry.statusEnum` instead of `isCompleted: entry.status == "completed"`.)
+
+- [ ] **Step 4.5: Run tests, verify pass**
+
+```bash
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -only-testing:RoadFlareTests/PresentationTypesTests \
+  -only-testing:RoadFlareTests/AppStatePresentationTests \
+  -quiet 2>&1 | tail -50
+```
+
+Expected: all new tests pass; existing `isCompleted*` tests at lines 526 + 531 still pass (`isCompleted` is now computed but returns the same Bool); existing `AppStatePresentationTests` line 265 (`isCompleted == true`) still passes.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift \
+        RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+git commit -m "$(cat <<'EOF'
+feat(presentation): cancelled-status fareLabel + isCancelled projection
+
+RideHistoryRow now stores status (RideHistoryEntry.Status) and
+projects both isCompleted and isCancelled as computed properties.
+The from(_:) factory renders "Cancelled" in place of dollars when
+status is cancelled; em-dash fallback preserved for legacy completed
+entries with fare=0.
+
+Existing isCompleted callers (HistoryTab + 3 tests) continue to work
+without change.
+
+Issue #65.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: appOrigin filter in `AppState.rideHistoryRows`
+
+**Files:**
+- Modify: `RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift`
+- Modify: `RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift` (append new test)
+
+- [ ] **Step 5.1: Write failing test**
+
+Append to `AppStatePresentationTests.swift` inside the existing `@Suite("AppState.rideHistoryRows")` (`AppStateRideHistoryRowsTests` struct, around line 235), after the `mapsEntryToRow` test:
+
+```swift
+@Test func filtersOutNonRoadflareAppOriginEntries() {
+    let (appState, rideHistory, _) = makeAppStateWithInMemoryStores()
+
+    // Roadflare-origin entry: should appear.
+    let roadflareEntry = RideHistoryEntry(
+        id: "roadflare-1",
+        date: Date(timeIntervalSince1970: 1_000),
+        counterpartyPubkey: fakePubkeyA,
+        counterpartyName: "Driver A",
+        pickupGeohash: "abc", dropoffGeohash: "def",
+        pickup: Location(latitude: 0, longitude: 0),
+        destination: Location(latitude: 1, longitude: 1),
+        fare: Decimal(10),
+        paymentMethod: "cash"
+        // appOrigin defaults to "roadflare"
+    )
+    // Ridestr-origin entry (synced from Android rider app): should be hidden.
+    let ridestrEntry = RideHistoryEntry(
+        id: "ridestr-1",
+        date: Date(timeIntervalSince1970: 2_000),
+        counterpartyPubkey: fakePubkeyA,
+        counterpartyName: "Driver B",
+        pickupGeohash: "abc", dropoffGeohash: "def",
+        pickup: Location(latitude: 0, longitude: 0),
+        destination: Location(latitude: 1, longitude: 1),
+        fare: Decimal(20),
+        paymentMethod: "cash",
+        appOrigin: "ridestr"
+    )
+    rideHistory.addRide(roadflareEntry)
+    rideHistory.addRide(ridestrEntry)
+
+    let rows = appState.rideHistoryRows
+    #expect(rows.count == 1)
+    #expect(rows.first?.id == "roadflare-1")
+}
+```
+
+- [ ] **Step 5.2: Run test, verify failure**
+
+```bash
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -only-testing:RoadFlareTests/AppStatePresentationTests/AppStateRideHistoryRowsTests/filtersOutNonRoadflareAppOriginEntries \
+  -quiet 2>&1 | tail -30
+```
+
+Expected: test fails (`rows.count` is 2, not 1) — no filter applied yet.
+
+- [ ] **Step 5.3: Add the filter**
+
+Open `RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift`. Replace `rideHistoryRows` (line 65):
+
+**OLD:**
+```swift
+public var rideHistoryRows: [RideHistoryRow] {
+    rideHistory.rides.map { RideHistoryRow.from($0) }
+}
+```
+
+**NEW:**
+```swift
+public var rideHistoryRows: [RideHistoryRow] {
+    rideHistory.rides
+        .filter { $0.appOrigin == "roadflare" }
+        .map { RideHistoryRow.from($0) }
+}
+```
+
+- [ ] **Step 5.4: Run test, verify pass**
+
+```bash
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -only-testing:RoadFlareTests/AppStatePresentationTests \
+  -quiet 2>&1 | tail -30
+```
+
+Expected: all `AppStateRideHistoryRowsTests` tests pass, including the existing `mapsEntryToRow` (the static `fakeEntry` defaults to `appOrigin == "roadflare"`).
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift \
+        RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift
+git commit -m "$(cat <<'EOF'
+feat(history): filter rideHistoryRows by appOrigin == roadflare
+
+Required for proper cross-app coexistence when a user runs both
+RoadFlare iOS and Ridestr Android against the same account. Each app
+publishes Kind 30174 to a shared d-tag and merges other-origin entries
+into the local store on read; this filter limits the iOS history view
+to its own origin, mirroring Ridestr Android's filter.
+
+Issue #65.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Cancelled-row fare-color override in `HistoryTab.swift`
+
+**Files:**
+- Modify: `RoadFlare/RoadFlare/Views/History/HistoryTab.swift`
+
+- [ ] **Step 6.1: Make the one-line change**
+
+Open `RoadFlare/RoadFlare/Views/History/HistoryTab.swift`. Locate `RideHistoryCard` (line 69). The fare label is rendered at lines 83-85:
+
+```swift
+Text(row.fareLabel)
+    .font(RFFont.headline(18))
+    .foregroundColor(Color.rfPrimary)
+```
+
+Change line 85 (the `.foregroundColor(...)` line) to:
+
+```swift
+    .foregroundColor(row.isCancelled ? Color.rfError : Color.rfPrimary)
+```
+
+The font and Text contents are unchanged. The `FlareIndicator` at line 74 already uses `.rfError` for non-completed rows via `row.isCompleted`, so it auto-flips for cancelled entries with no further edit.
+
+- [ ] **Step 6.2: Build and run full test suite**
+
+```bash
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -quiet 2>&1 | tail -50
+```
+
+Expected: build succeeds; all tests pass.
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add RoadFlare/RoadFlare/Views/History/HistoryTab.swift
+git commit -m "$(cat <<'EOF'
+feat(ui): render cancelled-ride fare label in red
+
+RideHistoryCard now swaps the fare-label foreground color to
+Color.rfError when row.isCancelled. The label text itself is
+"Cancelled" (set in RideHistoryRow.from), so the row reads as
+"Cancelled" in red where dollars previously appeared.
+
+Issue #65.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 7.1: Run the full Xcode test suite**
+
+```bash
+cd ~/Documents/Projects/roadflare-ios
+xcodebuild test \
+  -project RoadFlare/RoadFlare.xcodeproj \
+  -scheme RoadFlare \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -quiet 2>&1 | tail -80
+```
+
+Expected: all tests pass, no warnings introduced. If concurrency warnings or new compile errors appear in the app target that didn't appear in `swift test`, this is the catch-net.
+
+- [ ] **Step 7.2: Run `gitnexus_detect_changes`**
+
+Per `.claude/CLAUDE.md`, before declaring done:
+
+```bash
+npx -y gitnexus@1.5.3 analyze
+```
+
+Then via the GitNexus MCP, verify the changed-symbols list matches expectations: `RideHistoryEntry` (extension only), `RideCoordinator.recordRideHistory`, `RideCoordinator.sessionDidReachTerminal`, `RideCoordinator.sessionDidChangeStage`, `RideCoordinator.restoreRideState`, `RideHistoryRow`, `RideHistoryRow.from`, `AppState.rideHistoryRows`, `RideHistoryCard`. Nothing else.
+
+- [ ] **Step 7.3: Manual smoke check (optional but recommended)**
+
+Build and run on simulator, drive a ride to the rideConfirmed stage, then:
+1. Tap "Cancel Ride" → confirm in alert. Verify history shows "Cancelled" in red where the fare would be.
+2. Drive another ride to inProgress, tap "Close Ride" before driver completion. Verify history shows the estimated fare normally (not "$0" or "–").
+
+- [ ] **Step 7.4: Verify all acceptance criteria from the spec**
+
+Check off against the spec's "In scope" list:
+- [x] Persist cancelled rides to local + Nostr-backed history
+- [x] Fix forceEndRide $0 fallback
+- [x] appOrigin display filter
+- [x] "Cancelled" red label UI
+- [x] Test coverage
+
+If all green: link the PR to issue #65 and the spec doc.
+
+---
+
+## Self-review checklist
+
+After writing the plan, the author ran the following checks:
+
+**Spec coverage:** Each "In scope" bullet from the spec maps to a task — Status enum (Task 1), persistence + cache (Tasks 2 + 3), forceEnd fix (Task 3), appOrigin filter (Task 5), UI (Tasks 4 + 6), tests (interleaved). The "Out of scope" items (schema bump, expired/bruteForcePin persistence, detail-view UX) are not implemented — correct.
+
+**Placeholder scan:** No "TBD", "TODO", or "implement later". Every code step has full code. Every test step has the assertion. The one verification command per task uses an explicit `xcodebuild` invocation.
+
+**Type consistency:** `ActiveRideIdentity` defined in Task 2 → used in Task 3. `RideHistoryEntry.Status` defined in Task 1 → used in Tasks 3, 4. `lastActiveRideIdentity` named consistently across Tasks 2, 3. `isCancelled` introduced in Task 4, consumed in Task 6.

--- a/docs/superpowers/specs/2026-04-27-ride-history-cancellation-design.md
+++ b/docs/superpowers/specs/2026-04-27-ride-history-cancellation-design.md
@@ -1,0 +1,337 @@
+# Ride History Cancellation — Design Spec
+
+Tracks: [roadflare-ios#65](https://github.com/variablefate/roadflare-ios/issues/65)
+
+## Purpose
+
+Today, RoadFlare iOS treats every terminal ride event the same way at the history layer:
+
+- **Rider taps "Close Ride" while ride is still active** (`forceEndRide()`) → records history with `fare = 0` (no fare estimate fallback) and default `status = "completed"`. User sees `"–"` / a phantom $0.00 ride.
+- **Rider taps "Cancel Ride"** (`cancelRide()`) → ride vanishes; never enters history.
+- **Driver sends Kind 3179 cancellation** (`.cancelledByDriver`) → also vanishes.
+- **Driver completes ride** (`.completed`) → records correctly.
+
+The Android Ridestr rider app (`~/Documents/Projects/ridestr/rider-app`) already solves this: cancelled rides are persisted with `status = "cancelled"`, `fare = 0`, and rendered with red error styling. Cross-app coexistence (Ridestr + Drivestr same account) is handled by writing all rides to a shared Kind 30174 backup and filtering display by `appOrigin`.
+
+This spec brings RoadFlare iOS to parity with that proven pattern, scoped to what RoadFlare actually needs (fiat-only, USD-only, no Bitcoin, no out-of-app payment integration).
+
+## Scope
+
+**In scope:**
+1. Persist cancelled rides to local + Nostr-backed history (`status = "cancelled"`, `fare = 0`).
+2. Fix `forceEndRide()` to record with the fare estimate, not a $0 fallback.
+3. Add `appOrigin` display filter to `AppState.rideHistoryRows`, mirroring Ridestr's filter — required for correct multi-app coexistence on the same account.
+4. UI treatment for cancelled rides: replace fare amount with the word "Cancelled" in `Color.rfError`; hide distance/duration.
+5. Test coverage for all of the above.
+
+**Explicitly out of scope (mentioned for clarity):**
+- **Schema version bump.** A separate next-release task will bump `RideHistoryEntry.schemaVersion` (and sibling `FollowedDriversBackup`, `RideHistoryBackupContent`) from `1` → `2`. The current fix uses fields already present in v1 (`status`, `appOrigin`); no bump is required to ship this issue. Tracked as a follow-up.
+- **Driver-side (Drivestr Android) cancelled-history behavior.** Already implemented in `drivestr/.../DriverViewModel.kt`.
+- **Detail-view UX for cancelled rides** (showing reason / which party cancelled). The `cancelledByRider(reason:)` and `cancelledByDriver(reason:)` payloads already carry a reason string; surfacing it in a detail screen is a future feature.
+- **`.expired` and `.bruteForcePin` history entries.** Ridestr's rider app does not persist these either. Keep current behavior (no entry).
+- **Replacing fare estimate with driver's `finalFare` field.** RoadFlare is fiat-only with out-of-app payment; the rider's fare estimate IS the canonical fare for both apps' display. There is one fare amount.
+
+## Architecture
+
+### Data model (no schema change)
+
+`RideHistoryEntry.status: String` already exists (`RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift:492`). Default is `"completed"`. We start writing `"cancelled"` for the cancelled cases.
+
+Add a typed projection on the SDK model:
+
+```swift
+public extension RideHistoryEntry {
+    enum Status: String, Sendable {
+        case completed
+        case cancelled
+    }
+    /// Fail-open: any unrecognized status string is treated as completed
+    /// so unknown / future statuses don't redact fare data.
+    var statusEnum: Status { Status(rawValue: status) ?? .completed }
+}
+```
+
+This is purely additive — no Codable change, no wire-format change. The string field stays the source of truth.
+
+### Wiring constraint: SDK clears ride identity before terminal callback fires
+
+When `sessionDidReachTerminal` fires for **cancellation** outcomes (`.cancelledByRider`, `.cancelledByDriver`, `.bruteForcePin`), the rider session's `confirmationEventId` and `driverPubkey` are already `nil`. This is because:
+
+- The state machine's `.cancel` event handler (`RideStateMachine.swift:189-191`) returns `RideContext(riderPubkey: current.riderPubkey)`, clearing all other fields.
+- `RiderRideSession.cancelRide` calls `stateMachine.reset()` (line 367) which does the same clear.
+- Both happen BEFORE `delegate?.sessionDidReachTerminal(...)` fires (lines 370, 500, 563).
+- For `.completed`, the state machine stays at `.completed` (no reset), so IDs remain readable — that's why the existing completed-path `recordRideHistory()` works.
+
+This is verified by the existing test pattern: `RideCoordinatorTests.swift:815-853` tests cancellation by calling `coordinator.sessionDidReachTerminal(...)` directly **without** calling `session.restore` first — exactly because the contract says session state is gone.
+
+A naive `recordRideHistory(status: .cancelled)` call inside the cancellation branch would hit the existing `guard let confirmationId = session.confirmationEventId` and silently no-op every time.
+
+**Resolution: coordinator-side identity cache.** Keep the SDK contract unchanged; have the coordinator cache the ride identity while it's still readable, and use the cached values for cancellation history records.
+
+### Coordinator routing
+
+**File:** `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift`
+
+**New cache field on the coordinator:**
+
+```swift
+/// Snapshot of the most recently active ride's identity, captured while the
+/// session still holds it (in `sessionDidChangeStage` and on session restore).
+/// Used to record cancelled-ride history entries after the SDK has reset state.
+/// Cleared on terminal outcome (whether completed, cancelled, or otherwise).
+private var lastActiveRideIdentity: ActiveRideIdentity?
+
+private struct ActiveRideIdentity {
+    let confirmationEventId: String
+    let driverPubkey: String
+}
+```
+
+**Cache populate sites:**
+
+1. **`sessionDidChangeStage(from: to:)` at `RideCoordinator.swift:417`** — extend the existing handler. When `to.isActiveRide` is true and both `session.confirmationEventId` and `session.driverPubkey` are present, populate `lastActiveRideIdentity`. (`isActiveRide` is defined in `RidestrSDK/Sources/RidestrSDK/Models/RideModels.swift:33-38` and includes only `.rideConfirmed`, `.enRoute`, `.driverArrived`, `.inProgress`.)
+
+2. **Session-restore path at `RideCoordinator.swift:162`** — immediately after the `currentFareEstimate` assignment block (lines 156-162), check `session.stage.isActiveRide` and populate `lastActiveRideIdentity` from `session.confirmationEventId` and `session.driverPubkey`. Note: `session.restore` does NOT call `emitStageChangeIfNeeded`, so `sessionDidChangeStage` will NOT fire for restored sessions — the restore path must populate the cache directly.
+
+`confirmationEventId` is first set when transitioning into `.rideConfirmed` (the rider publishes the confirmation, fires `.confirm` event in the state machine). Earlier stages (`.waitingForAcceptance`, `.driverAccepted`) have `confirmationEventId == nil`. So both populate sites correctly skip pre-confirmation stages, and the cache stays nil — matching Ridestr's `shouldSaveCancelledHistory = rideStage in [RIDE_CONFIRMED, DRIVER_ARRIVED, IN_PROGRESS]` gate exactly.
+
+**`recordRideHistory(...)` gains a status parameter and uses cached identity as fallback:**
+
+```swift
+private func recordRideHistory(status: RideHistoryEntry.Status = .completed) {
+    let confirmationId: String
+    let driverPubkey: String
+    if let live = session.confirmationEventId, let livePubkey = session.driverPubkey {
+        confirmationId = live
+        driverPubkey = livePubkey
+    } else if let cached = lastActiveRideIdentity {
+        confirmationId = cached.confirmationEventId
+        driverPubkey = cached.driverPubkey
+    } else {
+        return  // pre-confirmation cancellation or untracked state — drop silently
+    }
+
+    let pickup = pickupLocation ?? session.precisePickup ?? Location(latitude: 0, longitude: 0)
+    let destination = destinationLocation ?? session.preciseDestination ?? Location(latitude: 0, longitude: 0)
+    let isCancelled = (status == .cancelled)
+
+    let entry = RideHistoryEntry(
+        id: confirmationId,
+        date: .now,
+        status: status.rawValue,
+        counterpartyPubkey: driverPubkey,
+        counterpartyName: driversRepository.cachedDriverName(pubkey: driverPubkey),
+        pickupGeohash: ProgressiveReveal.historyGeohash(for: pickup),
+        dropoffGeohash: ProgressiveReveal.historyGeohash(for: destination),
+        pickup: pickup,
+        destination: destination,
+        fare: isCancelled ? 0 : (currentFareEstimate?.fareUSD ?? 0),
+        paymentMethod: session.paymentMethod ?? selectedPaymentMethod ?? PaymentMethod.cash.rawValue,
+        distance: isCancelled ? nil : currentFareEstimate?.distanceMiles,
+        duration: isCancelled ? nil : currentFareEstimate.map { Int($0.durationMinutes) }
+        // appOrigin defaults to "roadflare" via RideHistoryEntry.init
+    )
+    rideHistory.addRide(entry)
+    backupRideHistory()
+}
+```
+
+**Updated `sessionDidReachTerminal`:**
+
+```swift
+public func sessionDidReachTerminal(_ outcome: RideSessionTerminalOutcome) {
+    switch outcome {
+    case .completed:
+        recordRideHistory()  // session IDs still live for completion path
+    case .cancelledByRider, .cancelledByDriver:
+        recordRideHistory(status: .cancelled)  // falls through to lastActiveRideIdentity
+        let message = terminalMessage(for: outcome)
+        clearCoordinatorUIState(clearError: message == nil)
+        lastError = message
+    case .expired, .bruteForcePin:
+        let message = terminalMessage(for: outcome)
+        clearCoordinatorUIState(clearError: message == nil)
+        lastError = message
+    }
+    lastActiveRideIdentity = nil
+}
+```
+
+Routing changes (full picture):
+
+| Path | Today | New |
+|---|---|---|
+| `forceEndRide()` (line ~300) | `recordRideHistory()` with `fare ?? 0` fallback if estimate nil | unchanged call shape; estimate is reliably present (restored on cold-start from `PersistedRideState.fareUSD`) and now correctly recorded |
+| `sessionDidReachTerminal(.completed)` | `recordRideHistory()` | unchanged |
+| `sessionDidReachTerminal(.cancelledByRider)` | drops; no record | `recordRideHistory(status: .cancelled)` via cached identity |
+| `sessionDidReachTerminal(.cancelledByDriver)` | drops + shows toast | `recordRideHistory(status: .cancelled)` via cached identity, continue with existing toast |
+| `sessionDidReachTerminal(.expired)` | drops + shows toast | unchanged (out of scope per Ridestr precedent) |
+| `sessionDidReachTerminal(.bruteForcePin)` | drops + shows toast | unchanged |
+
+Pre-confirmation cancellations still produce no entry: the cache is only populated when `confirmationEventId` is non-nil at stage-change time, so `lastActiveRideIdentity` stays nil and `recordRideHistory` returns early. This matches Ridestr's `shouldSaveCancelledHistory = rideStage in [RIDE_CONFIRMED, DRIVER_ARRIVED, IN_PROGRESS]` gate.
+
+### Sync
+
+No new sync code. `addRide(entry)` chains into `backupRideHistory()` → `RideHistorySyncCoordinator.publishAndMark(from:)` → `domainService.publishRideHistoryBackup(content)` → Kind 30174 publish. The `RideHistoryEntry`'s `status` field is included in the standard `Codable` encoding. Cancelled entries flow through the existing pipeline.
+
+**Cross-app coexistence (the "syncs properly" requirement):**
+
+iOS and Android both publish Kind 30174 to the same d-tag (`"rideshare-history"`) and pubkey. The replaceable-event semantics mean each publish overwrites the previous — but `RideHistoryRepository.mergeFromBackup(_:)` already merges by ID on read, so cross-app entries persist locally. The missing piece on iOS is the **display filter** that Ridestr already has.
+
+**File:** `RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift`, line 65.
+
+```swift
+public var rideHistoryRows: [RideHistoryRow] {
+    rideHistory.rides
+        .filter { $0.appOrigin == "roadflare" }
+        .map { RideHistoryRow.from($0) }
+}
+```
+
+Note: `RideHistoryEntry.appOrigin` is non-optional `String` defaulting to `"roadflare"` (`RoadflareModels.swift:505,517`). The Codable-synthesis for non-optional String requires the key be present in any decoded JSON — so a hypothetical legacy entry without `appOrigin` would fail to decode entirely and never reach this filter. No legacy-string fallback needed (this is the difference from Ridestr's Kotlin filter, which handles `appOrigin == null` because Kotlin Strings are nullable). If we ever need to accept legacy entries, we'd add a custom `init(from decoder:)` that defaults missing keys — out of scope here.
+
+### UI
+
+**File:** `RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift`
+
+Replace the stored `isCompleted: Bool` field (line 50) with a stored `status` and computed projections (additive — keeps existing `isCompleted` callers green):
+
+```swift
+public let status: RideHistoryEntry.Status
+public var isCompleted: Bool { status == .completed }
+public var isCancelled: Bool { status == .cancelled }
+```
+
+In `RideHistoryRow.from(_:)` (line 55+), the factory passes `status: entry.statusEnum` instead of `isCompleted: entry.status == "completed"` (line 82). The `fareLabel` derivation (lines 64-77) gains a cancelled-status branch that overrides the formatted dollars:
+
+```swift
+let fareLabel: String
+switch entry.statusEnum {
+case .cancelled:
+    fareLabel = "Cancelled"
+case .completed:
+    if entry.fare == 0 {
+        fareLabel = "–"  // existing legacy fallback for unknown completed-fare entries
+    } else {
+        // existing NumberFormatter logic preserved
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        fareLabel = formatter.string(from: entry.fare as NSDecimalNumber) ?? "$\(entry.fare)"
+    }
+}
+```
+
+Distance/duration labels stay nil-safe and will be `nil` for cancelled entries because the coordinator skips populating them on the entry.
+
+**Existing callers of `row.isCompleted` continue to work** (verified during exploration — 4 call sites):
+- `RoadFlare/RoadFlare/Views/History/HistoryTab.swift:74` — `FlareIndicator(color: row.isCompleted ? .rfOnline : .rfError)`. Stays as-is.
+- `RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift:526` (`isCompletedTrueForCompletedStatus`) and `:531` (`isCompletedFalseForCancelledStatus`). Stay as-is.
+- `RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift:265` — `#expect(rows[0].isCompleted == true)`. Stays as-is.
+
+**File:** `RoadFlare/RoadFlare/Views/History/HistoryTab.swift`
+
+The `RideHistoryCard` view (lines ~67+) renders `row.fareLabel` somewhere in the card body — the existing `Text` view rendering needs a foreground color override when `row.isCancelled`:
+
+```swift
+Text(row.fareLabel)
+    .foregroundColor(row.isCancelled ? Color.rfError : <existing color>)
+```
+
+The exact `Text` callsite and existing styling are deferred to the implementation plan (the plan should `grep` for `row.fareLabel` in `HistoryTab.swift` to identify the exact location). The design constraint is unambiguous: when `row.isCancelled`, the fare label reads "Cancelled" in `Color.rfError`; everything else inherits existing styling.
+
+Note: `FlareIndicator` (line 74) already uses `.rfError` for non-completed rides, so cancelled entries get the red flare automatically — no change needed there.
+
+### What does NOT change
+
+- `RideHistoryEntry` Codable shape, JSON wire format, or schema version
+- Kind 30174 d-tag (`"rideshare-history"`)
+- `RideHistoryRepository.mergeFromBackup` / `restoreFromBackup` / publish logic
+- `RideHistorySyncCoordinator`
+- Driver-side history logic (already correct in Drivestr Android; iOS has no driver app)
+- Out-of-app payment flows (no fare changes hands for cancelled rides; this is a display fix only)
+
+## Behavior matrix
+
+Walked through every realistic terminal interleaving:
+
+| Scenario | Outcome | History row | Sync |
+|---|---|---|---|
+| Driver completes ride (happy path) | `.completed` | `status=completed`, fare=estimate | published |
+| Rider taps Close while still active (escape hatch) | `forceEndRide` (no terminal callback) | `status=completed`, fare=estimate | published |
+| Rider taps Cancel pre-confirmation | `.cancelledByRider`, no `confirmationId` | none (guard skips) | n/a |
+| Rider taps Cancel post-confirmation | `.cancelledByRider` | `status=cancelled`, fare=0 | published |
+| Driver sends 3179 pre-confirmation | `.cancelledByDriver`, no `confirmationId` | none | n/a |
+| Driver sends 3179 post-confirmation | `.cancelledByDriver` | `status=cancelled`, fare=0 | published + toast |
+| Stage timeout pre/post-confirmation | `.expired` | none (out of scope) | n/a |
+| 3 PIN failures | `.bruteForcePin` (via `cancelRide(terminalOverride:)`) | none (out of scope) | n/a |
+| App killed mid-ride, restored, rider closes | `forceEndRide` (estimate restored from `PersistedRideState.fareUSD`) | `status=completed`, fare=estimate | published |
+| Driver completes after rider already force-ended | rider session torn down; driver event arrives at no-listener; `addRide` is idempotent (`RideHistoryRepository.addRide` early-outs on duplicate `id`) — no double entry | n/a | n/a |
+| Rider cancels then immediately starts a new ride | terminal handler clears `lastActiveRideIdentity` before next ride starts; new ride re-populates cache on stage transition | n/a | n/a |
+| App killed mid-ride, restored, rider cancels | restore path populates `lastActiveRideIdentity` after `session.restore`; cancel records correctly with restored identity | published | n/a |
+| Cross-app: Ridestr Android entries pulled into iOS local store | merged in via `mergeFromBackup` | hidden by appOrigin filter | iOS re-publishes full set including foreign entries (preserves them in backup) |
+
+## Tests
+
+### Existing tests that need updating
+
+`RoadFlare/RoadFlareTests/RideCoordinatorTests.swift`:
+
+- **`sessionDidReachTerminalCancelledByRiderClearsUIAndChatWithoutError`** (line 816) and **`sessionDidReachTerminalCancelledByDriverSurfacesMessage`** (line 836) currently model the SDK contract that ride identity is gone by terminal-callback time, so they don't call `session.restore`. With the new design, these tests still hold their existing assertions (UI clears, error message surfaces), but the coordinator's terminal handler now ALSO calls `recordRideHistory(status: .cancelled)`. With `lastActiveRideIdentity` nil (test never populated it), `recordRideHistory` early-returns — so `history.rides` stays empty and the existing tests stay green. **No change required.**
+
+- **Existing `sessionDidReachTerminalExpiredSetsTimeoutMessage`** (line 856) and **`sessionDidReachTerminalBruteForcePinSetsMessage`** (line 876) stay unchanged — those outcomes don't persist history under the new design either.
+
+- **Existing `sessionDidReachTerminalCompletedRecordsHistoryAndKeepsUI`** (line 758) stays green; the completed path uses live session IDs (set via `session.restore` in this test).
+
+In other words, the existing tests don't need code changes. They naturally test the "no cache populated → no record" path. The new tests below cover the "cache populated → record" paths.
+
+### New tests
+
+1. **`RideCoordinatorTests`** — additions. Each populates the cache by calling `session.restore(...)` to land in an active stage, then calls `coordinator.sessionDidChangeStage(from: .driverAccepted, to: .rideConfirmed)` to manually trigger the populate (mirrors the production flow where `restoreRideState()` would populate the cache after `session.restore`):
+   - `cancelByRiderPostConfirmationRecordsCancelledHistory` — restore into `.rideConfirmed`, populate cache via stage-change call, fire `.cancelledByRider`, assert `history.rides.count == 1` with `status == "cancelled"`, `fare == 0`, `distance == nil`, `duration == nil`.
+   - `cancelByRiderPreConfirmationRecordsNothing` — restore into `.waitingForAcceptance` (where `confirmationEventId == nil`); the stage-change call into a non-active stage does NOT populate the cache; fire `.cancelledByRider`, assert `history.rides.isEmpty`.
+   - `cancelByDriverPostConfirmationRecordsCancelledHistory` — same setup as rider variant but with `.cancelledByDriver`.
+   - `forceEndRideRecordsCompletedWithEstimate` — restore into `.rideConfirmed`, set `currentFareEstimate`, call `coordinator.forceEndRide()`, assert entry has `status == "completed"`, `fare == estimate.fareUSD`, `distance == estimate.distanceMiles`. The forceEnd path uses live session IDs (no cache fallback needed) because `forceEndRide` records BEFORE calling `session.forceEndRide()`.
+   - `restoreRideStateInActiveStagePopulatesCacheForLaterCancel` — set up `rideStateRepository` with a persisted active-stage snapshot, call `coordinator.restoreRideState()`, then fire `.cancelledByRider` directly (no manual stage-change call). Assert history entry recorded — verifies the restore-path populate works end-to-end.
+   - `lastActiveRideIdentityClearedAfterTerminal` — populate cache, fire `.completed`, then start a fresh `.waitingForAcceptance` flow and fire `.cancelledByRider` from pre-confirmation. Assert no second history entry (cache was cleared, not inherited from previous ride).
+
+2. **`RoadflareModelsTests`** — `RideHistoryEntry.statusEnum` round-trip:
+   - `"completed"` → `.completed`
+   - `"cancelled"` → `.cancelled`
+   - `"unknown_future_value"` → `.completed` (fail-open assertion)
+
+3. **`PresentationTypesTests`** — `RideHistoryRow.from(_:)`:
+   - cancelled entry → `fareLabel == "Cancelled"`, `distanceLabel == nil`, `durationLabel == nil`, `isCancelled == true`
+   - completed entry with `fare == 0` → `fareLabel == "–"` (preserve legacy behavior)
+   - completed entry with `fare > 0` → existing currency formatting unchanged
+
+4. **`AppStatePresentationTests`** — appOrigin filter:
+   - mix of `appOrigin == "roadflare"` and `appOrigin == "ridestr"` entries → `rideHistoryRows` returns only the roadflare entries.
+
+5. **Existing `PersistenceTests` round-trip** — verify cancelled entry survives `RideHistoryPersistence` round-trip without changes (no test code change; just confirm green).
+
+## Open questions
+
+None. All design decisions resolved through brainstorming with the issue author:
+- Force-end keeps `"completed"` semantics (option B).
+- Cancellation event = persistence trigger (cancel-button or received Kind 3179).
+- Single fare amount = the rider's estimate.
+- UI: word "Cancelled" in red where dollars would be; no card tint or pill.
+- Cross-app sync via `appOrigin` display filter (parity with Ridestr).
+- Schema version bump deferred to next overall release.
+
+## References
+
+- Issue: [roadflare-ios#65](https://github.com/variablefate/roadflare-ios/issues/65)
+- Ridestr Android rider cancel persistence: `~/Documents/Projects/ridestr/rider-app/src/main/java/com/ridestr/rider/viewmodels/RiderViewModel.kt:3049`, `:4097`
+- Ridestr Android cancelled-row UI: `~/Documents/Projects/ridestr/common/src/main/java/com/ridestr/common/ui/components/HistoryComponents.kt:154`
+- Ridestr Android appOrigin filter: `~/Documents/Projects/ridestr/rider-app/src/main/java/com/ridestr/rider/ui/screens/HistoryScreen.kt:32`
+- iOS `RideHistoryEntry`: `RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift:488`
+- iOS `RideCoordinator.recordRideHistory`: `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift:334`
+- iOS `RideCoordinator.sessionDidReachTerminal`: `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift:403`
+- iOS `RideHistoryRow.from`: `RoadFlare/RoadFlareCore/Presentation/RideHistoryRow.swift:55`
+- iOS `AppState.rideHistoryRows`: `RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift:65`
+- iOS `HistoryTab` & `RideHistoryCard`: `RoadFlare/RoadFlare/Views/History/HistoryTab.swift`

--- a/docs/superpowers/specs/2026-04-27-ride-history-cancellation-design.md
+++ b/docs/superpowers/specs/2026-04-27-ride-history-cancellation-design.md
@@ -234,16 +234,23 @@ Distance/duration labels stay nil-safe and will be `nil` for cancelled entries b
 
 **File:** `RoadFlare/RoadFlare/Views/History/HistoryTab.swift`
 
-The `RideHistoryCard` view (lines ~67+) renders `row.fareLabel` somewhere in the card body — the existing `Text` view rendering needs a foreground color override when `row.isCancelled`:
+`RideHistoryCard` renders the fare label at lines 83-85:
 
 ```swift
 Text(row.fareLabel)
-    .foregroundColor(row.isCancelled ? Color.rfError : <existing color>)
+    .font(RFFont.headline(18))
+    .foregroundColor(Color.rfPrimary)
 ```
 
-The exact `Text` callsite and existing styling are deferred to the implementation plan (the plan should `grep` for `row.fareLabel` in `HistoryTab.swift` to identify the exact location). The design constraint is unambiguous: when `row.isCancelled`, the fare label reads "Cancelled" in `Color.rfError`; everything else inherits existing styling.
+Change line 85 to swap the foreground color when the ride is cancelled:
 
-Note: `FlareIndicator` (line 74) already uses `.rfError` for non-completed rides, so cancelled entries get the red flare automatically — no change needed there.
+```swift
+.foregroundColor(row.isCancelled ? Color.rfError : Color.rfPrimary)
+```
+
+That's the only view change. The font (`RFFont.headline(18)`) is unchanged; the word "Cancelled" reads in red where dollars previously rendered.
+
+`FlareIndicator` at line 74 already uses `.rfError` for non-completed rides via `row.isCompleted ? .rfOnline : .rfError`. Since `isCompleted` becomes a computed property (`status == .completed`), cancelled entries will automatically render with `.rfError` here — no change needed.
 
 ### What does NOT change
 


### PR DESCRIPTION
## Summary

Closes #65.

- **Persist cancelled rides to history** with `status="cancelled"`, fare `0`, distance/duration nil — matching the proven Ridestr Android pattern. Rider-cancel and driver-cancel both produce a history entry; pre-confirmation cancellations correctly drop.
- **Fix the \$0-on-force-end bug.** `forceEndRide()` now reliably records with `currentFareEstimate.fareUSD` (which is restored on cold-start from `PersistedRideState.fareUSD`).
- **`appOrigin` display filter** on `AppState.rideHistoryRows` — required for cross-app coexistence on the same account (RoadFlare iOS + Ridestr Android share Kind 30174 backups; each app filters its own origin).
- **"Cancelled" red label** in the history row where dollars previously rendered. The existing `FlareIndicator` already swapped to `.rfError` for non-completed rows.

## Architecture note

The SDK clears `confirmationEventId` and `driverPubkey` from the state machine **before** `sessionDidReachTerminal` fires for cancellation outcomes (state-machine `.cancel` event resets context at `RideStateMachine.swift:189-191`). This is the historical reason cancelled rides never reached the history. Rather than touching the SDK contract, this PR introduces a **coordinator-side `lastActiveRideIdentity` cache** populated when the session enters an active stage (and on `restoreRideState`), used as a fallback in `recordRideHistory` when live IDs are gone. SDK is untouched apart from an additive `RideHistoryEntry.Status` enum projection.

## ADR

[`decisions/0012-coordinator-ride-identity-cache.md`](https://github.com/variablefate/roadflare-ios/blob/fix/issue-65-ride-history-cancellation/decisions/0012-coordinator-ride-identity-cache.md) — captures why this PR caches identity app-side rather than changing the SDK contract, alternatives considered, and the load-bearing record-before-clear ordering invariant.

## Spec & plan

- Spec: \`docs/superpowers/specs/2026-04-27-ride-history-cancellation-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-27-ride-history-cancellation.md\`

## Test plan

- [x] SDK: \`swift test --package-path RidestrSDK\` — 824 tests pass across 53 suites.
- [x] App tests for files I touched (\`RideCoordinatorTests\`, \`PresentationTypesTests\`, \`AppStatePresentationTests\`): all green via \`xcodebuild test\`.
- [x] New tests cover: post-confirmation rider-cancel records, post-confirmation driver-cancel records (toast still surfaces), pre-confirmation cancel records nothing, forceEnd records \`status=completed\` with the estimate, restoreRideState in active stage populates cache, and \`lastActiveRideIdentity\` cleared after every terminal.
- [ ] Manual smoke test on simulator: cancel a confirmed ride → "Cancelled" in red appears; close before driver completes → estimated fare appears (not "\$0" / em-dash).
- Known: pre-existing flake \`DriverDetailViewStateTests/lastLocationTimestampLabelIsRelativeString\` fails under parallel \`xcodebuild\` runs but passes in isolation; verified pre-existing on clean main. Tracked separately.

## Out of scope (per spec)

- Schema-version bump (deferred to next overall release).
- \`.expired\` and \`.bruteForcePin\` history entries (Ridestr precedent does not persist these either).
- Detail-view UX for cancelled rides (showing reason / who cancelled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)