### PR TITLE
fix(onboarding): make PaymentSetupView scroll + pin Continue button

### DIFF
--- a/RoadFlare/RoadFlare/Views/Onboarding/PaymentSetupView.swift
+++ b/RoadFlare/RoadFlare/Views/Onboarding/PaymentSetupView.swift
@@ -9,29 +9,30 @@ struct PaymentSetupView: View {
         ZStack {
             Color.rfSurface.ignoresSafeArea()
 
-            VStack(spacing: 24) {
-                Spacer().frame(height: 40)
+            ScrollView {
+                VStack(spacing: 24) {
+                    Image(systemName: "creditcard")
+                        .font(.system(size: 50))
+                        .foregroundColor(Color.rfPrimary)
 
-                Image(systemName: "creditcard")
-                    .font(.system(size: 50))
-                    .foregroundColor(Color.rfPrimary)
+                    VStack(spacing: 8) {
+                        Text("Payment Methods")
+                            .font(RFFont.headline(24))
+                            .foregroundColor(Color.rfOnSurface)
+                        Text("Select the payment methods you can use.\nYour driver will see these when you request a ride.")
+                            .font(RFFont.body(14))
+                            .foregroundColor(Color.rfOnSurfaceVariant)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 16)
+                    }
 
-                VStack(spacing: 8) {
-                    Text("Payment Methods")
-                        .font(RFFont.headline(24))
-                        .foregroundColor(Color.rfOnSurface)
-                    Text("Select the payment methods you can use.\nYour driver will see these when you request a ride.")
-                        .font(RFFont.body(14))
-                        .foregroundColor(Color.rfOnSurfaceVariant)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 16)
+                    PaymentMethodPicker(settings: appState.settings)
+                        .padding(.horizontal, 24)
                 }
-
-                PaymentMethodPicker(settings: appState.settings)
-                    .padding(.horizontal, 24)
-
-                Spacer()
-
+                .padding(.top, 40)
+                .padding(.bottom, 16)
+            }
+            .safeAreaInset(edge: .bottom) {
                 VStack(spacing: 8) {
                     if appState.settings.roadflarePaymentMethods.isEmpty {
                         Text("Select at least one payment method to continue")
@@ -48,10 +49,12 @@ struct PaymentSetupView: View {
                         Text("Continue")
                     }
                     .buttonStyle(RFPrimaryButtonStyle())
-                    .padding(.horizontal, 24)
                 }
-
-                Spacer().frame(height: 20)
+                .padding(.horizontal, 24)
+                .padding(.top, 12)
+                .padding(.bottom, 12)
+                .frame(maxWidth: .infinity)
+                .background(Color.rfSurface)
             }
         }
     }

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -208,9 +208,12 @@ public final class AppState {
 
     /// Mark profile name as set, publish Kind 0 to Nostr, move to payment setup.
     /// Optimistic: advances `authState` immediately, publishes in the background.
-    /// `markDirty` persists the dirty flag synchronously, so a publish that fails
-    /// (or never completes before app termination) is retried by the sync
-    /// coordinator on next relay reconnect via `flushPendingSyncPublishes`.
+    /// `markDirty` persists the dirty flag synchronously. If publish fails,
+    /// `completePaymentSetup` republishes profile via `saveAndPublishSettings`,
+    /// and once the user reaches `.ready` any still-dirty domain is retried by
+    /// `SyncCoordinator.flushPendingSyncPublishes` on the next relay reconnect.
+    /// (Reconnect-flush is gated by `authState == .ready`, so it does not fire
+    /// during the `.paymentSetup` window.)
     public func completeProfileSetup(name: String) async {
         settings.setProfileName(name)
         syncCoordinator?.markDirty(.profile)
@@ -219,8 +222,9 @@ public final class AppState {
     }
 
     /// Mark payment setup as done, finish onboarding. Publishes profile +
-    /// settings backup in the background; same retry semantics as
-    /// `completeProfileSetup`.
+    /// settings backup in the background. Once `authState == .ready`, any
+    /// domain still dirty is retried on the next relay reconnect via
+    /// `SyncCoordinator.flushPendingSyncPublishes`.
     public func completePaymentSetup() async {
         settings.setProfileCompleted(true)
         syncCoordinator?.markDirty(.profileBackup)

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -207,19 +207,25 @@ public final class AppState {
     }
 
     /// Mark profile name as set, publish Kind 0 to Nostr, move to payment setup.
+    /// Optimistic: advances `authState` immediately, publishes in the background.
+    /// `markDirty` persists the dirty flag synchronously, so a publish that fails
+    /// (or never completes before app termination) is retried by the sync
+    /// coordinator on next relay reconnect via `flushPendingSyncPublishes`.
     public func completeProfileSetup(name: String) async {
         settings.setProfileName(name)
         syncCoordinator?.markDirty(.profile)
-        await publishProfile()
         authState = .paymentSetup
+        Task { await self.publishProfile() }
     }
 
-    /// Mark payment setup as done, finish onboarding. Publishes profile + settings backup.
+    /// Mark payment setup as done, finish onboarding. Publishes profile +
+    /// settings backup in the background; same retry semantics as
+    /// `completeProfileSetup`.
     public func completePaymentSetup() async {
         settings.setProfileCompleted(true)
         syncCoordinator?.markDirty(.profileBackup)
-        await saveAndPublishSettings()
         authState = .ready
+        Task { await self.saveAndPublishSettings() }
     }
 
     // MARK: - Forwarding to SDK (through SyncCoordinator)

--- a/decisions/0014-optimistic-onboarding-publish.md
+++ b/decisions/0014-optimistic-onboarding-publish.md
@@ -1,0 +1,75 @@
+# ADR-0014: Optimistic Onboarding Publish
+
+**Status:** Active
+**Created:** 2026-04-29
+**Tags:** concurrency, ux, sync, onboarding
+
+## Context
+
+`AppState.completeProfileSetup(name:)` and `completePaymentSetup()` previously awaited a Nostr relay publish before flipping `authState` to the next stage:
+
+```swift
+public func completeProfileSetup(name: String) async {
+    settings.setProfileName(name)
+    syncCoordinator?.markDirty(.profile)
+    await publishProfile()              // ← network round-trip
+    authState = .paymentSetup           // ← gated on the round-trip
+}
+```
+
+Tapping Continue on either onboarding screen left the view visibly frozen for several seconds while the publish completed — one Kind 0 publish on profile setup, one Kind 0 + one Kind 30177 on payment setup. The freeze was reported during device testing of issue #83's layout fix on iPhone 16e and reproduced consistently on cellular networks. The SDK's `publishProfileAndMark` already swallows publish errors silently (logs only), so the awaited round-trip was not providing a user-visible failure surface — it was only blocking the UI.
+
+The publish state machine already records intent durably: `RoadflareSyncStateStore.markDirty` writes the dirty flag synchronously to UserDefaults, and `SyncCoordinator.flushPendingSyncPublishes` republishes any dirty domain on relay reconnect. The retry path existed; the awaited publish was redundant durability for a state machine that already had a stronger guarantee.
+
+## Decision
+
+Advance `authState` immediately after marking the relevant sync domain dirty, and spawn the publish as a fire-and-forget `Task`:
+
+```swift
+public func completeProfileSetup(name: String) async {
+    settings.setProfileName(name)
+    syncCoordinator?.markDirty(.profile)   // persists dirty flag synchronously
+    authState = .paymentSetup              // optimistic
+    Task { await self.publishProfile() }   // fire-and-forget
+}
+
+public func completePaymentSetup() async {
+    settings.setProfileCompleted(true)
+    syncCoordinator?.markDirty(.profileBackup)
+    authState = .ready
+    Task { await self.saveAndPublishSettings() }
+}
+```
+
+**Retry layering:**
+1. **Profile-setup natural retry** — if `publishProfile` fails during the `.paymentSetup` window, `completePaymentSetup` re-attempts it via `saveAndPublishSettings`, which calls `publishProfile()` + `publishProfileBackup()` sequentially.
+2. **Reconnect flush** — once `authState == .ready`, `SyncCoordinator.flushPendingSyncPublishes` republishes any still-dirty domain on the next relay reconnect (triggered by foreground transition or the connection-coordinator watchdog). The `.ready` gate is enforced at every flush call site (`handleForeground` line 463, connection-coordinator `shouldReconnect` closures lines 689/739), so flush does not fire during the `.profileIncomplete → .paymentSetup` window.
+3. **App-launch resume** — the dirty flag survives termination via UserDefaults, so a publish interrupted by app kill is republished by `setupServicesWithSync`'s startup sync.
+
+A user-visible failure surface (60s watchdog + retry banner) is intentionally deferred to issue #88 along with the AppState publish-injection test seam needed to exercise it deterministically.
+
+## Rationale
+
+- **The awaited publish was not load-bearing for failure surface.** `publishProfileAndMark` swallows errors internally (logs only) — awaiting it gave the UI no signal it could act on. Removing the await loses no information.
+- **The dirty flag is the source of truth, not the await.** `markDirty` writes synchronously to UserDefaults; the retry path is already in place. Awaiting the publish was duplicating the durability guarantee with a slow synchronous round-trip.
+- **Onboarding is the worst surface for blocking on the network.** First-time users on cellular often have multi-second relay handshakes. A frozen Continue button reads as a broken app and abandons users at the highest-value moment in the funnel.
+- **Layered retry covers the realistic failure modes.** A profile publish that fails during `.paymentSetup` gets a free retry from `completePaymentSetup`. A profile-backup publish that fails during `.ready` gets retried by foreground reconnect. An app-kill mid-publish gets retried at next launch. The only case left uncovered is "user reaches `.ready` and never reconnects, never foregrounds, never restarts" — the case #88's user-visible surface targets explicitly.
+
+## Alternatives Considered
+
+- **Keep awaited publish.** Status quo. Multi-second freeze on Continue. Rejected — direct user-visibility regression with no failure-surface benefit (errors already silent).
+- **Awaited publish + loading spinner / disabled button.** Better UX than frozen view, still slow. Doesn't fix the underlying redundancy. Rejected — adds UI for a wait the user shouldn't have to see.
+- **Optimistic transition + immediate failure-surface watchdog (60s + banner + retry button).** This is the right end state, but the watchdog needs an AppState publish-injection test seam that doesn't yet exist, and the banner needs UI design (placement, copy, persistence-across-launches semantics). Splitting it from the lag-fix lets the layout fix and the lag fix ship under the App Store deadline; the watchdog work is tracked in #88.
+- **Move the optimistic-publish coordination into a new SDK API (e.g., `markDirtyAndPublishInBackground`).** Considered for module-boundary cleanliness per `.claude/CLAUDE.md`'s "sync domain logic belongs in the SDK." Rejected because the fire-and-forget `Task { await self.publishProfile() }` is UI-orchestration sequencing, not protocol semantics — the actual publish (`publishProfileAndMark`) already lives in the SDK. A helper that wraps "spawn a Task to call an SDK method" would be a one-line indirection that adds an SDK API for one app-side caller. Tracked as a candidate consolidation if a second caller appears.
+
+## Consequences
+
+- Both `completeProfileSetup` and `completePaymentSetup` return immediately on the call's `await`. Call sites that previously assumed publish completion before the function returns no longer hold (none in production code; the test suite did not assert on this either).
+- The doc comments on both methods explicitly describe the retry layering and the `.ready` gate, so a future reader looking at `Task { await self.publishProfile() }` finds the contract in the same place as the code.
+- Failure mode is unchanged from `main`: previously silent (errors swallowed), now still silent. PR #85 does not regress error visibility — it just stops blocking the UI on it.
+- Issue #88 is now load-bearing for the user-visible failure surface. If #88 ships, it will leverage the same dirty-flag mechanism this ADR describes; if it slips, the failure mode remains identical to pre-PR-#85 (silent + retry-on-reconnect).
+
+## Affected Files
+
+- `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` — `completeProfileSetup`, `completePaymentSetup` (commit 9ae695c, doc comments tightened in c5ab595)
+- `decisions/0014-optimistic-onboarding-publish.md` — this file


### PR DESCRIPTION
## Summary

Two onboarding fixes bundled here:

1. **Layout (#83 — the user-stranded bug)** — wrap `PaymentSetupView` in a `ScrollView` and pin the Continue button + empty-state warning to the bottom safe-area edge via `.safeAreaInset(edge: .bottom)`. The button is now reachable on every iPhone size class regardless of how many payment methods, custom methods, or Dynamic Type sizing the user has.

2. **Optimistic onboarding transitions** — `completeProfileSetup` and `completePaymentSetup` no longer await the Nostr relay round-trip before advancing `authState`. Both flip state immediately and spawn the publish as a fire-and-forget `Task`. Surfaced during device testing of #1: tapping Continue on either onboarding screen visibly froze for several seconds while a profile event (and a profile + backup event on payment setup) round-tripped a relay before the next view rendered.

Closes #83. Follow-up tracked in #88.

## Bug

A user reported getting stranded during onboarding after adding **Cash** as a payment method: the Continue button was pushed below the visible screen and there was no way to scroll. Force-quit and relaunch did not help — the saved selection re-rendered the same broken layout, permanently blocking onboarding on that device size.

Root cause was a fixed `VStack` with no scroll fallback: when `PaymentMethodPicker` grew tall enough (the first selection adds a header section and a row, which is the cliff on small devices), the middle `Spacer()` collapsed and the bottom content got clipped by the safe area. SwiftUI doesn't auto-scroll — it just clips.

This affects iPhone SE (3rd gen), 13/12 mini, and any device with Larger Text Dynamic Type, in either orientation.

## Layout fix (Option A from #83)

The standard iOS "long-form + sticky CTA" pattern:

```swift
ScrollView {
    VStack(spacing: 24) { /* icon, title, subtitle, PaymentMethodPicker */ }
}
.safeAreaInset(edge: .bottom) {
    /* empty-state warning + Continue button, on rfSurface background */
}
```

`safeAreaInset(edge: .bottom)` keeps the Continue button always visible above the home indicator, while the scrollable content above adapts to any height or Dynamic Type setting.

## Optimistic transition

Before:

```swift
public func completeProfileSetup(name: String) async {
    settings.setProfileName(name)
    syncCoordinator?.markDirty(.profile)
    await publishProfile()              // ← network round-trip, ~seconds
    authState = .paymentSetup           // ← view doesn't transition until publish returns
}
```

After:

```swift
public func completeProfileSetup(name: String) async {
    settings.setProfileName(name)
    syncCoordinator?.markDirty(.profile)
    authState = .paymentSetup           // ← view transitions instantly
    Task { await self.publishProfile() }
}
```

`syncCoordinator?.markDirty(...)` is persisted synchronously by `RoadflareSyncStateStore` (writes to UserDefaults). If the publish fails or is interrupted by app termination, the dirty flag survives, and `SyncCoordinator.flushPendingSyncPublishes` republishes on the next relay reconnect — same retry path that already exists for the rest of the app.

**Failure mode is unchanged from `main`**: `publishProfileAndMark` already swallows errors silently. This PR doesn't make that worse — it just stops blocking the UI on it. A user-visible "couldn't reach the relay" surface with retry is tracked in #88 and will land separately.

## Recovery for already-stranded users

This is a layout fix — there is no broken persistent state to repair. A user who got stranded on the prior build will be unstuck the moment they install this version: the saved `roadflarePaymentMethods` selection is preserved and the Continue button becomes reachable. New users never see the broken layout.

## Tests

The layout change is purely structural — button tap handler, picker, empty-state warning logic, and `completePaymentSetup()` call are all unchanged. The optimistic transition is a small surface-level change but lacks easy unit-testability without a publish-injection test seam in `AppState` (the project's existing test patterns assume `AppState()` with no injectable publish service). Adding that seam plus deterministic timeout tests is bundled into #88, where it pairs with the failure-surface watchdog work that needs the same infrastructure.

## Build / test

- `xcodebuild -scheme RoadFlare ... build` → **BUILD SUCCEEDED** (simulator and device).
- `xcodebuild -scheme RoadFlareTests` clean except for two pre-existing flakes in `ChatCoordinatorTests` (`subscribeToChatReplacesExistingSubscription`, `delayedPreviousSubscribeDoesNotReactivateStaleChat`) — confirmed they pass on clean `main` when run in isolation. Unrelated to this change.
- Installed and walked through onboarding on a physical iPhone 16e: the layout fix renders correctly and the optimistic-transition fix removes the multi-second freeze on Continue from both onboarding screens.

## Test plan

- [ ] Boot iPhone SE (3rd gen) simulator, complete onboarding past PaymentSetupView with 0 selections (Continue still visible)
- [ ] Same simulator: select Cash (the reported repro), confirm Continue is reachable
- [ ] Add multiple methods + a custom method, confirm content scrolls and Continue stays pinned
- [ ] Settings → Accessibility → Larger Text at max, repeat the above
- [ ] Confirm tapping Continue on ProfileSetupView and PaymentSetupView advances immediately (no multi-second freeze) on real-device cellular
- [ ] Confirm publish still happens in the background — check that profile + backup events appear on the relay shortly after onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)