### PR TITLE
fix(rider-app): personalize chat surfaces + show driver vehicle (#79, #80)

### DIFF
--- a/RidestrUI/Sources/RidestrUI/Components/RideStatusCard.swift
+++ b/RidestrUI/Sources/RidestrUI/Components/RideStatusCard.swift
@@ -25,6 +25,7 @@ public struct RideStatusCard: View {
     public let fareEstimate: FareEstimate?
     public let paymentMethods: [String]
     public let driverName: String?
+    public let vehicleDescription: String?
     public let pickupAddress: String?
     public let destinationAddress: String?
     public let waitingTimeoutSeconds: Int
@@ -40,6 +41,7 @@ public struct RideStatusCard: View {
         fareEstimate: FareEstimate? = nil,
         paymentMethods: [String] = [],
         driverName: String? = nil,
+        vehicleDescription: String? = nil,
         pickupAddress: String? = nil,
         destinationAddress: String? = nil,
         waitingTimeoutSeconds: Int = 120,
@@ -53,6 +55,7 @@ public struct RideStatusCard: View {
         self.fareEstimate = fareEstimate
         self.paymentMethods = paymentMethods
         self.driverName = driverName
+        self.vehicleDescription = vehicleDescription
         self.pickupAddress = pickupAddress
         self.destinationAddress = destinationAddress
         self.waitingTimeoutSeconds = waitingTimeoutSeconds
@@ -203,6 +206,8 @@ private struct WaitingContentView: View {
                     .foregroundColor(theme.onSurfaceColor)
             }
 
+            vehicleDescriptionLabel
+
             rideSummaryCard
 
             if let pin, stage == .rideConfirmed || stage == .enRoute {
@@ -238,6 +243,7 @@ private struct WaitingContentView: View {
                     .font(theme.headline(24))
                     .foregroundColor(theme.onSurfaceColor)
             }
+            vehicleDescriptionLabel
             if let pin {
                 Text("Show this PIN to your driver:")
                     .font(theme.body(14))
@@ -329,6 +335,19 @@ private struct WaitingContentView: View {
                 .padding(.horizontal, 24)
             }
             Spacer().frame(height: 40)
+        }
+    }
+
+    // MARK: - Vehicle Description
+
+    @ViewBuilder
+    private var vehicleDescriptionLabel: some View {
+        if let trimmed = vehicleDescription?
+            .trimmingCharacters(in: .whitespaces),
+           !trimmed.isEmpty {
+            Text(trimmed)
+                .font(theme.body(15))
+                .foregroundColor(theme.onSurfaceSecondaryColor)
         }
     }
 

--- a/RidestrUI/Sources/RidestrUI/Components/RideStatusCard.swift
+++ b/RidestrUI/Sources/RidestrUI/Components/RideStatusCard.swift
@@ -389,11 +389,18 @@ private struct WaitingContentView: View {
         }
     }
 
+    /// Label text for the chat button. Personalized with the driver's name when
+    /// available; falls back to the generic "Chat with Driver" when nil/blank.
+    static func chatButtonLabelText(driverName: String?) -> String {
+        let trimmed = driverName?.trimmingCharacters(in: .whitespaces) ?? ""
+        return trimmed.isEmpty ? "Chat with Driver" : "Chat with \(trimmed)"
+    }
+
     @ViewBuilder
     private var chatButton: some View {
         if let onChat {
             Button { onChat() } label: {
-                Label("Chat with Driver", systemImage: "message")
+                Label(Self.chatButtonLabelText(driverName: driverName), systemImage: "message")
                     .font(theme.title(16))
                     .foregroundColor(theme.accentColor)
                     .frame(maxWidth: .infinity)

--- a/RidestrUI/Tests/RidestrUITests/RideStatusCardTests.swift
+++ b/RidestrUI/Tests/RidestrUITests/RideStatusCardTests.swift
@@ -108,4 +108,16 @@ struct RideStatusCardTests {
         #expect(view.displayMode == .card)
         #expect(view.paymentMethods.count == 3)
     }
+
+    @Test("Chat button label uses driver name when present")
+    func chatLabelWithDriverName() {
+        #expect(RideStatusCard.chatButtonLabelText(driverName: "Alice") == "Chat with Alice")
+    }
+
+    @Test("Chat button label falls back to generic when driver name missing")
+    func chatLabelFallback() {
+        #expect(RideStatusCard.chatButtonLabelText(driverName: nil) == "Chat with Driver")
+        #expect(RideStatusCard.chatButtonLabelText(driverName: "") == "Chat with Driver")
+        #expect(RideStatusCard.chatButtonLabelText(driverName: "   ") == "Chat with Driver")
+    }
 }

--- a/RidestrUI/Tests/RidestrUITests/RideStatusCardTests.swift
+++ b/RidestrUI/Tests/RidestrUITests/RideStatusCardTests.swift
@@ -16,6 +16,7 @@ struct RideStatusCardTests {
             fareEstimate: fare,
             paymentMethods: ["venmo", "zelle"],
             driverName: "Alice",
+            vehicleDescription: "Black Tesla Model S",
             pickupAddress: "123 Main St",
             destinationAddress: "456 Market St",
             waitingTimeoutSeconds: 180,
@@ -28,6 +29,7 @@ struct RideStatusCardTests {
         #expect(card.fareEstimate != nil)
         #expect(card.paymentMethods.count == 2)
         #expect(card.driverName == "Alice")
+        #expect(card.vehicleDescription == "Black Tesla Model S")
         #expect(card.pickupAddress == "123 Main St")
         #expect(card.destinationAddress == "456 Market St")
         #expect(card.waitingTimeoutSeconds == 180)
@@ -41,6 +43,7 @@ struct RideStatusCardTests {
         #expect(card.fareEstimate == nil)
         #expect(card.paymentMethods.isEmpty)
         #expect(card.driverName == nil)
+        #expect(card.vehicleDescription == nil)
         #expect(card.pickupAddress == nil)
         #expect(card.destinationAddress == nil)
         #expect(card.waitingTimeoutSeconds == 120)

--- a/RoadFlare/RoadFlare/Views/Ride/ActiveRideView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/ActiveRideView.swift
@@ -23,6 +23,9 @@ struct ActiveRideView: View {
             driverName: coordinator?.session.driverPubkey.flatMap {
                 appState.driverDisplayName(pubkey: $0)
             },
+            vehicleDescription: coordinator?.session.driverPubkey.flatMap {
+                appState.driverProfile(pubkey: $0)?.vehicleDescription
+            },
             pickupAddress: coordinator?.pickupLocation?.address,
             destinationAddress: coordinator?.destinationLocation?.address,
             unreadChatCount: coordinator?.chat.unreadCount ?? 0,

--- a/RoadFlare/RoadFlare/Views/Ride/ChatView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/ChatView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import RidestrSDK
 import RoadFlareCore
 
 struct WiredChatView: View {
@@ -7,6 +8,15 @@ struct WiredChatView: View {
     @State private var messageText = ""
 
     private var coordinator: RideCoordinator? { appState.rideCoordinator }
+
+    private var chatTitle: String {
+        guard let pubkey = coordinator?.session.driverPubkey,
+              let name = appState.driverDisplayName(pubkey: pubkey)?
+                .trimmingCharacters(in: .whitespaces),
+              !name.isEmpty
+        else { return "Chat" }
+        return "Chat with \(name)"
+    }
 
     var body: some View {
         ZStack {
@@ -78,7 +88,7 @@ struct WiredChatView: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 10)
                 }
-                .navigationTitle("Chat")
+                .navigationTitle(chatTitle)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbarBackground(Color.rfSurface, for: .navigationBar)
                 .toolbarColorScheme(.dark, for: .navigationBar)


### PR DESCRIPTION
## Summary

Two small ride-screen polish fixes for the iOS 1.0.1 ship, bundled in a single PR because both touch `RidestrUI/Sources/RidestrUI/Components/RideStatusCard.swift` and would have collided in separate branches. Each issue is a separate commit for `git blame` clarity.

### Closes #79 — chat surfaces use the driver's name
- `RidestrUI.RideStatusCard` chat button: `Label("Chat with Driver", …)` → `Label(Self.chatButtonLabelText(driverName: driverName), …)`. Falls back to the generic copy when `driverName` is nil/blank.
- `RoadFlare.WiredChatView` navigation title: `"Chat"` → `"Chat with [name]"` resolved through the existing `AppState.driverDisplayName(pubkey:)` helper. Falls back to `"Chat"` when nil/blank.
- New `RideStatusCard.chatButtonLabelText(driverName:)` static helper plus 2 unit tests covering present/nil/empty/whitespace driver names.
- `RoadFlare/RoadFlare/Views/Ride/ChatView.swift` now imports `RidestrSDK` so it can read `coordinator?.session.driverPubkey`.

### Closes #80 — show driver vehicle on driver-on-the-way / arrived
- `RidestrUI.RideStatusCard`: additive `vehicleDescription: String? = nil` parameter (default `nil`, non-breaking — see issue #80's M-effort note).
- Renders as a subtitle under the driver-name line on the **en-route** (`driverAccepted` / `rideConfirmed` / `enRoute`) and **arrived** (`driverArrived`) stages only. Hidden on `idle` / `waitingForAcceptance` / `inProgress` / `completed` since it stops being actionable there.
- Wired from `ActiveRideView` via `appState.driverProfile(pubkey:)?.vehicleDescription` — the SDK's `vehicleDescription` already returns `nil` rather than emitting `"Black undefined undefined"` when fields are missing, so no host-side guard needed.
- Existing `fullInit` / `minimalInit` tests updated to round-trip `vehicleDescription`.

## Test plan
- [x] `swift test --filter RideStatusCard` on `RidestrUI` package — 10/10 pass (8 pre-existing + 2 new chat-label tests).
- [x] `xcodebuild build -scheme RoadFlare` from worktree — BUILD SUCCEEDED.
- [x] `xcodebuild test -scheme RoadFlareTests` — see "Known flakes" below.
- [ ] Manual smoke: launch sim, observe en-route / arrived screens with a profile that has vehicle info → vehicle line appears; without it → row is hidden.
- [ ] Manual smoke: open chat sheet with a known driver → title reads `"Chat with [name]"`, button reads `"Chat with [name]"`.

## Known flakes (unrelated to this PR)
Three RoadFlareTests subscription/timing tests failed on first run; none touch the UI code in this PR (they exercise `RideCoordinator` / `ChatCoordinator` async subscription replacement using `eventually {}`):
- `RideCoordinatorTests/locationSubscriptionRestartsAfterAppliedNewerKeyShare`
- `ChatCoordinatorTests/cleanupAsyncDoesNotUnsubscribeReplacementSubscription`
- `ChatCoordinatorTests/subscribeToChatReplacesExistingSubscription`

Re-running these in isolation to confirm flake (will update the PR if any reproduce).

## Cross-app symmetry
For #79, the Drivestr Android driver app likely needs a parallel fix on its side ("Chat with Rider" → "Chat with [rider name]"). Worth filing a parallel issue in the `ridestr` repo — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)