### PR TITLE
fix: complete stale-key handling loop (#72)

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/LocationSyncCoordinator.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/LocationSyncCoordinator.swift
@@ -110,8 +110,10 @@ public final class LocationSyncCoordinator: @unchecked Sendable {
     public func checkForStaleKeys() async {
         for driver in driversRepository.drivers {
             guard driver.hasKey else {
-                // No key at all — request one
-                await requestKeyRefresh(driverPubkey: driver.pubkey)
+                // No key at all — request one. Best-effort: a per-driver
+                // publish failure shouldn't abort the sweep across remaining
+                // drivers.
+                try? await requestKeyRefresh(driverPubkey: driver.pubkey)
                 continue
             }
             let localKeyUpdatedAt = driver.roadflareKey?.keyUpdatedAt ?? 0
@@ -124,7 +126,7 @@ public final class LocationSyncCoordinator: @unchecked Sendable {
                 if remoteTimestamp > localKeyUpdatedAt {
                     RidestrLogger.info("[LocationSyncCoordinator] Stale key for \(driver.pubkey.prefix(8)): local=\(localKeyUpdatedAt), remote=\(remoteTimestamp)")
                     driversRepository.markKeyStale(pubkey: driver.pubkey)
-                    await requestKeyRefresh(driverPubkey: driver.pubkey)
+                    try? await requestKeyRefresh(driverPubkey: driver.pubkey)
                 } else {
                     driversRepository.clearKeyStale(pubkey: driver.pubkey)
                 }
@@ -138,21 +140,24 @@ public final class LocationSyncCoordinator: @unchecked Sendable {
 
     /// Send a "stale" key ack to a driver, requesting they re-send Kind 3186.
     /// Used when: rider has no key for this driver, or driver rotated keys.
-    public func requestKeyRefresh(driverPubkey: String) async {
+    ///
+    /// Throws on event-building or relay-publish failure so user-facing
+    /// callers can distinguish "dispatched" from "silently dropped" — the
+    /// latter would otherwise burn a per-pubkey rate-limit slot in the app
+    /// layer with nothing actually sent. Best-effort callers (e.g. the
+    /// background `checkForStaleKeys` sweep) wrap with `try?` so a single
+    /// driver's failure doesn't abort the loop.
+    public func requestKeyRefresh(driverPubkey: String) async throws {
         let localKey = driversRepository.getRoadflareKey(driverPubkey: driverPubkey)
-        do {
-            let ackEvent = try await RideshareEventBuilder.keyAcknowledgement(
-                driverPubkey: driverPubkey,
-                keyVersion: localKey?.version ?? 0,
-                keyUpdatedAt: localKey?.keyUpdatedAt ?? 0,
-                status: "stale",
-                keypair: keypair
-            )
-            _ = try await relayManager.publish(ackEvent)
-            RidestrLogger.info("[LocationSyncCoordinator] Sent stale key ack to \(driverPubkey.prefix(8))")
-        } catch {
-            // Best effort
-        }
+        let ackEvent = try await RideshareEventBuilder.keyAcknowledgement(
+            driverPubkey: driverPubkey,
+            keyVersion: localKey?.version ?? 0,
+            keyUpdatedAt: localKey?.keyUpdatedAt ?? 0,
+            status: "stale",
+            keypair: keypair
+        )
+        _ = try await relayManager.publish(ackEvent)
+        RidestrLogger.info("[LocationSyncCoordinator] Sent stale key ack to \(driverPubkey.prefix(8))")
     }
 
     // MARK: - Publish Followed Drivers (Kind 30011)

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/FollowedDriversRepositoryTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/FollowedDriversRepositoryTests.swift
@@ -147,6 +147,30 @@ struct FollowedDriversRepositoryTests {
         #expect(repo.getDriver(pubkey: "d1")?.roadflareKey == current)
     }
 
+    // Regression for issue #72, Bug 3: writing one driver's key during a
+    // backup-restore must not flip another driver's stale flag. The iOS-side
+    // restore path (`AppState.restoreKeyFromBackup`) routes exclusively
+    // through `updateDriverKey` for the target pubkey, so the only way the
+    // user-reported "restoring one driver makes others outdated" symptom
+    // could originate on the rider side is through a cross-driver write
+    // here. This test pins that contract.
+    @Test func updateDriverKeyDoesNotAffectOtherDriversStaleFlags() {
+        let repo = makeRepo()
+        let key1 = RoadflareKey(privateKeyHex: "p1", publicKeyHex: "q1", version: 1, keyUpdatedAt: 100)
+        let key2 = RoadflareKey(privateKeyHex: "p2", publicKeyHex: "q2", version: 1, keyUpdatedAt: 100)
+        repo.addDriver(FollowedDriver(pubkey: "d1", roadflareKey: key1))
+        repo.addDriver(FollowedDriver(pubkey: "d2", roadflareKey: key2))
+        repo.markKeyStale(pubkey: "d2")
+
+        // Restore-style key write for d1.
+        let restoredKey = RoadflareKey(privateKeyHex: "p1b", publicKeyHex: "q1b", version: 2, keyUpdatedAt: 200)
+        let outcome = repo.updateDriverKey(driverPubkey: "d1", roadflareKey: restoredKey, source: .sync)
+        #expect(outcome == .appliedNewer)
+
+        // d2's stale state must be untouched.
+        #expect(repo.staleKeyPubkeys == ["d2"])
+    }
+
     @Test func updateDriverNote() {
         let repo = makeRepo()
         repo.addDriver(FollowedDriver(pubkey: "d1"))

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/LocationSyncCoordinatorTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/LocationSyncCoordinatorTests.swift
@@ -322,13 +322,28 @@ struct LocationSyncCoordinatorTests {
         // makeKit() does not pre-load a driver key, so this also covers the
         // keyless-driver (version 0) path.
 
-        await kit.coordinator.requestKeyRefresh(driverPubkey: kit.driverKeypair.publicKeyHex)
+        try await kit.coordinator.requestKeyRefresh(driverPubkey: kit.driverKeypair.publicKeyHex)
 
         #expect(kit.relay.publishedEvents.count == 1)
         let ack = kit.relay.publishedEvents[0]
         #expect(ack.kind == EventKind.keyAcknowledgement.rawValue)
         let driverPTag = ack.tags.first { $0.count >= 2 && $0[0] == "p" }
         #expect(driverPTag?[1] == kit.driverKeypair.publicKeyHex)
+    }
+
+    // Pins the contract that the SDK now surfaces publish failures to the
+    // caller (issue #72 follow-up): the AppState rate-limit wrapper relies
+    // on this so it can roll back the cooldown slot when nothing was
+    // actually sent. A best-effort caller (e.g. `checkForStaleKeys`) wraps
+    // with `try?` to preserve the previous best-effort behavior.
+    @Test func requestKeyRefreshThrowsWhenRelayPublishFails() async throws {
+        let kit = try await makeKit()
+        kit.relay.shouldFailPublish = true
+
+        await #expect(throws: (any Error).self) {
+            try await kit.coordinator.requestKeyRefresh(driverPubkey: kit.driverKeypair.publicKeyHex)
+        }
+        #expect(kit.relay.publishedEvents.isEmpty)
     }
 
     // MARK: - publishFollowedDriversList

--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 import RidestrSDK
 import RoadFlareCore
 
@@ -336,20 +337,40 @@ struct AddDriverSheet: View {
         // (rider previously followed the driver), our Kind 30011 backup
         // already carries the existing key — restore it locally and skip the
         // notification entirely. The follow-notification path only fires for
-        // genuinely new follows (no key in backup, no key locally).
+        // genuinely new follows (no key in backup, no key locally) or when
+        // the backup is unreachable (graceful degradation; logged).
         Task {
             await appState.publishDriversList()
 
-            if !appState.hasKeyForDriver(pubkey: hexPubkey) {
-                await appState.restoreKeyFromBackup(driverPubkey: hexPubkey)
-            }
-
+            // Already have a key locally (rare — driver may have re-published
+            // before this Task ran). Refresh the key-share subscription so we
+            // catch any subsequent rotation event (preserves the PR #54 side
+            // effect that the new flow would otherwise skip on re-add).
             if appState.hasKeyForDriver(pubkey: hexPubkey) {
+                appState.restartKeyShareSubscription()
                 return
             }
 
-            await appState.sendFollowNotification(driverPubkey: hexPubkey)
-            await appState.requestDriverKeyRefresh(driverPubkey: hexPubkey)
+            switch await appState.restoreKeyFromBackup(driverPubkey: hexPubkey) {
+            case .restored:
+                // Re-add: backup carried the key. Refresh the subscription
+                // (PR #54) but skip Kind 3187 to avoid Bug 3.
+                appState.restartKeyShareSubscription()
+            case .backupUnavailable:
+                // Couldn't tell whether this is a re-add or a new follow.
+                // Fall through to the new-follow handshake; on a re-add this
+                // re-introduces the Bug 3 over-rotation transiently, but the
+                // rider's local state still ends up correct after the next
+                // `checkForStaleKeys` sweep. Logged so the failure is visible
+                // when investigating user reports.
+                AppLogger.auth.warning(
+                    "Backup unreachable for \(hexPubkey.prefix(8)) on add; proceeding with new-follow handshake"
+                )
+                fallthrough
+            case .notInBackup:
+                await appState.sendFollowNotification(driverPubkey: hexPubkey)
+                await appState.requestDriverKeyRefresh(driverPubkey: hexPubkey)
+            }
         }
 
         dismiss()

--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -326,21 +326,30 @@ struct AddDriverSheet: View {
         )
         appState.addDriver(driver, profile: resolvedProfile, name: name)
 
-        // Publish Kind 30011 (source of truth) + Kind 3187 (real-time nudge to driver).
-        // On re-add, try to restore the key from Kind 30011 on the relay first.
-        // If still no key, send a stale ack to request one from the driver.
+        // Publish Kind 30011 (source of truth), then attempt to restore the
+        // driver's key from our own Kind 30011 backup before sending Kind 3187.
+        //
+        // Order matters here (issue #72, Bug 3): the driver-side Android client
+        // treats Kind 3187 as a fresh-follow signal and may rotate keys for all
+        // followers in response, marking *every other* rider's stored key as
+        // stale on their next `checkForStaleKeys` pass. When this is a re-add
+        // (rider previously followed the driver), our Kind 30011 backup
+        // already carries the existing key — restore it locally and skip the
+        // notification entirely. The follow-notification path only fires for
+        // genuinely new follows (no key in backup, no key locally).
         Task {
             await appState.publishDriversList()
-            await appState.sendFollowNotification(driverPubkey: hexPubkey)
 
-            // If no key locally, try restoring from our Kind 30011 backup on the relay
             if !appState.hasKeyForDriver(pubkey: hexPubkey) {
                 await appState.restoreKeyFromBackup(driverPubkey: hexPubkey)
             }
-            // If still no key after restore attempt, request from driver
-            if !appState.hasKeyForDriver(pubkey: hexPubkey) {
-                await appState.requestDriverKeyRefresh(driverPubkey: hexPubkey)
+
+            if appState.hasKeyForDriver(pubkey: hexPubkey) {
+                return
             }
+
+            await appState.sendFollowNotification(driverPubkey: hexPubkey)
+            await appState.requestDriverKeyRefresh(driverPubkey: hexPubkey)
         }
 
         dismiss()

--- a/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
@@ -7,6 +7,9 @@ struct DriverDetailSheet: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
     @State private var note: String = ""
+    @State private var keyRefreshToastMessage: String?
+    @State private var keyRefreshToastIsError: Bool = false
+    @State private var isRequestingKeyRefresh: Bool = false
 
     var body: some View {
         // Capture the presentation state once per body invocation. Each access
@@ -37,8 +40,19 @@ struct DriverDetailSheet: View {
                 if let version = state?.keyVersion {
                     Section("RoadFlare Key") {
                         LabeledContent("Version", value: "\(version)")
-                        LabeledContent("Key Status", value: "Active")
-                            .foregroundStyle(.green)
+                        if state?.isKeyStale == true {
+                            LabeledContent("Key Status", value: "Outdated")
+                                .foregroundStyle(.red)
+                            Button {
+                                requestKeyRefresh()
+                            } label: {
+                                Label("Request Fresh Key", systemImage: "arrow.clockwise")
+                            }
+                            .disabled(isRequestingKeyRefresh)
+                        } else {
+                            LabeledContent("Key Status", value: "Active")
+                                .foregroundStyle(.green)
+                        }
                     }
                 } else if state?.hasKey == false {
                     Section("RoadFlare Key") {
@@ -96,6 +110,24 @@ struct DriverDetailSheet: View {
                 // appear after the initial body render settled and `state` could
                 // still be nil if the driver is no longer in the repo.
                 note = appState.driverDetailViewState(pubkey: pubkey)?.note ?? ""
+            }
+            .toast($keyRefreshToastMessage, isError: keyRefreshToastIsError)
+        }
+    }
+
+    private func requestKeyRefresh() {
+        isRequestingKeyRefresh = true
+        Task {
+            let outcome = await appState.requestKeyRefresh(pubkey: pubkey)
+            isRequestingKeyRefresh = false
+            switch outcome {
+            case .sent:
+                keyRefreshToastMessage = "Refresh requested. Waiting for the driver to respond."
+                keyRefreshToastIsError = false
+            case .rateLimited(let retryAt):
+                let seconds = max(1, Int(retryAt.timeIntervalSinceNow.rounded(.up)))
+                keyRefreshToastMessage = "Just sent — wait \(seconds)s before requesting again."
+                keyRefreshToastIsError = true
             }
         }
     }

--- a/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift
@@ -128,6 +128,9 @@ struct DriverDetailSheet: View {
                 let seconds = max(1, Int(retryAt.timeIntervalSinceNow.rounded(.up)))
                 keyRefreshToastMessage = "Just sent — wait \(seconds)s before requesting again."
                 keyRefreshToastIsError = true
+            case .publishFailed:
+                keyRefreshToastMessage = "Couldn't reach the relay. Check your connection and try again."
+                keyRefreshToastIsError = true
             }
         }
     }

--- a/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
@@ -18,6 +18,9 @@ struct RideRequestView: View {
     @State private var mapKit = MapKitServices()
     @State private var locationManager = RiderLocationManager()
     @State private var isLocating = false
+    @State private var staleRefreshToastMessage: String?
+    @State private var staleRefreshToastIsError: Bool = false
+    @State private var isRefreshingStaleKeys: Bool = false
 
     private var coordinator: RideCoordinator? { appState.rideCoordinator }
     private var stage: RiderStage { coordinator?.session.stage ?? .idle }
@@ -29,6 +32,7 @@ struct RideRequestView: View {
         // rebuilds the filtered `RideRequestDriverOption` list from the repo.
         let onlineOptions = appState.onlineDriverOptions()
         let onlinePubkeys = onlineOptions.map(\.pubkey)
+        let staleKeyDriverCount = appState.staleKeyDriverPubkeys.count
         let favorites = appState.favoriteLocationRows
         let recents = appState.recentLocationRows
         let addressSearchItems = makeAddressSearchItems(favorites: favorites, recents: recents)
@@ -78,6 +82,14 @@ struct RideRequestView: View {
                                 }
                                 .buttonStyle(RFPrimaryButtonStyle())
                                 .padding(.horizontal, 48)
+                            }
+                            if staleKeyDriverCount > 0 {
+                                StaleKeyRefreshBanner(
+                                    count: staleKeyDriverCount,
+                                    isRefreshing: isRefreshingStaleKeys,
+                                    onRefresh: refreshStaleKeys
+                                )
+                                .padding(.horizontal, 16)
                             }
                         }
                 } else {
@@ -309,6 +321,24 @@ struct RideRequestView: View {
                 fareError = nil
             }
         }
+        .toast($staleRefreshToastMessage, isError: staleRefreshToastIsError)
+    }
+
+    private func refreshStaleKeys() {
+        guard !isRefreshingStaleKeys else { return }
+        isRefreshingStaleKeys = true
+        Task {
+            let sentCount = await appState.refreshAllStaleDriverKeys()
+            isRefreshingStaleKeys = false
+            if sentCount == 0 {
+                staleRefreshToastMessage = "Just sent — try again in a minute."
+                staleRefreshToastIsError = true
+            } else {
+                let plural = sentCount == 1 ? "driver" : "drivers"
+                staleRefreshToastMessage = "Refresh requested for \(sentCount) \(plural)."
+                staleRefreshToastIsError = false
+            }
+        }
     }
 
     // MARK: - Actions
@@ -476,5 +506,51 @@ struct RideRequestView: View {
         if !appliedExplicitSelection {
             self.selectedDriverPubkey = onlineOptions.first?.pubkey
         }
+    }
+}
+
+// MARK: - Stale Key Refresh Banner
+
+/// Empty-state CTA shown when the rider has no eligible online drivers but at
+/// least one followed driver has a stale key. Without this, the rider sees an
+/// empty list with no explanation — the SDK already supports the refresh
+/// request (Kind 3188 "stale" ack), but riders had no surface to fire it.
+struct StaleKeyRefreshBanner: View {
+    let count: Int
+    let isRefreshing: Bool
+    let onRefresh: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "key.slash")
+                    .foregroundColor(Color.rfError)
+                Text(headline)
+                    .font(RFFont.title(15))
+                    .foregroundColor(Color.rfOnSurface)
+            }
+            Text("Their keys rotated and need to be re-shared before you can request a ride.")
+                .font(RFFont.body(13))
+                .foregroundColor(Color.rfOnSurfaceVariant)
+            Button(action: onRefresh) {
+                HStack(spacing: 8) {
+                    if isRefreshing {
+                        ProgressView().tint(.white)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    Text("Request Fresh Keys")
+                }
+            }
+            .buttonStyle(RFPrimaryButtonStyle())
+            .disabled(isRefreshing)
+        }
+        .rfCard(.high)
+    }
+
+    private var headline: String {
+        count == 1
+            ? "1 driver has an outdated key"
+            : "\(count) drivers have outdated keys"
     }
 }

--- a/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
@@ -47,6 +47,10 @@ public struct DriverDetailViewState: Equatable, Sendable, Identifiable {
     /// The key's version number, if a key is present.
     public let keyVersion: Int?
 
+    /// Whether the driver's key has been flagged stale and needs a refresh.
+    /// `false` when no key is present.
+    public let isKeyStale: Bool
+
     // MARK: - Last Known Location section
 
     /// Raw status string from the last location broadcast (e.g. "online"), or nil if no location.
@@ -119,6 +123,7 @@ public struct DriverDetailViewState: Equatable, Sendable, Identifiable {
             canPing: canPing,
             hasKey: driver.hasKey,
             keyVersion: driver.roadflareKey?.version,
+            isKeyStale: isKeyStale,
             lastLocationStatus: isKeyStale ? nil : location?.status,
             lastLocationTimestampLabel: lastLocationTimestampLabel,
             note: driver.note ?? ""

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -18,6 +18,17 @@ public enum AccountDeletionError: Error, Equatable {
     case activeRideInProgress
 }
 
+/// Outcome of a user-initiated key refresh request.
+///
+/// `requestKeyRefresh(pubkey:)` enforces a per-driver cooldown so a frustrated
+/// rider tapping the button repeatedly doesn't spam the driver with stale
+/// acks; `.rateLimited` carries the next-eligible timestamp so callers can
+/// surface a precise countdown.
+public enum KeyRefreshOutcome: Sendable, Equatable {
+    case sent
+    case rateLimited(retryAt: Date)
+}
+
 /// Central app state coordinator. Owns SDK services and manages auth lifecycle.
 ///
 /// Views access this via `@Environment(AppState.self)`. All sync orchestration
@@ -276,6 +287,14 @@ public final class AppState {
     /// Intentionally not persisted — resets on app restart to avoid stale state.
     private var pingCooldowns: [String: Date] = [:]
     private static let pingCooldownSeconds: TimeInterval = 600  // 10 minutes
+
+    /// Per-driver last user-initiated key-refresh timestamps. Cleared on
+    /// identity replacement alongside `pingCooldowns`. Mirrors Android's
+    /// `keyRefreshRequests` map (rider-app/.../RoadflareTab.kt) — a 60s window
+    /// is enough that a tap-spam rider still gets actionable feedback ("wait
+    /// 30s before requesting again") rather than queueing a flood of stale acks.
+    private var keyRefreshCooldowns: [String: Date] = [:]
+    static let keyRefreshCooldownSeconds: TimeInterval = 60  // matches Android rider
 
     /// Returns `true` when `driver` is a valid ping target.
     ///
@@ -707,6 +726,7 @@ public final class AppState {
             pendingDriverDeepLink = nil
         }
         pingCooldowns = [:]
+        keyRefreshCooldowns = [:]
 
         // 6. Nil service refs
         rideCoordinator = nil
@@ -826,9 +846,55 @@ extension AppState {
         await rideCoordinator?.publishFollowedDriversList()
     }
 
-    /// Request a fresh share key from a driver.
+    /// Request a fresh share key from a driver. Internal flows (e.g. add-driver
+    /// re-handshake) — does not enforce the user-facing rate limit.
     public func requestDriverKeyRefresh(driverPubkey: String) async {
         await rideCoordinator?.requestKeyRefresh(driverPubkey: driverPubkey)
+    }
+
+    /// User-initiated key refresh for a driver whose key is flagged stale.
+    ///
+    /// Enforces a per-pubkey cooldown (`keyRefreshCooldownSeconds`) so that a
+    /// rider hammering the button doesn't spam the driver. Returns
+    /// `.rateLimited(retryAt:)` when the cooldown is still active so the
+    /// caller can show a precise wait time. Otherwise returns `.sent` after
+    /// dispatching the SDK request.
+    @discardableResult
+    public func requestKeyRefresh(pubkey: String) async -> KeyRefreshOutcome {
+        if let last = keyRefreshCooldowns[pubkey] {
+            let retryAt = last.addingTimeInterval(Self.keyRefreshCooldownSeconds)
+            if Date.now < retryAt {
+                return .rateLimited(retryAt: retryAt)
+            }
+        }
+        // Claim the slot before awaiting — sendDriverPing follows the same
+        // pattern; without it, two rapid taps both pass the cooldown check
+        // because the await is a suspension point.
+        keyRefreshCooldowns[pubkey] = Date.now
+        await rideCoordinator?.requestKeyRefresh(driverPubkey: pubkey)
+        return .sent
+    }
+
+    /// Pubkeys of all followed drivers whose key is currently flagged stale.
+    /// Empty when no repository has been installed.
+    public var staleKeyDriverPubkeys: [String] {
+        guard let repo = driversRepository else { return [] }
+        return Array(repo.staleKeyPubkeys)
+    }
+
+    /// Fan-out user-initiated key refresh for every stale-key driver.
+    /// Each pubkey goes through the same cooldown as `requestKeyRefresh(pubkey:)`,
+    /// so a banner-tap spammer still hits the per-pubkey limit. Returns the
+    /// number of `.sent` outcomes for caller-side toast feedback.
+    @discardableResult
+    public func refreshAllStaleDriverKeys() async -> Int {
+        var sentCount = 0
+        for pubkey in staleKeyDriverPubkeys {
+            if case .sent = await requestKeyRefresh(pubkey: pubkey) {
+                sentCount += 1
+            }
+        }
+        return sentCount
     }
 
     /// Check all followed drivers for stale keys and request refreshes.
@@ -948,6 +1014,10 @@ extension AppState {
 
     func primePingCooldownForTesting(driverPubkey: String, lastPing: Date) {
         pingCooldowns[driverPubkey] = lastPing
+    }
+
+    func primeKeyRefreshCooldownForTesting(pubkey: String, lastRequest: Date) {
+        keyRefreshCooldowns[pubkey] = lastRequest
     }
 
     /// Replace the persistence-backed `rideHistory` / `savedLocations` repos so

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -913,10 +913,10 @@ extension AppState {
     /// rider hammering the button doesn't spam the driver. Returns
     /// `.rateLimited(retryAt:)` when the cooldown is still active so the
     /// caller can show a precise wait time. Returns `.publishFailed` if no
-    /// coordinator is wired (logout/identity-replacement window) or the SDK
-    /// publish throws — the cooldown is *not* claimed in either case so the
-    /// rider can retry immediately. Otherwise returns `.sent` after the
-    /// publish lands.
+    /// coordinator is wired (logout/identity-replacement window — the
+    /// cooldown is never claimed) or the SDK publish throws (the cooldown
+    /// is rolled back); either way the rider can retry immediately.
+    /// Otherwise returns `.sent` after the publish lands.
     @discardableResult
     public func requestKeyRefresh(pubkey: String) async -> KeyRefreshOutcome {
         if let last = keyRefreshCooldowns[pubkey] {
@@ -936,9 +936,9 @@ extension AppState {
         // the catch wouldn't fire, and `.sent` would be returned with the
         // slot claimed.
         guard let dispatch = keyRefreshDispatch() else { return .publishFailed }
-        // Claim the slot before awaiting — `sendDriverPing` (line 376) follows
-        // the same eager-claim-then-rollback pattern. Without the eager claim,
-        // two rapid taps both pass the cooldown check because the await is a
+        // Claim the slot before awaiting — `sendDriverPing` follows the same
+        // eager-claim-then-rollback pattern. Without the eager claim, two
+        // rapid taps both pass the cooldown check because the await is a
         // suspension point. Without the rollback, a publish failure would
         // burn 60s with nothing actually sent.
         keyRefreshCooldowns[pubkey] = Date.now

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -343,6 +343,12 @@ public final class AppState {
     private var keyRefreshCooldowns: [String: Date] = [:]
     static let keyRefreshCooldownSeconds: TimeInterval = 60  // matches Android rider
 
+    #if DEBUG
+    /// Test-only override for the SDK call inside `requestKeyRefresh(pubkey:)`.
+    /// Set via `setKeyRefreshSDKHookForTesting(_:)`. See that method's docs.
+    var keyRefreshSDKHookForTesting: ((String) async throws -> Void)?
+    #endif
+
     /// Returns `true` when `driver` is a valid ping target.
     ///
     /// Checks: has a current RoadFlare key, key is not stale, driver is not online,
@@ -906,9 +912,11 @@ extension AppState {
     /// Enforces a per-pubkey cooldown (`keyRefreshCooldownSeconds`) so that a
     /// rider hammering the button doesn't spam the driver. Returns
     /// `.rateLimited(retryAt:)` when the cooldown is still active so the
-    /// caller can show a precise wait time. Returns `.publishFailed` if the
-    /// SDK publish throws — the cooldown is rolled back so the rider can
-    /// retry immediately. Otherwise returns `.sent` after the publish lands.
+    /// caller can show a precise wait time. Returns `.publishFailed` if no
+    /// coordinator is wired (logout/identity-replacement window) or the SDK
+    /// publish throws — the cooldown is *not* claimed in either case so the
+    /// rider can retry immediately. Otherwise returns `.sent` after the
+    /// publish lands.
     @discardableResult
     public func requestKeyRefresh(pubkey: String) async -> KeyRefreshOutcome {
         if let last = keyRefreshCooldowns[pubkey] {
@@ -917,6 +925,17 @@ extension AppState {
                 return .rateLimited(retryAt: retryAt)
             }
         }
+        // Resolve the dispatch closure: in production it's the SDK call, in
+        // tests it can be overridden via `keyRefreshSDKHookForTesting` so we
+        // can drive both `.sent` and `.publishFailed` paths without standing
+        // up a full RideCoordinator. Returns nil when no coordinator is wired
+        // (logout/identity-replacement window) — bail before claiming the
+        // cooldown slot so the rider can retry immediately rather than burn
+        // 60s on a publish that never happened. The optional-chain
+        // `try await rideCoordinator?...` would otherwise silently return nil,
+        // the catch wouldn't fire, and `.sent` would be returned with the
+        // slot claimed.
+        guard let dispatch = keyRefreshDispatch() else { return .publishFailed }
         // Claim the slot before awaiting — `sendDriverPing` (line 376) follows
         // the same eager-claim-then-rollback pattern. Without the eager claim,
         // two rapid taps both pass the cooldown check because the await is a
@@ -924,13 +943,21 @@ extension AppState {
         // burn 60s with nothing actually sent.
         keyRefreshCooldowns[pubkey] = Date.now
         do {
-            try await rideCoordinator?.requestKeyRefresh(driverPubkey: pubkey)
+            try await dispatch(pubkey)
             return .sent
         } catch {
             keyRefreshCooldowns[pubkey] = nil
             AppLogger.auth.info("requestKeyRefresh failed for \(pubkey.prefix(8)): \(error.localizedDescription)")
             return .publishFailed
         }
+    }
+
+    private func keyRefreshDispatch() -> ((String) async throws -> Void)? {
+        #if DEBUG
+        if let hook = keyRefreshSDKHookForTesting { return hook }
+        #endif
+        guard let coordinator = rideCoordinator else { return nil }
+        return { pubkey in try await coordinator.requestKeyRefresh(driverPubkey: pubkey) }
     }
 
     /// Pubkeys of all followed drivers whose key is currently flagged stale,
@@ -1080,6 +1107,15 @@ extension AppState {
 
     func primeKeyRefreshCooldownForTesting(pubkey: String, lastRequest: Date) {
         keyRefreshCooldowns[pubkey] = lastRequest
+    }
+
+    /// Test-only override for the SDK call inside `requestKeyRefresh(pubkey:)`.
+    /// When set, this closure is invoked with the target pubkey instead of
+    /// `rideCoordinator?.requestKeyRefresh(...)`. Lets tests drive the
+    /// `.sent` path (closure returns) and the `.publishFailed` path (closure
+    /// throws) without wiring a full RideCoordinator.
+    func setKeyRefreshSDKHookForTesting(_ hook: ((String) async throws -> Void)?) {
+        keyRefreshSDKHookForTesting = hook
     }
 
     /// Replace the persistence-backed `rideHistory` / `savedLocations` repos so

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -23,10 +23,35 @@ public enum AccountDeletionError: Error, Equatable {
 /// `requestKeyRefresh(pubkey:)` enforces a per-driver cooldown so a frustrated
 /// rider tapping the button repeatedly doesn't spam the driver with stale
 /// acks; `.rateLimited` carries the next-eligible timestamp so callers can
-/// surface a precise countdown.
+/// surface a precise countdown. `.publishFailed` distinguishes a relay
+/// publish failure (e.g. all relays disconnected) so the caller can show
+/// an actionable error rather than a misleading "sent" toast — and AppState
+/// rolls back the cooldown slot in that case so the rider can retry.
 public enum KeyRefreshOutcome: Sendable, Equatable {
     case sent
     case rateLimited(retryAt: Date)
+    case publishFailed
+}
+
+/// Outcome of `restoreKeyFromBackup(driverPubkey:)`.
+///
+/// Distinguishes "no key was in the backup" from "couldn't reach the relay
+/// or decode it" so the caller can react differently — important on the
+/// add-driver re-handshake path, where falling through to the new-follow
+/// branch on a transient relay failure would re-trigger the issue #72
+/// Bug 3 over-rotation symptom.
+public enum RestoreKeyFromBackupOutcome: Sendable, Equatable {
+    /// Backup was reachable, the driver was in it, and a key was applied to
+    /// the local repo.
+    case restored
+    /// Backup was reachable but the driver entry has no key (e.g. driver
+    /// was followed before any Kind 3186 was received). Treat as a genuine
+    /// new follow — Kind 3187 + Kind 3188 are appropriate.
+    case notInBackup
+    /// Couldn't fetch the backup, snapshot was missing, or the latest
+    /// remote event was undecodable. The caller cannot tell from the
+    /// signal alone whether this is a re-add or a new follow.
+    case backupUnavailable
 }
 
 /// Central app state coordinator. Owns SDK services and manages auth lifecycle.
@@ -228,19 +253,28 @@ public final class AppState {
 
     // MARK: - Driver Key Management
 
-    /// Try to restore a specific driver's key from our Kind 30011 backup on the relay.
-    public func restoreKeyFromBackup(driverPubkey: String) async {
+    /// Try to restore a specific driver's key from our Kind 30011 backup on
+    /// the relay.
+    ///
+    /// The returned outcome lets callers distinguish "the backup said this
+    /// driver has no key" from "we couldn't reach or decode the backup" —
+    /// critical on the add-driver re-handshake path where a transient
+    /// failure should NOT silently fall through to Kind 3187, since Kind
+    /// 3187 triggers driver-side key rotation for all followers (issue #72
+    /// Bug 3).
+    @discardableResult
+    public func restoreKeyFromBackup(driverPubkey: String) async -> RestoreKeyFromBackupOutcome {
         guard let service = roadflareDomainService,
-              let repo = driversRepository else { return }
+              let repo = driversRepository else { return .backupUnavailable }
         let remote = await service.fetchLatestFollowedDriversState()
-        guard let snapshot = remote.snapshot else { return }
+        guard let snapshot = remote.snapshot else { return .backupUnavailable }
 
         if let latestSeenCreatedAt = remote.latestSeenCreatedAt,
            snapshot.createdAt != latestSeenCreatedAt {
             AppLogger.auth.warning(
                 "Skipping key restore for \(driverPubkey.prefix(8)) because the latest followed-drivers backup is not decodable"
             )
-            return
+            return .backupUnavailable
         }
 
         if let entry = snapshot.value.drivers.first(where: { $0.pubkey == driverPubkey }),
@@ -252,7 +286,20 @@ public final class AppState {
             )
             rideCoordinator?.startLocationSubscriptions()
             AppLogger.auth.info("Restored key for \(driverPubkey.prefix(8)) from Kind 30011 backup")
+            return .restored
         }
+
+        return .notInBackup
+    }
+
+    /// Restart the key-share subscription. Surfaced so the add-driver
+    /// re-handshake can preserve the side effect from `sendFollowNotification`
+    /// (PR #54) when the new flow skips the Kind 3187 publish: a fresh
+    /// subscription forces relay re-delivery of any subsequent Kind 3186
+    /// rotations within the 12-hour window, even if the long-lived
+    /// subscription from app launch dropped events.
+    public func restartKeyShareSubscription() {
+        rideCoordinator?.startKeyShareSubscription()
     }
 
     /// Send Kind 3187 follow notification to a driver (real-time nudge).
@@ -847,9 +894,11 @@ extension AppState {
     }
 
     /// Request a fresh share key from a driver. Internal flows (e.g. add-driver
-    /// re-handshake) — does not enforce the user-facing rate limit.
+    /// re-handshake) — does not enforce the user-facing rate limit. Best-effort:
+    /// publish failures are swallowed because internal callers have no UI to
+    /// surface them and the periodic `checkForStaleKeys` sweep will retry.
     public func requestDriverKeyRefresh(driverPubkey: String) async {
-        await rideCoordinator?.requestKeyRefresh(driverPubkey: driverPubkey)
+        try? await rideCoordinator?.requestKeyRefresh(driverPubkey: driverPubkey)
     }
 
     /// User-initiated key refresh for a driver whose key is flagged stale.
@@ -857,8 +906,9 @@ extension AppState {
     /// Enforces a per-pubkey cooldown (`keyRefreshCooldownSeconds`) so that a
     /// rider hammering the button doesn't spam the driver. Returns
     /// `.rateLimited(retryAt:)` when the cooldown is still active so the
-    /// caller can show a precise wait time. Otherwise returns `.sent` after
-    /// dispatching the SDK request.
+    /// caller can show a precise wait time. Returns `.publishFailed` if the
+    /// SDK publish throws — the cooldown is rolled back so the rider can
+    /// retry immediately. Otherwise returns `.sent` after the publish lands.
     @discardableResult
     public func requestKeyRefresh(pubkey: String) async -> KeyRefreshOutcome {
         if let last = keyRefreshCooldowns[pubkey] {
@@ -867,19 +917,31 @@ extension AppState {
                 return .rateLimited(retryAt: retryAt)
             }
         }
-        // Claim the slot before awaiting — sendDriverPing follows the same
-        // pattern; without it, two rapid taps both pass the cooldown check
-        // because the await is a suspension point.
+        // Claim the slot before awaiting — `sendDriverPing` (line 376) follows
+        // the same eager-claim-then-rollback pattern. Without the eager claim,
+        // two rapid taps both pass the cooldown check because the await is a
+        // suspension point. Without the rollback, a publish failure would
+        // burn 60s with nothing actually sent.
         keyRefreshCooldowns[pubkey] = Date.now
-        await rideCoordinator?.requestKeyRefresh(driverPubkey: pubkey)
-        return .sent
+        do {
+            try await rideCoordinator?.requestKeyRefresh(driverPubkey: pubkey)
+            return .sent
+        } catch {
+            keyRefreshCooldowns[pubkey] = nil
+            AppLogger.auth.info("requestKeyRefresh failed for \(pubkey.prefix(8)): \(error.localizedDescription)")
+            return .publishFailed
+        }
     }
 
-    /// Pubkeys of all followed drivers whose key is currently flagged stale.
-    /// Empty when no repository has been installed.
+    /// Pubkeys of all followed drivers whose key is currently flagged stale,
+    /// returned in deterministic (lexicographic) order. Empty when no
+    /// repository has been installed.
+    ///
+    /// Sorting matters because callers and tests compare arrays directly;
+    /// `Set.Iterator` does not guarantee a stable order across reads.
     public var staleKeyDriverPubkeys: [String] {
         guard let repo = driversRepository else { return [] }
-        return Array(repo.staleKeyPubkeys)
+        return repo.staleKeyPubkeys.sorted()
     }
 
     /// Fan-out user-initiated key refresh for every stale-key driver.

--- a/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
@@ -175,8 +175,8 @@ final class LocationCoordinator {
         await locationSync.checkForStaleKeys()
     }
 
-    func requestKeyRefresh(driverPubkey: String) async {
-        await locationSync.requestKeyRefresh(driverPubkey: driverPubkey)
+    func requestKeyRefresh(driverPubkey: String) async throws {
+        try await locationSync.requestKeyRefresh(driverPubkey: driverPubkey)
     }
 
     // MARK: - Cleanup

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -113,7 +113,7 @@ public final class RideCoordinator {
     public func startLocationSubscriptions() { location.startLocationSubscriptions() }
     func startKeyShareSubscription() { location.startKeyShareSubscription() }
     public func publishFollowedDriversList() async { await location.publishFollowedDriversList() }
-    public func requestKeyRefresh(driverPubkey: String) async { await location.requestKeyRefresh(driverPubkey: driverPubkey) }
+    public func requestKeyRefresh(driverPubkey: String) async throws { try await location.requestKeyRefresh(driverPubkey: driverPubkey) }
     public func checkForStaleKeys() async { await location.checkForStaleKeys() }
 
     func restoreRideState() {

--- a/RoadFlare/RoadFlareTests/AppState/RequestKeyRefreshTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/RequestKeyRefreshTests.swift
@@ -1,0 +1,167 @@
+import Testing
+import Foundation
+@testable import RoadFlareCore
+@testable import RidestrSDK
+
+// Pure AppState behavior tests for the user-initiated key-refresh path. The SDK
+// network call is bypassed because `rideCoordinator` stays nil — the test seam
+// `installDriverPingTestContext` only wires the repository. That's deliberate:
+// these tests pin the rate-limit + outcome contract without depending on relay
+// machinery. The underlying `LocationSyncCoordinator.requestKeyRefresh` is
+// covered separately in the SDK suite.
+
+private let pubkeyA = String(repeating: "a", count: 64)
+private let pubkeyB = String(repeating: "b", count: 64)
+private let testKey = RoadflareKey(
+    privateKeyHex: String(repeating: "c", count: 64),
+    publicKeyHex:  String(repeating: "d", count: 64),
+    version: 1, keyUpdatedAt: nil
+)
+
+private func makeRepo(drivers: [FollowedDriver] = []) -> FollowedDriversRepository {
+    let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+    drivers.forEach { repo.addDriver($0) }
+    return repo
+}
+
+@Suite("AppState.requestKeyRefresh")
+@MainActor
+struct AppStateRequestKeyRefreshTests {
+
+    @Test func firstCallReturnsSent() async {
+        let driver = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driver])
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        let outcome = await appState.requestKeyRefresh(pubkey: pubkeyA)
+        #expect(outcome == .sent)
+    }
+
+    @Test func secondCallWithinCooldownReturnsRateLimited() async {
+        let driver = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driver])
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        _ = await appState.requestKeyRefresh(pubkey: pubkeyA)
+        let outcome = await appState.requestKeyRefresh(pubkey: pubkeyA)
+
+        guard case .rateLimited(let retryAt) = outcome else {
+            Issue.record("Expected .rateLimited, got \(outcome)")
+            return
+        }
+        #expect(retryAt > Date.now)
+        // Retry should land within ~60s of now (allowing a generous margin for slow CI).
+        #expect(retryAt.timeIntervalSinceNow <= 60)
+    }
+
+    @Test func cooldownIsPerPubkey() async {
+        let driverA = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let driverB = FollowedDriver(pubkey: pubkeyB, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driverA, driverB])
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        _ = await appState.requestKeyRefresh(pubkey: pubkeyA)
+        // Driver B has its own cooldown slot — same-instant request must succeed.
+        let outcomeB = await appState.requestKeyRefresh(pubkey: pubkeyB)
+        #expect(outcomeB == .sent)
+    }
+
+    @Test func expiredCooldownAllowsResend() async {
+        let driver = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driver])
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        // Prime cooldown to a timestamp safely past the 60s window.
+        let pastDate = Date.now.addingTimeInterval(-(AppState.keyRefreshCooldownSeconds + 5))
+        appState.primeKeyRefreshCooldownForTesting(pubkey: pubkeyA, lastRequest: pastDate)
+
+        let outcome = await appState.requestKeyRefresh(pubkey: pubkeyA)
+        #expect(outcome == .sent)
+    }
+}
+
+@Suite("AppState.refreshAllStaleDriverKeys")
+@MainActor
+struct AppStateRefreshAllStaleDriverKeysTests {
+
+    @Test func returnsZeroWhenNoStaleDrivers() async {
+        let driver = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driver])
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        let sent = await appState.refreshAllStaleDriverKeys()
+        #expect(sent == 0)
+    }
+
+    @Test func sendsForEachStaleDriver() async {
+        let driverA = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let driverB = FollowedDriver(pubkey: pubkeyB, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driverA, driverB])
+        repo.markKeyStale(pubkey: pubkeyA)
+        repo.markKeyStale(pubkey: pubkeyB)
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        let sent = await appState.refreshAllStaleDriverKeys()
+        #expect(sent == 2)
+    }
+
+    @Test func skipsNonStaleDrivers() async {
+        let staleDriver = FollowedDriver(pubkey: pubkeyA, name: "Stale", roadflareKey: testKey)
+        let freshDriver = FollowedDriver(pubkey: pubkeyB, name: "Fresh", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [staleDriver, freshDriver])
+        repo.markKeyStale(pubkey: pubkeyA)
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        let sent = await appState.refreshAllStaleDriverKeys()
+        #expect(sent == 1)
+        // The non-stale driver's cooldown slot must remain free so a real
+        // user-initiated tap on its row works immediately afterward.
+        #expect(appState.staleKeyDriverPubkeys == [pubkeyA])
+    }
+
+    @Test func subsequentCallReturnsZeroDueToRateLimit() async {
+        let driver = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driver])
+        repo.markKeyStale(pubkey: pubkeyA)
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        _ = await appState.refreshAllStaleDriverKeys()
+        let secondSent = await appState.refreshAllStaleDriverKeys()
+        #expect(secondSent == 0)
+    }
+}
+
+@Suite("AppState.staleKeyDriverPubkeys")
+@MainActor
+struct AppStateStaleKeyDriverPubkeysTests {
+
+    @Test func emptyWhenNoRepository() {
+        let appState = AppState()
+        #expect(appState.staleKeyDriverPubkeys.isEmpty)
+    }
+
+    @Test func emptyWhenNoStaleDrivers() {
+        let driver = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driver])
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+        #expect(appState.staleKeyDriverPubkeys.isEmpty)
+    }
+
+    @Test func reflectsStaleSet() {
+        let driver = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driver])
+        repo.markKeyStale(pubkey: pubkeyA)
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+        #expect(appState.staleKeyDriverPubkeys == [pubkeyA])
+    }
+}

--- a/RoadFlare/RoadFlareTests/AppState/RequestKeyRefreshTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/RequestKeyRefreshTests.swift
@@ -164,4 +164,23 @@ struct AppStateStaleKeyDriverPubkeysTests {
         appState.installDriverPingTestContext(driversRepository: repo)
         #expect(appState.staleKeyDriverPubkeys == [pubkeyA])
     }
+
+    // Pins the deterministic ordering contract: the property converts
+    // `Set<String>` to `[String]`, and `Set.Iterator` does not guarantee a
+    // stable order across reads. Without the explicit sort, this test
+    // would flake non-deterministically (and so would any future caller
+    // that compares the array directly).
+    @Test func sortedAcrossMultipleStaleDrivers() {
+        let driverA = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let driverB = FollowedDriver(pubkey: pubkeyB, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driverA, driverB])
+        // Mark in reverse-lexicographic order to defeat any insertion-order
+        // coincidence: ['b...' first, then 'a...'].
+        repo.markKeyStale(pubkey: pubkeyB)
+        repo.markKeyStale(pubkey: pubkeyA)
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+        // pubkeyA = "a...", pubkeyB = "b...", so sorted order is [A, B].
+        #expect(appState.staleKeyDriverPubkeys == [pubkeyA, pubkeyB])
+    }
 }

--- a/RoadFlare/RoadFlareTests/AppState/RequestKeyRefreshTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/RequestKeyRefreshTests.swift
@@ -3,12 +3,19 @@ import Foundation
 @testable import RoadFlareCore
 @testable import RidestrSDK
 
-// Pure AppState behavior tests for the user-initiated key-refresh path. The SDK
-// network call is bypassed because `rideCoordinator` stays nil — the test seam
-// `installDriverPingTestContext` only wires the repository. That's deliberate:
-// these tests pin the rate-limit + outcome contract without depending on relay
-// machinery. The underlying `LocationSyncCoordinator.requestKeyRefresh` is
-// covered separately in the SDK suite.
+// Pure AppState behavior tests for the user-initiated key-refresh path.
+//
+// `rideCoordinator` stays nil in tests because constructing a real one is
+// heavy. The production path treats a nil coordinator as a publish failure
+// (so a tap during the brief logout / identity-replacement window doesn't
+// burn a 60s cooldown for a publish that never happened); for tests that
+// need to drive `.sent` or simulate an SDK throw, install
+// `setKeyRefreshSDKHookForTesting(_:)` with a stub closure.
+//
+// The underlying `LocationSyncCoordinator.requestKeyRefresh` `throws`
+// contract is covered separately in the SDK suite.
+
+private struct StubError: Error {}
 
 private let pubkeyA = String(repeating: "a", count: 64)
 private let pubkeyB = String(repeating: "b", count: 64)
@@ -33,6 +40,7 @@ struct AppStateRequestKeyRefreshTests {
         let repo = makeRepo(drivers: [driver])
         let appState = AppState()
         appState.installDriverPingTestContext(driversRepository: repo)
+        appState.setKeyRefreshSDKHookForTesting { _ in /* succeed */ }
 
         let outcome = await appState.requestKeyRefresh(pubkey: pubkeyA)
         #expect(outcome == .sent)
@@ -43,6 +51,7 @@ struct AppStateRequestKeyRefreshTests {
         let repo = makeRepo(drivers: [driver])
         let appState = AppState()
         appState.installDriverPingTestContext(driversRepository: repo)
+        appState.setKeyRefreshSDKHookForTesting { _ in /* succeed */ }
 
         _ = await appState.requestKeyRefresh(pubkey: pubkeyA)
         let outcome = await appState.requestKeyRefresh(pubkey: pubkeyA)
@@ -52,7 +61,6 @@ struct AppStateRequestKeyRefreshTests {
             return
         }
         #expect(retryAt > Date.now)
-        // Retry should land within ~60s of now (allowing a generous margin for slow CI).
         #expect(retryAt.timeIntervalSinceNow <= 60)
     }
 
@@ -62,6 +70,7 @@ struct AppStateRequestKeyRefreshTests {
         let repo = makeRepo(drivers: [driverA, driverB])
         let appState = AppState()
         appState.installDriverPingTestContext(driversRepository: repo)
+        appState.setKeyRefreshSDKHookForTesting { _ in /* succeed */ }
 
         _ = await appState.requestKeyRefresh(pubkey: pubkeyA)
         // Driver B has its own cooldown slot — same-instant request must succeed.
@@ -74,6 +83,7 @@ struct AppStateRequestKeyRefreshTests {
         let repo = makeRepo(drivers: [driver])
         let appState = AppState()
         appState.installDriverPingTestContext(driversRepository: repo)
+        appState.setKeyRefreshSDKHookForTesting { _ in /* succeed */ }
 
         // Prime cooldown to a timestamp safely past the 60s window.
         let pastDate = Date.now.addingTimeInterval(-(AppState.keyRefreshCooldownSeconds + 5))
@@ -81,6 +91,48 @@ struct AppStateRequestKeyRefreshTests {
 
         let outcome = await appState.requestKeyRefresh(pubkey: pubkeyA)
         #expect(outcome == .sent)
+    }
+
+    // Pins the contract that an SDK throw rolls back the cooldown so the
+    // rider can retry immediately. Without rollback, the user would see a
+    // misleading "sent" toast and be locked out for 60s.
+    @Test func publishFailureRollsBackCooldown() async {
+        let driver = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driver])
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+        appState.setKeyRefreshSDKHookForTesting { _ in throw StubError() }
+
+        let outcome = await appState.requestKeyRefresh(pubkey: pubkeyA)
+        #expect(outcome == .publishFailed)
+
+        // Slot was rolled back — a retry the very next instant must reach the
+        // SDK call again rather than getting `.rateLimited`. We swap in a
+        // succeeding hook to verify that the second call actually progresses
+        // past the cooldown check.
+        appState.setKeyRefreshSDKHookForTesting { _ in /* succeed */ }
+        let retry = await appState.requestKeyRefresh(pubkey: pubkeyA)
+        #expect(retry == .sent)
+    }
+
+    // Pins the no-coordinator + no-hook path: `.publishFailed` is returned
+    // and the cooldown is NOT claimed. Reachable during the brief logout /
+    // identity-replacement window.
+    @Test func noDispatchAvailableReturnsPublishFailedWithoutClaimingSlot() async {
+        let driver = FollowedDriver(pubkey: pubkeyA, name: "Alice", roadflareKey: testKey)
+        let repo = makeRepo(drivers: [driver])
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+        // No hook installed → keyRefreshDispatch() returns nil.
+
+        let outcome = await appState.requestKeyRefresh(pubkey: pubkeyA)
+        #expect(outcome == .publishFailed)
+
+        // Slot must not have been claimed; the next call must still reach the
+        // dispatch resolution (returns `.publishFailed` again, not
+        // `.rateLimited`).
+        let retry = await appState.requestKeyRefresh(pubkey: pubkeyA)
+        #expect(retry == .publishFailed)
     }
 }
 
@@ -106,6 +158,7 @@ struct AppStateRefreshAllStaleDriverKeysTests {
         repo.markKeyStale(pubkey: pubkeyB)
         let appState = AppState()
         appState.installDriverPingTestContext(driversRepository: repo)
+        appState.setKeyRefreshSDKHookForTesting { _ in /* succeed */ }
 
         let sent = await appState.refreshAllStaleDriverKeys()
         #expect(sent == 2)
@@ -118,6 +171,7 @@ struct AppStateRefreshAllStaleDriverKeysTests {
         repo.markKeyStale(pubkey: pubkeyA)
         let appState = AppState()
         appState.installDriverPingTestContext(driversRepository: repo)
+        appState.setKeyRefreshSDKHookForTesting { _ in /* succeed */ }
 
         let sent = await appState.refreshAllStaleDriverKeys()
         #expect(sent == 1)
@@ -132,6 +186,7 @@ struct AppStateRefreshAllStaleDriverKeysTests {
         repo.markKeyStale(pubkey: pubkeyA)
         let appState = AppState()
         appState.installDriverPingTestContext(driversRepository: repo)
+        appState.setKeyRefreshSDKHookForTesting { _ in /* succeed */ }
 
         _ = await appState.refreshAllStaleDriverKeys()
         let secondSent = await appState.refreshAllStaleDriverKeys()

--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -216,11 +216,24 @@ struct DriverDetailViewStateTests {
                                                isKeyStale: true, canPing: false)
         #expect(state.statusLabel == "Key outdated")
         #expect(state.canRequestRide == false)
+        #expect(state.isKeyStale == true)
         // Both last-location fields must be nil when the key is stale — the
         // raw "online" status and the "3 min ago" timestamp were both derived
         // from a broadcast decrypted with the pre-rotation key.
         #expect(state.lastLocationStatus == nil)
         #expect(state.lastLocationTimestampLabel == nil)
+    }
+
+    // Pins the contract that DriverDetailSheet's "Key Status" branch reads
+    // from: a non-stale active key must surface as `isKeyStale == false` so the
+    // sheet can render the green "Active" label. Without this field, the
+    // sheet hardcoded "Active" even for stale keys (issue #72 / Bug 1).
+    @Test func isKeyStaleFalseForActiveKey() {
+        let driver = makeDriver()
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: makeLocation(status: "online"),
+                                               profile: nil, isKeyStale: false, canPing: false)
+        #expect(state.isKeyStale == false)
     }
 
     // Mirrors the DriverListItem precedence test: stale wins over any location

--- a/decisions/0013-stale-key-refresh-flow.md
+++ b/decisions/0013-stale-key-refresh-flow.md
@@ -16,7 +16,7 @@ The Android rider app implements an equivalent flow (`rider-app/.../RoadflareTab
 
 Wire the user-initiated key-refresh flow through a new app-layer rate-limiter and surface it on two views:
 
-1. **`AppState.requestKeyRefresh(pubkey:) async -> KeyRefreshOutcome`** — public, rate-limited entry point. Outcomes: `.sent`, `.rateLimited(retryAt:)`, `.publishFailed`. The cooldown slot is claimed eagerly (before the SDK await, mirroring the `sendDriverPing` race-protection pattern at `AppState.swift:376`) and rolled back on `.publishFailed` so the rider can retry immediately rather than wait out 60 seconds for nothing. This required making `LocationSyncCoordinator.requestKeyRefresh` `throws` so the publish failure surfaces to the caller (previously it caught everything internally as "best effort").
+1. **`AppState.requestKeyRefresh(pubkey:) async -> KeyRefreshOutcome`** — public, rate-limited entry point. Outcomes: `.sent`, `.rateLimited(retryAt:)`, `.publishFailed`. The cooldown slot is claimed eagerly (before the SDK await, mirroring the `sendDriverPing` race-protection pattern in the same file) and rolled back on `.publishFailed` so the rider can retry immediately rather than wait out 60 seconds for nothing. This required making `LocationSyncCoordinator.requestKeyRefresh` `throws` so the publish failure surfaces to the caller (previously it caught everything internally as "best effort").
 
 2. **Per-pubkey cooldown of 60 seconds**, stored in `keyRefreshCooldowns: [String: Date]` on `AppState`, cleared in `prepareForIdentityReplacement` alongside `pingCooldowns`. 60s matches Android.
 

--- a/decisions/0013-stale-key-refresh-flow.md
+++ b/decisions/0013-stale-key-refresh-flow.md
@@ -1,0 +1,73 @@
+# ADR-0013: User-Initiated Stale-Key Refresh Flow
+
+**Status:** Active
+**Created:** 2026-04-28
+**Tags:** architecture, ux, sync, public-api
+
+## Context
+
+The SDK has had `LocationSyncCoordinator.requestKeyRefresh(driverPubkey:)` since the RoadFlare protocol was introduced — a Kind 3188 "stale" ack telling a driver to re-publish their Kind 3186 key share. But it was only invoked from the periodic `checkForStaleKeys` sweep. Riders whose driver keys had rotated saw a red "Key outdated" pill on the drivers tab and a silently-filtered ride-request list with no way to recover unless that automatic sweep happened to succeed (which it can't if the relay was briefly unreachable, the rate-limit window was active driver-side, or the rider's `key_updated_at` never advanced past stale).
+
+Issue #72 collected three symptoms of the same incomplete loop: a misleading "Active" green label on stale keys in the detail sheet (Bug 1), no user-initiated path to request a refresh (Bug 2), and a re-add flow that triggered cross-driver over-rotation because Kind 3187 was published before the local key restore (Bug 3). Each fix individually was small; together they form the user-facing half of the protocol the SDK already supported.
+
+The Android rider app implements an equivalent flow (`rider-app/.../RoadflareTab.kt:109-178`) with a per-driver `keyRefreshRequests` map and a 60-second cooldown. The iOS app needed to surface the same primitive without breaking the rate-limit assumptions the driver-side Android client makes.
+
+## Decision
+
+Wire the user-initiated key-refresh flow through a new app-layer rate-limiter and surface it on two views:
+
+1. **`AppState.requestKeyRefresh(pubkey:) async -> KeyRefreshOutcome`** — public, rate-limited entry point. Outcomes: `.sent`, `.rateLimited(retryAt:)`, `.publishFailed`. The cooldown slot is claimed eagerly (before the SDK await, mirroring the `sendDriverPing` race-protection pattern at `AppState.swift:376`) and rolled back on `.publishFailed` so the rider can retry immediately rather than wait out 60 seconds for nothing. This required making `LocationSyncCoordinator.requestKeyRefresh` `throws` so the publish failure surfaces to the caller (previously it caught everything internally as "best effort").
+
+2. **Per-pubkey cooldown of 60 seconds**, stored in `keyRefreshCooldowns: [String: Date]` on `AppState`, cleared in `prepareForIdentityReplacement` alongside `pingCooldowns`. 60s matches Android.
+
+3. **`AppState.staleKeyDriverPubkeys: [String]`** — sorted projection of `FollowedDriversRepository.staleKeyPubkeys`, used by the empty-state banner.
+
+4. **`AppState.refreshAllStaleDriverKeys() async -> Int`** — fan-out for the empty-state banner, returning the number of `.sent` outcomes for toast feedback.
+
+5. **`DriverDetailViewState.isKeyStale: Bool`** — exposed so the detail sheet can render the truthful red "Outdated" / green "Active" branch instead of hardcoded "Active".
+
+6. **`StaleKeyRefreshBanner`** in `RideRequestView`'s empty-state branch — shown when the rider has no eligible online drivers but at least one stale-key driver. Tapping it fan-outs through `refreshAllStaleDriverKeys`.
+
+7. **`AddDriverSheet.addDriver` reordering** — `restoreKeyFromBackup` runs *before* `sendFollowNotification`, with explicit outcome handling (`.restored` / `.notInBackup` / `.backupUnavailable`) replacing the previous opaque `Void` return. The `restartKeyShareSubscription` side-effect from PR #54 is preserved on the re-add early-return path via a new `AppState.restartKeyShareSubscription()` shim.
+
+## Rationale
+
+- **App-layer cooldown over SDK-layer cooldown** because the rate limit guards a *user-tap* surface, not the protocol primitive itself; the SDK's `requestKeyRefresh` should remain a low-level fire-once primitive that other callers (e.g. the periodic sweep) use unrate-limited. Precedent: `pingCooldowns` (ADR-0009) lives in the same place for the same reason. A future consolidation (cross-client cooldown semantics moved into the SDK) is out of scope for this fix and tracked separately.
+
+- **`KeyRefreshOutcome` instead of `throws`** because the call site is a SwiftUI button handler that needs to render three distinct user-facing states (success toast, wait-N-seconds toast, publish-failed toast), not a do/catch block. Plain `throws` would force every caller to either `try?` (silent failure — the bug we're fixing) or invent its own error-classification.
+
+- **`restoreKeyFromBackup` outcome enum** because the previous `Void` return collapsed three semantically-different cases ("backup said no key", "backup unreachable", "backup said yes and applied"). The add-driver flow's correctness depends on distinguishing them: a transient unreachable case must NOT silently fall through to Kind 3187 if it can be avoided, and when it must (graceful degradation), the choice should be logged so user reports can be diagnosed.
+
+- **Restore-before-notify ordering** is the iOS-side half of the Bug 3 fix. The Android driver client treats Kind 3187 as a fresh-follow signal that may rotate keys for all followers, marking every other rider's stored key as stale on their next sweep. Restoring the key from our own Kind 30011 backup first lets us short-circuit on re-adds without touching the driver. The Android-side complement (driver reads existing follower from mute list and re-delivers without rotating) is tracked separately on the Drivestr repo.
+
+- **`restartKeyShareSubscription` preserved on re-add path** because PR #54's subscription-restart side effect on `sendFollowNotification` was added to force relay re-delivery of Kind 3186 events the long-lived subscription may have missed. Restoring a key from backup doesn't satisfy that goal — backups give us a *snapshot*, not a fresh subscription. Splitting the side effect into its own AppState method keeps both flows correct.
+
+## Alternatives Considered
+
+- **Auto-refresh in the periodic sweep only.** Already implemented; insufficient because a single sweep failure (relay flake, rate-limit window) leaves the rider locked out indefinitely. The user has no agency.
+- **Fire `.sent` regardless of publish outcome (status-quo before this PR).** Original implementation. Causes a false-success toast plus a 60s lockout on publish failure. Rejected during code review (verify-and-fix pass 2).
+- **Move the cooldown into `LocationSyncCoordinator`.** Rejected for this PR because it would also require moving `pingCooldowns` for consistency, expanding scope. Tracked separately.
+- **Banner everywhere a stale driver exists, not just empty state.** Rejected for this PR because the empty-state CTA is the dead-end the issue identifies; broader placement is a UX scope decision. Tracked separately.
+
+## Consequences
+
+- The SDK's `requestKeyRefresh` now `throws`. Existing best-effort callers wrap with `try?` (one site in `LocationSyncCoordinator.checkForStaleKeys`).
+- New public API on `AppState` (`KeyRefreshOutcome`, `RestoreKeyFromBackupOutcome`, `requestKeyRefresh(pubkey:)`, `staleKeyDriverPubkeys`, `refreshAllStaleDriverKeys`, `restartKeyShareSubscription`) and a new public field on `DriverDetailViewState` (`isKeyStale`).
+- The add-driver flow's behavior on `.backupUnavailable` is the same as the pre-fix flow (graceful degradation, logged). A future enhancement could retry the backup fetch with backoff before falling through.
+- Riders now have both a per-driver "Request Fresh Key" button (DriverDetailSheet) and a fan-out empty-state banner (RideRequestView).
+- Any future caller that compares `staleKeyDriverPubkeys` arrays directly will get deterministic ordering.
+
+## Affected Files
+
+- `RidestrSDK/Sources/RidestrSDK/RoadFlare/LocationSyncCoordinator.swift` — `requestKeyRefresh` throws; `checkForStaleKeys` wraps with `try?`
+- `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/LocationSyncCoordinatorTests.swift` — added throw-on-publish-failure test
+- `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/FollowedDriversRepositoryTests.swift` — Bug 3 cross-driver invariant test
+- `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` — new public outcomes, cooldown storage, `requestKeyRefresh(pubkey:)`, `staleKeyDriverPubkeys` (sorted), `refreshAllStaleDriverKeys`, `restartKeyShareSubscription`, `restoreKeyFromBackup` outcome enum
+- `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift` — `requestKeyRefresh` throws
+- `RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift` — `requestKeyRefresh` throws
+- `RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift` — `isKeyStale` field
+- `RoadFlare/RoadFlare/Views/Drivers/DriverDetailSheet.swift` — truthful key-status branch + "Request Fresh Key" button
+- `RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift` — reordered handshake + outcome switch
+- `RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift` — `StaleKeyRefreshBanner`
+- `RoadFlare/RoadFlareTests/AppState/RequestKeyRefreshTests.swift` — new test suite
+- `RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift` — `isKeyStale` projection tests


### PR DESCRIPTION
Closes #72.

Stale-key handling had the SDK protocol primitive (`LocationSyncCoordinator.requestKeyRefresh`) but no UX wiring, so a rider locked out by an outdated driver key had no path to recover. This bundles all three sub-bugs from #72 because the third (restore-flow over-rotation) is invisible without the second (UI surface to act on stale state) and the first (truthful key-status label).

## Summary

- **Bug 1 (truthful label).** `DriverDetailSheet` always rendered "Key Status: Active" in green even for stale keys. Expose `isKeyStale` on `DriverDetailViewState` and branch on it (red "Outdated" vs green "Active").
- **Bug 2 (remediation path).** Add `AppState.requestKeyRefresh(pubkey:)` with a 60s per-pubkey cooldown (mirrors Android), a "Request Fresh Key" button in `DriverDetailSheet` when the key is stale, and a `StaleKeyRefreshBanner` in the empty-state of `RideRequestView` that fans out refreshes when no eligible drivers exist but stale ones do.
- **Bug 3 (restore over-rotation).** `AddDriverSheet.addDriver` was firing `sendFollowNotification` (Kind 3187) before attempting `restoreKeyFromBackup`. The driver-side Android client may rotate keys for all followers in response, marking every other rider's stored key as stale. iOS-side audit: rider's `restoreKeyFromBackup` only writes to the target driver via `updateDriverKey`, no cross-driver writes — the over-rotation comes from the Kind 3187 trigger. Reorder so restore-from-backup runs first; only send the follow notification when no key is recovered.

## Test approach

- New presentation tests pin the new `isKeyStale` field on `DriverDetailViewState` (active + stale paths).
- New `AppStateRequestKeyRefreshTests` cover sent / rate-limited / per-pubkey isolation / expired-cooldown for the user-initiated refresh.
- New `AppStateRefreshAllStaleDriverKeysTests` and `AppStateStaleKeyDriverPubkeysTests` cover the banner's fan-out path and the stale-key listing.
- New SDK test (`updateDriverKeyDoesNotAffectOtherDriversStaleFlags`) pins the iOS-side Bug 3 invariant: the only write `restoreKeyFromBackup` performs cannot mutate other drivers' staleKey state.

## Verification

- [x] `xcodebuild ... test` — `** TEST SUCCEEDED **` on the full app + test target
- [x] `swift test` (SDK) — 825 tests in 53 suites passed
- [ ] Manual: confirm the Drivers Tab → driver detail sheet now shows red "Outdated" + a "Request Fresh Key" button when a driver's `isKeyStale == true`, and the ride-request empty-state shows the banner when stale drivers exist but no online ones do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)