### PR TITLE
fix(tests): tolerate `.abbreviated` formatter "3m ago" output

### DIFF
--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -295,14 +295,17 @@ struct DriverDetailViewStateTests {
         let referenceDate = Date(timeIntervalSince1970: 1_000_000 + 180)  // 3 min after timestamp
         let loc = makeLocation(status: "online", timestamp: 1_000_000)
         // Locale pinned to en_US so the assertion is deterministic across CI hosts —
-        // production callers use the default `.current` locale.
+        // production callers use the default `.current` locale. `.abbreviated` style
+        // also varies between "3 min. ago" and "3m ago" depending on the runner's
+        // CFLocale/ICU resource state (fresh simulator clones produce the narrower
+        // form under parallel xcodebuild test), so accept either.
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: loc, profile: nil,
                                                isKeyStale: false, canPing: false,
                                                referenceDate: referenceDate,
                                                locale: Locale(identifier: "en_US"))
         let label = try #require(state.lastLocationTimestampLabel)
-        #expect(label.contains("min"))
+        #expect(label.contains("min") || label.contains("m ago"))
     }
 
     @Test func noteDefaultsToEmptyString() {


### PR DESCRIPTION
## Summary

`RoadFlareTests/PresentationTypesTests/lastLocationTimestampLabelIsRelativeString` flakes under parallel `xcodebuild test` but passes in isolation. Production code uses `RelativeDateTimeFormatter` with `unitsStyle = .abbreviated` and an injected `en_US` locale — that combination produces **either** "3 min. ago" **or** "3m ago" depending on the runner process's CFLocale/ICU resource state. Fresh simulator "Clone N" processes spawned for parallel testing consistently produce the narrower "3m ago" form, which the previous `label.contains("min")` assertion rejected.

The hypothesis that another test was mutating shared locale state turned out not to be the cause — `RelativeDateTimeFormatter.UnitsStyle` has no `.narrow` member, no test mutates global locale, and a single-process concurrent stress test on macOS Foundation produces "3m ago" 200/200 deterministically. The variance is process-level resource initialization, not state mutation.

Production behavior is intentional (`.abbreviated` is the right UX for that label), so the fix tightens only the test assertion to accept either output:

```swift
#expect(label.contains("min") || label.contains("m ago"))
```

## Test plan

- [x] Reproduced the flake on `main` — full parallel suite fails with `(label → "3m ago").contains("min")` on first attempt
- [x] Full parallel `xcodebuild test` (200 unit tests) — target test passes after fix
- [x] `xcodebuild test -only-testing:RoadFlareTests/DriverDetailViewState` — passes
- [x] Full unit-test suite under parallel testing (`-skip-testing:RoadFlareUITests`) — passes
- [x] `gitnexus_detect_changes` — risk: low, 0 affected processes

## Notes

While reproducing, I observed 4 unrelated pre-existing failures in `ChatCoordinatorTests`, `RideCoordinatorTests`, and a `RoadFlareUITests-Runner` accessibility-load timeout that did not recur on subsequent runs. Those look like separate async-timing flakes worth tracking but are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)