### PR TITLE
fix(rider): subscribe to Kind 30173 for live driver vehicles (#91)

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift
+++ b/RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift
@@ -69,6 +69,63 @@ public struct RoadflareLocationEvent: Sendable {
     public let createdAt: Int
 }
 
+// MARK: - Driver Availability (Kind 30173)
+
+/// The driver's currently active vehicle, parsed from a Kind 30173 event.
+///
+/// Treat as a single overwrite-only unit: a Kind 30173 update replaces the entire
+/// `VehicleInfo`, never merges field-by-field. Drivestr is a multi-vehicle app and
+/// `car_color` (or any field) being absent on a fresh event is a genuine signal of
+/// the driver's current vehicle, not an invitation to keep stale data from the
+/// previous vehicle. See issue #91.
+public struct VehicleInfo: Sendable, Equatable {
+    public let make: String?
+    public let model: String?
+    public let color: String?
+
+    public init(make: String? = nil, model: String? = nil, color: String? = nil) {
+        self.make = make
+        self.model = model
+        self.color = color
+    }
+
+    /// Display string built from color + make + model. Nil when no fields are set.
+    /// Mirrors `UserProfileContent.vehicleDescription` so swapping the source
+    /// (Kind 30173 vs Kind 0 fallback) does not change the rendered text shape.
+    public var description: String? {
+        let parts = [color, make, model].compactMap { $0?.nilIfEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: " ")
+    }
+}
+
+/// Parsed content of a driver availability event (Kind 30173).
+///
+/// Cross-platform shape with Drivestr's `DriverAvailabilityEvent.kt`. Vehicle fields
+/// are optional because a driver may publish availability without a vehicle attached
+/// (e.g. going offline). The `status` mirrors the on-wire `"available"` / `"offline"`
+/// strings — we keep the raw form so future status values don't require an SDK bump.
+public struct DriverAvailabilityEventData: Sendable, Equatable {
+    public let eventId: String
+    public let driverPubkey: String
+    public let createdAt: Int
+    public let status: String?
+    public let vehicle: VehicleInfo
+
+    public init(
+        eventId: String,
+        driverPubkey: String,
+        createdAt: Int,
+        status: String?,
+        vehicle: VehicleInfo
+    ) {
+        self.eventId = eventId
+        self.driverPubkey = driverPubkey
+        self.createdAt = createdAt
+        self.status = status
+        self.vehicle = vehicle
+    }
+}
+
 // MARK: - Followed Driver
 
 /// A driver in the rider's trusted network.

--- a/RidestrSDK/Sources/RidestrSDK/Nostr/NostrFilter.swift
+++ b/RidestrSDK/Sources/RidestrSDK/Nostr/NostrFilter.swift
@@ -213,6 +213,18 @@ extension NostrFilter {
             .dTags(["roadflare-location"])
     }
 
+    /// Filter for Kind 30173 driver availability events from specific drivers.
+    ///
+    /// The author filter restricts the subscription to the rider's followed drivers —
+    /// without it the rider would receive every public Kind 30173 broadcast on the
+    /// network, which is a privacy/bandwidth disaster. Mirrors `roadflareLocations`.
+    public static func driverAvailability(driverPubkeys: [String]) -> NostrFilter {
+        NostrFilter()
+            .kinds([.driverAvailability])
+            .authors(driverPubkeys)
+            .dTags(["rideshare-availability"])
+    }
+
     /// Filter for RoadFlare key shares addressed to this user (Kind 3186).
     public static func keyShares(myPubkey: String) -> NostrFilter {
         NostrFilter()

--- a/RidestrSDK/Sources/RidestrSDK/Nostr/RideshareEventParser.swift
+++ b/RidestrSDK/Sources/RidestrSDK/Nostr/RideshareEventParser.swift
@@ -360,6 +360,33 @@ public enum RideshareEventParser {
         )
     }
 
+    // MARK: - Driver Availability (Kind 30173)
+
+    /// Parse a Kind 30173 driver availability event (plaintext JSON content).
+    ///
+    /// Returns nil when the event is the wrong kind or when the JSON envelope cannot be
+    /// decoded — vehicle fields are individually optional so a driver going offline with
+    /// no vehicle attached still produces a `DriverAvailabilityEventData` (with an empty
+    /// `VehicleInfo`). Cross-platform shape with Drivestr's `DriverAvailabilityEvent.kt`.
+    public static func parseDriverAvailability(event: NostrEvent) -> DriverAvailabilityEventData? {
+        guard event.kind == EventKind.driverAvailability.rawValue else { return nil }
+        guard let data = event.content.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        return DriverAvailabilityEventData(
+            eventId: event.id,
+            driverPubkey: event.pubkey,
+            createdAt: event.createdAt,
+            status: json["status"] as? String,
+            vehicle: VehicleInfo(
+                make: json["car_make"] as? String,
+                model: json["car_model"] as? String,
+                color: json["car_color"] as? String
+            )
+        )
+    }
+
     // MARK: - Followed Drivers List (Kind 30011)
 
     /// Parse and decrypt the followed drivers list (own backup).

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
@@ -21,6 +21,13 @@ public final class FollowedDriversRepository: @unchecked Sendable {
     /// In-memory driver profile cache (from Kind 0 fetches). Not persisted.
     public private(set) var driverProfiles: [String: UserProfileContent] = [:]
 
+    /// In-memory active-vehicle cache (from Kind 30173 driver-availability events).
+    /// Not persisted. Treated as authoritative for *active* vehicle info; the rider's
+    /// driver-detail / list views fall back to the Kind 0 profile only when this is nil.
+    /// Retained across availability flips (online → offline) so the rider can still see
+    /// the last vehicle the driver drove. Cleared only on `removeDriver` / `clearAll`.
+    public private(set) var driverVehicles: [String: VehicleInfo] = [:]
+
     /// Drivers with stale keys (detected via Kind 30012 comparison). In-memory only.
     public private(set) var staleKeyPubkeys: Set<String> = []
 
@@ -70,6 +77,7 @@ public final class FollowedDriversRepository: @unchecked Sendable {
             driverNames.removeValue(forKey: pubkey)
             driverLocations.removeValue(forKey: pubkey)
             driverProfiles.removeValue(forKey: pubkey)
+            driverVehicles.removeValue(forKey: pubkey)
             staleKeyPubkeys.remove(pubkey)
             driversSnapshot = drivers
             namesSnapshot = driverNames
@@ -210,6 +218,30 @@ public final class FollowedDriversRepository: @unchecked Sendable {
         }
     }
 
+    // MARK: - Driver Vehicles (in-memory only)
+
+    /// Replace the cached active vehicle for `driverPubkey` with `vehicle`.
+    ///
+    /// **Overwrite semantics — never merge.** A Kind 30173 update is a complete
+    /// snapshot of the driver's currently active vehicle: when the driver swaps
+    /// from a Camry to a Tesla, the Tesla event may legitimately omit `car_color`,
+    /// and the rider must see that omission rather than the Camry's silver. The
+    /// signed `VehicleInfo` always replaces the prior entry verbatim.
+    ///
+    /// No-op when `driverPubkey` is not in the followed-drivers list — protects
+    /// against late events arriving after a driver was unfollowed.
+    public func updateDriverVehicle(pubkey: String, vehicle: VehicleInfo) {
+        lock.withLock {
+            guard drivers.contains(where: { $0.pubkey == pubkey }) else { return }
+            driverVehicles[pubkey] = vehicle
+        }
+    }
+
+    /// Latest cached active vehicle for `pubkey`, or nil if no Kind 30173 has arrived.
+    public func cachedDriverVehicle(pubkey: String) -> VehicleInfo? {
+        lock.withLock { driverVehicles[pubkey] }
+    }
+
     /// Cache a driver's full profile from their Kind 0 event.
     public func cacheDriverProfile(pubkey: String, profile: UserProfileContent) {
         var snapshot: [String: String]?
@@ -342,6 +374,7 @@ public final class FollowedDriversRepository: @unchecked Sendable {
             driverNames = [:]
             driverLocations = [:]
             driverProfiles = [:]
+            driverVehicles = [:]
             staleKeyPubkeys = []
             driversSnapshot = drivers
             namesSnapshot = driverNames
@@ -426,6 +459,7 @@ public final class FollowedDriversRepository: @unchecked Sendable {
             driverNames.removeValue(forKey: pubkey)
             driverLocations.removeValue(forKey: pubkey)
             driverProfiles.removeValue(forKey: pubkey)
+            driverVehicles.removeValue(forKey: pubkey)
             staleKeyPubkeys.remove(pubkey)
         }
     }

--- a/RidestrSDK/Tests/RidestrSDKTests/Nostr/RideshareEventParserTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/Nostr/RideshareEventParserTests.swift
@@ -603,4 +603,77 @@ struct RideshareEventParserTests {
         )
         #expect(decrypted == "1234")
     }
+
+    // MARK: - Driver Availability (Kind 30173)
+
+    @Test func parseDriverAvailabilityFullVehicle() {
+        let event = NostrEvent(
+            id: "avail1", pubkey: "driver1", createdAt: 1_700_000_000,
+            kind: EventKind.driverAvailability.rawValue,
+            tags: [["d", "rideshare-availability"]],
+            content: #"{"status":"available","car_make":"Toyota","car_model":"Camry","car_color":"Silver"}"#,
+            sig: "sig"
+        )
+        let parsed = RideshareEventParser.parseDriverAvailability(event: event)
+        #expect(parsed?.driverPubkey == "driver1")
+        #expect(parsed?.status == "available")
+        #expect(parsed?.vehicle.make == "Toyota")
+        #expect(parsed?.vehicle.model == "Camry")
+        #expect(parsed?.vehicle.color == "Silver")
+        #expect(parsed?.vehicle.description == "Silver Toyota Camry")
+    }
+
+    @Test func parseDriverAvailabilityPartialVehicleClearsOmittedFields() {
+        // Repro of issue #91: Drivestr is multi-vehicle. When the driver's *current*
+        // event omits a field (e.g. they swapped to a vehicle without a recorded
+        // color), the parsed VehicleInfo must reflect the omission, not silently
+        // inherit from a previous vehicle. The cache layer enforces no-merge; this
+        // test pins parser-side behaviour that absent JSON keys decode to nil.
+        let event = NostrEvent(
+            id: "avail2", pubkey: "driver1", createdAt: 1_700_000_001,
+            kind: EventKind.driverAvailability.rawValue,
+            tags: [["d", "rideshare-availability"]],
+            content: #"{"status":"available","car_make":"Tesla","car_model":"Model 3"}"#,
+            sig: "sig"
+        )
+        let parsed = RideshareEventParser.parseDriverAvailability(event: event)
+        #expect(parsed?.vehicle.make == "Tesla")
+        #expect(parsed?.vehicle.model == "Model 3")
+        #expect(parsed?.vehicle.color == nil)
+        #expect(parsed?.vehicle.description == "Tesla Model 3")
+    }
+
+    @Test func parseDriverAvailabilityOfflineWithNoVehicle() {
+        let event = NostrEvent(
+            id: "avail3", pubkey: "driver1", createdAt: 1_700_000_002,
+            kind: EventKind.driverAvailability.rawValue,
+            tags: [["d", "rideshare-availability"]],
+            content: #"{"status":"offline"}"#,
+            sig: "sig"
+        )
+        let parsed = RideshareEventParser.parseDriverAvailability(event: event)
+        #expect(parsed?.status == "offline")
+        #expect(parsed?.vehicle.make == nil)
+        #expect(parsed?.vehicle.model == nil)
+        #expect(parsed?.vehicle.color == nil)
+        #expect(parsed?.vehicle.description == nil)
+    }
+
+    @Test func parseDriverAvailabilityWrongKindReturnsNil() {
+        let event = NostrEvent(
+            id: "avail4", pubkey: "driver1", createdAt: 1_700_000_003,
+            kind: EventKind.metadata.rawValue, // wrong kind
+            tags: [], content: #"{"car_make":"Tesla"}"#, sig: "sig"
+        )
+        #expect(RideshareEventParser.parseDriverAvailability(event: event) == nil)
+    }
+
+    @Test func parseDriverAvailabilityMalformedJSONReturnsNil() {
+        let event = NostrEvent(
+            id: "avail5", pubkey: "driver1", createdAt: 1_700_000_004,
+            kind: EventKind.driverAvailability.rawValue,
+            tags: [], content: "not json", sig: "sig"
+        )
+        #expect(RideshareEventParser.parseDriverAvailability(event: event) == nil)
+    }
 }

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/FollowedDriversRepositoryTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/FollowedDriversRepositoryTests.swift
@@ -358,9 +358,88 @@ struct FollowedDriversRepositoryTests {
         repo.addDriver(FollowedDriver(pubkey: "d1"))
         repo.cacheDriverName(pubkey: "d1", name: "Alice")
         repo.updateDriverLocation(pubkey: "d1", latitude: 40.0, longitude: -74.0, status: "online", timestamp: 100, keyVersion: 1)
+        repo.updateDriverVehicle(pubkey: "d1", vehicle: VehicleInfo(make: "Toyota"))
         repo.clearAll()
         #expect(repo.drivers.isEmpty)
         #expect(repo.driverNames.isEmpty)
         #expect(repo.driverLocations.isEmpty)
+        #expect(repo.driverVehicles.isEmpty)
+    }
+
+    // MARK: - Driver Vehicles (Kind 30173 cache)
+
+    /// Single-vehicle baseline: matches current behaviour for a driver that only
+    /// ever publishes one vehicle. The cache should reflect exactly what was sent.
+    @Test func updateDriverVehicleSingleVehicleBaseline() {
+        let repo = makeRepo()
+        repo.addDriver(FollowedDriver(pubkey: "d1"))
+        repo.updateDriverVehicle(
+            pubkey: "d1",
+            vehicle: VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        )
+        #expect(repo.driverVehicles["d1"] == VehicleInfo(make: "Toyota", model: "Camry", color: "Silver"))
+        #expect(repo.cachedDriverVehicle(pubkey: "d1")?.description == "Silver Toyota Camry")
+    }
+
+    /// The bug from issue #91: driver swaps from a Camry to a Tesla. Riders must see
+    /// the Tesla after the swap — even when the Tesla event omits car_color, which
+    /// MUST clear the previously-cached Silver rather than silently merge it forward.
+    @Test func updateDriverVehicleOverwriteSemanticsClearOmittedFields() {
+        let repo = makeRepo()
+        repo.addDriver(FollowedDriver(pubkey: "d1"))
+        repo.updateDriverVehicle(
+            pubkey: "d1",
+            vehicle: VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        )
+        repo.updateDriverVehicle(
+            pubkey: "d1",
+            vehicle: VehicleInfo(make: "Tesla", model: "Model 3", color: nil)
+        )
+        let after = repo.driverVehicles["d1"]
+        #expect(after?.make == "Tesla")
+        #expect(after?.model == "Model 3")
+        #expect(after?.color == nil, "color must be cleared, not merged from prior Camry entry")
+        #expect(after?.description == "Tesla Model 3")
+    }
+
+    /// Each followed driver's vehicle must be tracked independently.
+    @Test func updateDriverVehicleIndependentPerDriver() {
+        let repo = makeRepo()
+        repo.addDriver(FollowedDriver(pubkey: "d1"))
+        repo.addDriver(FollowedDriver(pubkey: "d2"))
+        repo.updateDriverVehicle(pubkey: "d1", vehicle: VehicleInfo(make: "Toyota"))
+        repo.updateDriverVehicle(pubkey: "d2", vehicle: VehicleInfo(make: "Tesla"))
+        #expect(repo.driverVehicles["d1"]?.make == "Toyota")
+        #expect(repo.driverVehicles["d2"]?.make == "Tesla")
+    }
+
+    /// Late events for an unfollowed driver should not poison the cache. Mirrors
+    /// the existing protection on cacheDriverProfile / cacheDriverName.
+    @Test func updateDriverVehicleIgnoresUnfollowedDriver() {
+        let repo = makeRepo()
+        repo.updateDriverVehicle(pubkey: "ghost", vehicle: VehicleInfo(make: "Tesla"))
+        #expect(repo.driverVehicles["ghost"] == nil)
+    }
+
+    @Test func removeDriverClearsVehicleCache() {
+        let repo = makeRepo()
+        repo.addDriver(FollowedDriver(pubkey: "d1"))
+        repo.updateDriverVehicle(pubkey: "d1", vehicle: VehicleInfo(make: "Toyota"))
+        repo.removeDriver(pubkey: "d1")
+        #expect(repo.driverVehicles["d1"] == nil)
+    }
+
+    @Test func replaceAllReconcilesVehicleCacheForRemovedDrivers() {
+        let repo = makeRepo()
+        repo.addDriver(FollowedDriver(pubkey: "d1"))
+        repo.addDriver(FollowedDriver(pubkey: "d2"))
+        repo.updateDriverVehicle(pubkey: "d1", vehicle: VehicleInfo(make: "Toyota"))
+        repo.updateDriverVehicle(pubkey: "d2", vehicle: VehicleInfo(make: "Tesla"))
+
+        // Remote sync now lists only d1 — d2 was unfollowed elsewhere.
+        repo.replaceAll(drivers: [FollowedDriver(pubkey: "d1")])
+
+        #expect(repo.driverVehicles["d1"]?.make == "Toyota", "kept driver retains cache")
+        #expect(repo.driverVehicles["d2"] == nil, "removed driver's vehicle is reconciled away")
     }
 }

--- a/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift
@@ -348,6 +348,9 @@ struct AddDriverSheet: View {
             // effect that the new flow would otherwise skip on re-add).
             if appState.hasKeyForDriver(pubkey: hexPubkey) {
                 appState.restartKeyShareSubscription()
+                // Rebuild the Kind 30173 author filter to include the re-added driver
+                // so their currently-active vehicle shows up immediately. See issue #91.
+                appState.restartDriverAvailabilitySubscription()
                 return
             }
 
@@ -356,6 +359,7 @@ struct AddDriverSheet: View {
                 // Re-add: backup carried the key. Refresh the subscription
                 // (PR #54) but skip Kind 3187 to avoid Bug 3.
                 appState.restartKeyShareSubscription()
+                appState.restartDriverAvailabilitySubscription()
             case .backupUnavailable:
                 // Couldn't tell whether this is a re-add or a new follow.
                 // Fall through to the new-follow handshake; on a re-add this

--- a/RoadFlare/RoadFlare/Views/Ride/ActiveRideView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/ActiveRideView.swift
@@ -23,9 +23,15 @@ struct ActiveRideView: View {
             driverName: coordinator?.session.driverPubkey.flatMap {
                 appState.driverDisplayName(pubkey: $0)
             },
-            vehicleDescription: coordinator?.session.driverPubkey.flatMap {
-                appState.driverProfile(pubkey: $0)?.vehicleDescription
-            },
+            // Prefer the Kind 30173 snapshot taken at acceptance — locks the active
+            // ride to the agreed vehicle even if the driver swaps mid-trip. Fall
+            // back to the Kind 0 profile when no snapshot is available (driver
+            // never published Kind 30173, or app cold-started mid-ride before the
+            // first availability event arrived). See issue #91.
+            vehicleDescription: coordinator?.activeRideVehicle?.description
+                ?? coordinator?.session.driverPubkey.flatMap {
+                    appState.driverProfile(pubkey: $0)?.vehicleDescription
+                },
             pickupAddress: coordinator?.pickupLocation?.address,
             destinationAddress: coordinator?.destinationLocation?.address,
             unreadChatCount: coordinator?.chat.unreadCount ?? 0,

--- a/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
@@ -74,6 +74,9 @@ public struct DriverDetailViewState: Equatable, Sendable, Identifiable {
     ///   - displayName: Display name from the repository if known; the factory falls back to driver.name then a short pubkey prefix.
     ///   - location: The driver's latest cached location broadcast, if any.
     ///   - profile: The driver's cached Kind 0 profile, if available.
+    ///   - vehicle: The driver's currently active vehicle from Kind 30173, if known.
+    ///     Authoritative when present; the Kind 0 profile fallback only matters
+    ///     for drivers whose Drivestr session never published Kind 30173. See issue #91.
     ///   - isKeyStale: Whether this driver's key has been flagged as stale.
     ///   - canPing: Whether the ping action is currently available for this driver.
     ///   - referenceDate: Used for relative timestamp formatting (injectable for testing).
@@ -84,6 +87,7 @@ public struct DriverDetailViewState: Equatable, Sendable, Identifiable {
         displayName: String?,
         location: CachedDriverLocation?,
         profile: UserProfileContent?,
+        vehicle: VehicleInfo? = nil,
         isKeyStale: Bool,
         canPing: Bool,
         referenceDate: Date = .now,
@@ -119,7 +123,9 @@ public struct DriverDetailViewState: Equatable, Sendable, Identifiable {
             statusLabel: statusLabel,
             canRequestRide: canRequestRide,
             pictureURL: profile?.picture,
-            vehicleDescription: profile?.vehicleDescription,
+            // Kind 30173 (live active vehicle) wins; Kind 0 profile is the fallback
+            // for drivers whose Drivestr session never published Kind 30173. See issue #91.
+            vehicleDescription: vehicle?.description ?? profile?.vehicleDescription,
             canPing: canPing,
             hasKey: driver.hasKey,
             keyVersion: driver.roadflareKey?.version,

--- a/RoadFlare/RoadFlareCore/Presentation/DriverListItem.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverListItem.swift
@@ -61,6 +61,9 @@ public struct DriverListItem: Equatable, Sendable, Identifiable {
     ///   - displayName: Display name from the repository if known; the factory falls back to driver.name then a short pubkey prefix.
     ///   - location: The driver's latest cached location broadcast, if any.
     ///   - profile: The driver's cached Kind 0 profile, if available.
+    ///   - vehicle: The driver's currently active vehicle from Kind 30173, if known.
+    ///     Authoritative when present; the Kind 0 profile fallback only matters
+    ///     for drivers whose Drivestr session never published Kind 30173. See issue #91.
     ///   - isKeyStale: Whether this driver's key has been flagged as stale.
     ///   - canPing: Whether the ping action is currently available.
     public static func from(
@@ -68,6 +71,7 @@ public struct DriverListItem: Equatable, Sendable, Identifiable {
         displayName: String?,
         location: CachedDriverLocation?,
         profile: UserProfileContent?,
+        vehicle: VehicleInfo? = nil,
         isKeyStale: Bool,
         canPing: Bool
     ) -> DriverListItem {
@@ -84,7 +88,7 @@ public struct DriverListItem: Equatable, Sendable, Identifiable {
             displayName: resolvedName,
             status: status,
             pictureURL: profile?.picture,
-            vehicleDescription: profile?.vehicleDescription,
+            vehicleDescription: vehicle?.description ?? profile?.vehicleDescription,
             canPing: canPing
         )
     }

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift
@@ -19,6 +19,7 @@ extension AppState {
                 displayName: repo.cachedDriverName(pubkey: driver.pubkey),
                 location: repo.driverLocations[driver.pubkey],
                 profile: repo.driverProfiles[driver.pubkey],
+                vehicle: repo.driverVehicles[driver.pubkey],
                 isKeyStale: repo.staleKeyPubkeys.contains(driver.pubkey),
                 canPing: repo.canPingDriver(driver)
             )
@@ -35,6 +36,7 @@ extension AppState {
             displayName: repo.cachedDriverName(pubkey: pubkey),
             location: repo.driverLocations[pubkey],
             profile: repo.driverProfiles[pubkey],
+            vehicle: repo.driverVehicles[pubkey],
             isKeyStale: repo.staleKeyPubkeys.contains(pubkey),
             canPing: repo.canPingDriver(driver)
         )

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -770,7 +770,10 @@ public final class AppState {
         syncCoordinator?.teardown(clearPersistedState: clearPersistedSyncState)
         syncCoordinator = nil
 
-        // 4. Repository data (callbacks already nil'd by teardown)
+        // 4. Repository data (callbacks already nil'd by teardown).
+        //    `clearAll()` zeroes drivers, names, locations, profiles, vehicles
+        //    (Kind 30173 cache), and the stale-key set — see
+        //    FollowedDriversRepository.clearAll().
         driversRepository?.clearAll()
         if driversRepository == nil {
             driversPersistence.saveDrivers([])

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -312,6 +312,13 @@ public final class AppState {
         rideCoordinator?.startKeyShareSubscription()
     }
 
+    /// Restart the Kind 30173 driver-availability subscription. Sibling of
+    /// `restartKeyShareSubscription`; called whenever the followed-drivers list
+    /// changes so the author filter is rebuilt against the new set. See issue #91.
+    public func restartDriverAvailabilitySubscription() {
+        rideCoordinator?.startDriverAvailabilitySubscription()
+    }
+
     /// Send Kind 3187 follow notification to a driver (real-time nudge).
     public func sendFollowNotification(driverPubkey: String) async {
         guard let kp = keypair, let rm = relayManager,
@@ -333,6 +340,9 @@ public final class AppState {
         // subscription forces re-delivery of both historical (12-hour window) and
         // future key share events. See issue #54.
         rideCoordinator?.startKeyShareSubscription()
+        // Same reasoning for Kind 30173: rebuild the author filter to include the
+        // newly added driver so the rider sees their active vehicle. See issue #91.
+        rideCoordinator?.startDriverAvailabilitySubscription()
     }
 
     // MARK: - Driver Ping
@@ -879,6 +889,7 @@ extension AppState {
         Task {
             await rideCoordinator?.publishFollowedDriversList()
             rideCoordinator?.startLocationSubscriptions()
+            rideCoordinator?.startDriverAvailabilitySubscription()
         }
     }
 
@@ -891,9 +902,12 @@ extension AppState {
     }
 
     /// Clear all cached driver locations and restart location subscriptions.
+    /// Also restarts the Kind 30173 availability subscription so the rider's
+    /// pull-to-refresh re-pulls active vehicles, not just locations.
     public func refreshDriverLocations() {
         driversRepository?.clearDriverLocations()
         rideCoordinator?.startLocationSubscriptions()
+        rideCoordinator?.startDriverAvailabilitySubscription()
     }
 
     /// Fetch a driver's Kind 0 profile from Nostr. Returns nil if the service

--- a/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
@@ -31,6 +31,17 @@ final class LocationCoordinator {
     /// vehicle as the active-ride snapshot when it would otherwise stay nil
     /// (cold-start mid-ride, or fresh acceptance whose cache was empty at the
     /// transition). See issue #91 / `RideCoordinator.adoptVehicleIfNeeded`.
+    ///
+    /// Not `@Sendable` (unlike sibling SDK callbacks `onProfileChanged` /
+    /// `onDriversChanged`): `LocationCoordinator` is `@MainActor`, so the
+    /// callsite always runs on the main actor and the closure cannot escape.
+    ///
+    /// Fires even when `driversRepository.updateDriverVehicle(...)` was a no-op
+    /// (e.g. driver unfollowed before this event arrived). This is intentional:
+    /// the active-ride snapshot represents "the vehicle the rider agreed to,"
+    /// which is meaningful for an in-flight ride even if the rider unfollowed
+    /// the driver mid-trip. `adoptVehicleIfNeeded` independently gates on the
+    /// active session driverPubkey.
     var onDriverVehicleUpdate: ((String, VehicleInfo) -> Void)?
 
     var lastError: String?

--- a/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
@@ -33,8 +33,20 @@ final class LocationCoordinator {
     /// transition). See issue #91 / `RideCoordinator.adoptVehicleIfNeeded`.
     ///
     /// Not `@Sendable` (unlike sibling SDK callbacks `onProfileChanged` /
-    /// `onDriversChanged`): `LocationCoordinator` is `@MainActor`, so the
-    /// callsite always runs on the main actor and the closure cannot escape.
+    /// `onDriversChanged`). Safety relies on TWO conditions, both of which
+    /// are load-bearing:
+    ///   1. `LocationCoordinator` is `@MainActor`.
+    ///   2. The single call site (`handleDriverAvailabilityEvent`) is invoked
+    ///      from an unstructured `Task { ... }` inside `@MainActor` code, which
+    ///      inherits actor isolation — so the callback always fires on the main
+    ///      actor.
+    /// Note that "stored optional closure" is by definition `@escaping`; the
+    /// safety here is purely actor-isolation, not non-escaping. Refactoring the
+    /// `Task { ... }` in `startDriverAvailabilitySubscription` to `Task.detached`
+    /// would silently break condition (2) and produce a data race with
+    /// `RideCoordinator.activeRideVehicle`. If detached execution is ever needed,
+    /// mark this `@Sendable` and audit `adoptVehicleIfNeeded` for cross-actor
+    /// access.
     ///
     /// Fires even when `driversRepository.updateDriverVehicle(...)` was a no-op
     /// (e.g. driver unfollowed before this event arrived). This is intentional:

--- a/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
@@ -26,6 +26,13 @@ final class LocationCoordinator {
     private var activeKeyShareSubscription: ManagedSubscription?
     private var activeDriverAvailabilitySubscription: ManagedSubscription?
 
+    /// Hook fired after every successfully parsed Kind 30173 event, so an outer
+    /// coordinator (currently `RideCoordinator`) can opportunistically adopt the
+    /// vehicle as the active-ride snapshot when it would otherwise stay nil
+    /// (cold-start mid-ride, or fresh acceptance whose cache was empty at the
+    /// transition). See issue #91 / `RideCoordinator.adoptVehicleIfNeeded`.
+    var onDriverVehicleUpdate: ((String, VehicleInfo) -> Void)?
+
     var lastError: String?
 
     init(relayManager: any RelayManagerProtocol, keypair: NostrKeypair,
@@ -178,6 +185,7 @@ final class LocationCoordinator {
         // the driver's current active vehicle in full. Merging field-by-field would let
         // stale values leak across vehicle swaps. See issue #91.
         driversRepository.updateDriverVehicle(pubkey: parsed.driverPubkey, vehicle: parsed.vehicle)
+        onDriverVehicleUpdate?(parsed.driverPubkey, parsed.vehicle)
     }
 
     // MARK: - Key Share Subscription (Kind 3186)

--- a/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
@@ -24,6 +24,7 @@ final class LocationCoordinator {
 
     private var activeLocationSubscription: ManagedSubscription?
     private var activeKeyShareSubscription: ManagedSubscription?
+    private var activeDriverAvailabilitySubscription: ManagedSubscription?
 
     var lastError: String?
 
@@ -114,6 +115,71 @@ final class LocationCoordinator {
         }
     }
 
+    // MARK: - Driver Availability Subscription (Kind 30173)
+
+    /// Subscribe to Kind 30173 driver-availability events from followed drivers, so the
+    /// rider sees the driver's currently active vehicle. Mirrors `startLocationSubscriptions`:
+    /// the author filter is restricted to followed drivers, and the subscription must be
+    /// restarted whenever the followed-drivers list changes.
+    ///
+    /// Without this, the rider only ever sees Kind 0 vehicle data, which Drivestr does not
+    /// reliably re-publish when a multi-vehicle driver swaps active vehicles. See issue #91.
+    func startDriverAvailabilitySubscription() {
+        let pubkeys = driversRepository.allPubkeys
+        let previous = takeDriverAvailabilitySubscription()
+
+        guard !pubkeys.isEmpty else {
+            if let previous {
+                Task {
+                    previous.task.cancel()
+                    await relayManager.unsubscribe(previous.id)
+                }
+            }
+            return
+        }
+
+        let subId = SubscriptionID("driver-availability")
+        let generation = UUID()
+
+        let task = Task {
+            previous?.task.cancel()
+            if let oldId = previous?.id {
+                await relayManager.unsubscribe(oldId)
+            }
+            guard !Task.isCancelled,
+                  activeDriverAvailabilitySubscription?.generation == generation else { return }
+
+            do {
+                let filter = NostrFilter.driverAvailability(driverPubkeys: pubkeys)
+                let stream = try await relayManager.subscribe(filter: filter, id: subId)
+                guard !Task.isCancelled,
+                      activeDriverAvailabilitySubscription?.generation == generation else { return }
+
+                for await event in stream {
+                    guard !Task.isCancelled,
+                          activeDriverAvailabilitySubscription?.generation == generation else { break }
+                    handleDriverAvailabilityEvent(event)
+                }
+            } catch {
+                guard activeDriverAvailabilitySubscription?.generation == generation else { return }
+                lastError = "Driver availability subscription failed: \(error.localizedDescription)"
+            }
+        }
+        activeDriverAvailabilitySubscription = ManagedSubscription(id: subId, generation: generation, task: task)
+    }
+
+    func handleDriverAvailabilityEvent(_ event: NostrEvent) {
+        guard let parsed = RideshareEventParser.parseDriverAvailability(event: event) else {
+            AppLogger.location.debug("Driver availability event ignored — unparseable from \(event.pubkey.prefix(8))")
+            return
+        }
+        // Overwrite-only: the cache always replaces the prior entry, even when fields are
+        // nil — Kind 30173 is a parameterized replaceable event, so the latest payload is
+        // the driver's current active vehicle in full. Merging field-by-field would let
+        // stale values leak across vehicle swaps. See issue #91.
+        driversRepository.updateDriverVehicle(pubkey: parsed.driverPubkey, vehicle: parsed.vehicle)
+    }
+
     // MARK: - Key Share Subscription (Kind 3186)
 
     func startKeyShareSubscription() {
@@ -184,10 +250,13 @@ final class LocationCoordinator {
     func stopAll() async {
         let location = takeLocationSubscription()
         let keyShare = takeKeyShareSubscription()
+        let availability = takeDriverAvailabilitySubscription()
         location?.task.cancel()
         keyShare?.task.cancel()
+        availability?.task.cancel()
         if let id = location?.id { await relayManager.unsubscribe(id) }
         if let id = keyShare?.id { await relayManager.unsubscribe(id) }
+        if let id = availability?.id { await relayManager.unsubscribe(id) }
     }
 
     private func takeLocationSubscription() -> ManagedSubscription? {
@@ -199,6 +268,12 @@ final class LocationCoordinator {
     private func takeKeyShareSubscription() -> ManagedSubscription? {
         let previous = activeKeyShareSubscription
         activeKeyShareSubscription = nil
+        return previous
+    }
+
+    private func takeDriverAvailabilitySubscription() -> ManagedSubscription? {
+        let previous = activeDriverAvailabilitySubscription
+        activeDriverAvailabilitySubscription = nil
         return previous
     }
 }

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -44,11 +44,23 @@ public final class RideCoordinator {
     /// the vehicle they agreed to even if the driver re-publishes Kind 30173 with
     /// a different vehicle mid-ride.
     ///
-    /// In-memory only. On cold-start mid-ride, the snapshot is re-derived from the
-    /// live cache during `restoreRideState()`; if the driver swapped vehicles in the
-    /// meantime, the rebuilt snapshot reflects the *current* cache, not the original
-    /// agreement. Persisting through `PersistedRideState` would require a
-    /// cross-platform schema change and is intentionally deferred. See issue #91.
+    /// **In-memory only.** Populated in two ways:
+    ///   1. **Fresh acceptance** — `sessionDidChangeStage(.waitingForAcceptance →
+    ///      .driverAccepted)` reads the current `driverVehicles` cache. If the cache
+    ///      already has an entry for this driver, the snapshot locks immediately.
+    ///   2. **Cold-start mid-ride / cache empty at acceptance** — `restoreRideState()`
+    ///      reads the cache during `init`, but the Kind 30173 subscription only starts
+    ///      later in `restoreLiveSubscriptions()`, so the cache is always empty at
+    ///      restore time. To recover, `adoptVehicleIfNeeded(driverPubkey:vehicle:)` is
+    ///      called from `LocationCoordinator` on every Kind 30173 event; the *first*
+    ///      event observed for the active driver becomes the snapshot, which then
+    ///      locks for the rest of the ride.
+    ///
+    /// Trade-off: a driver who swaps vehicles between original acceptance and the
+    /// rider's cold-start will have the rider lock to the *new* vehicle on adopt,
+    /// not the original agreement. Persisting through `PersistedRideState` would
+    /// require a cross-platform schema change and is intentionally deferred.
+    /// See issue #91.
     public private(set) var activeRideVehicle: VehicleInfo?
 
     /// Snapshot of the most recently active ride's identity, captured while
@@ -119,12 +131,31 @@ public final class RideCoordinator {
         )
         self.session.delegate = self
 
+        // Wire the Kind 30173 hook so a restored or cache-empty active ride can adopt
+        // the first observed vehicle as the snapshot. See issue #91.
+        self.location.onDriverVehicleUpdate = { [weak self] pubkey, vehicle in
+            self?.adoptVehicleIfNeeded(driverPubkey: pubkey, vehicle: vehicle)
+        }
+
         restoreRideState()
     }
 
     public func startLocationSubscriptions() { location.startLocationSubscriptions() }
     func startKeyShareSubscription() { location.startKeyShareSubscription() }
     func startDriverAvailabilitySubscription() { location.startDriverAvailabilitySubscription() }
+
+    /// Called by `LocationCoordinator` for every Kind 30173 event so a restored or
+    /// fresh-but-empty-cache active ride can lock its snapshot to the first observed
+    /// vehicle. No-op once `activeRideVehicle` is set, so the snapshot remains stable
+    /// for the rest of the ride. See `activeRideVehicle` doc comment for the full
+    /// timing rationale (issue #91).
+    func adoptVehicleIfNeeded(driverPubkey: String, vehicle: VehicleInfo) {
+        guard activeRideVehicle == nil,
+              session.driverPubkey == driverPubkey,
+              session.stage == .driverAccepted || session.stage.isActiveRide
+        else { return }
+        activeRideVehicle = vehicle
+    }
     public func publishFollowedDriversList() async { await location.publishFollowedDriversList() }
     public func requestKeyRefresh(driverPubkey: String) async throws { try await location.requestKeyRefresh(driverPubkey: driverPubkey) }
     public func checkForStaleKeys() async { await location.checkForStaleKeys() }

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -39,6 +39,18 @@ public final class RideCoordinator {
     public var destinationLocation: Location?
     public var lastError: String?
 
+    /// Snapshot of the driver's active vehicle, captured at the moment the driver
+    /// accepted the ride. Read by `ActiveRideView` so the rider continues to see
+    /// the vehicle they agreed to even if the driver re-publishes Kind 30173 with
+    /// a different vehicle mid-ride.
+    ///
+    /// In-memory only. On cold-start mid-ride, the snapshot is re-derived from the
+    /// live cache during `restoreRideState()`; if the driver swapped vehicles in the
+    /// meantime, the rebuilt snapshot reflects the *current* cache, not the original
+    /// agreement. Persisting through `PersistedRideState` would require a
+    /// cross-platform schema change and is intentionally deferred. See issue #91.
+    public private(set) var activeRideVehicle: VehicleInfo?
+
     /// Snapshot of the most recently active ride's identity, captured while
     /// the session still holds it (in `sessionDidChangeStage` and on session
     /// restore). Used to record cancelled-ride history entries after the SDK
@@ -112,6 +124,7 @@ public final class RideCoordinator {
 
     public func startLocationSubscriptions() { location.startLocationSubscriptions() }
     func startKeyShareSubscription() { location.startKeyShareSubscription() }
+    func startDriverAvailabilitySubscription() { location.startDriverAvailabilitySubscription() }
     public func publishFollowedDriversList() async { await location.publishFollowedDriversList() }
     public func requestKeyRefresh(driverPubkey: String) async throws { try await location.requestKeyRefresh(driverPubkey: driverPubkey) }
     public func checkForStaleKeys() async { await location.checkForStaleKeys() }
@@ -179,6 +192,14 @@ public final class RideCoordinator {
                 driverPubkey: driverPubkey
             )
         }
+        // Cold-start mid-ride: re-derive the vehicle snapshot from the live cache.
+        // If the driver swapped vehicles between original acceptance and this
+        // restore, the rebuilt snapshot reflects the current cache rather than the
+        // original agreement — a known limitation called out in `activeRideVehicle`.
+        if (session.stage.isActiveRide || session.stage == .driverAccepted),
+           let driverPubkey = session.driverPubkey {
+            activeRideVehicle = driversRepository.cachedDriverVehicle(pubkey: driverPubkey)
+        }
     }
 
     func persistRideState() {
@@ -222,6 +243,7 @@ public final class RideCoordinator {
         await chat.cleanup()
         location.startLocationSubscriptions()
         location.startKeyShareSubscription()
+        location.startDriverAvailabilitySubscription()
         async let staleKeyRefresh: Void = driversRepository.hasDrivers ? location.checkForStaleKeys() : ()
 
         let stageBefore = session.stage
@@ -344,6 +366,7 @@ public final class RideCoordinator {
         selectedPaymentMethod = nil
         pickupLocation = nil
         destinationLocation = nil
+        activeRideVehicle = nil
         if clearError {
             lastError = nil
         }
@@ -483,6 +506,14 @@ extension RideCoordinator: RiderRideSessionDelegate {
            let driverPubkey = session.driverPubkey,
            let confirmationId = session.confirmationEventId {
             chat.subscribeToChat(driverPubkey: driverPubkey, confirmationEventId: confirmationId)
+        }
+        // Snapshot the driver's active vehicle at the moment they accept the ride
+        // — the rider agreed to ride in *this* car. Subsequent Kind 30173 events
+        // from the driver swapping to another vehicle no longer affect the active
+        // ride view. See issue #91.
+        if from == .waitingForAcceptance && to == .driverAccepted,
+           let driverPubkey = session.driverPubkey {
+            activeRideVehicle = driversRepository.cachedDriverVehicle(pubkey: driverPubkey)
         }
         if to == .idle || to == .completed {
             chat.cleanupAsync()

--- a/RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift
@@ -86,6 +86,32 @@ struct AppStateDriverListItemsTests {
         #expect(items[0].status == .keyStale)
         #expect(items[0].canRequestRide == false)
     }
+
+    /// Issue #91 wiring regression: `driverListItems()` must thread the live Kind
+    /// 30173 cache (`repo.driverVehicles[pubkey]`) into `DriverListItem.from(...,
+    /// vehicle:)`. Because the factory's `vehicle:` parameter has a `nil` default,
+    /// dropping the argument from the call site silently falls back to the Kind 0
+    /// profile — exactly the bug #91 fixed. This test exercises the full API
+    /// surface so a future refactor that loses the `vehicle:` argument is caught.
+    @Test func threadsLiveVehicleCacheIntoListItems() {
+        let driver = FollowedDriver(pubkey: fakePubkeyA, name: "Eve", roadflareKey: fakeKey)
+        let repo = makeRepo(drivers: [driver])
+        let kind0Profile = UserProfileContent(carMake: "Tesla", carModel: "Model 3", carColor: "Black")
+        repo.cacheDriverProfile(pubkey: fakePubkeyA, profile: kind0Profile)
+        repo.updateDriverVehicle(
+            pubkey: fakePubkeyA,
+            vehicle: VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        )
+
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        let items = appState.driverListItems()
+        #expect(items.count == 1)
+        // Live cache must win; if AppState+Presentation forgot to pass
+        // `vehicle:`, the factory would silently fall back to "Black Tesla Model 3".
+        #expect(items[0].vehicleDescription == "Silver Toyota Camry")
+    }
 }
 
 // MARK: - AppState.driverDetailViewState(pubkey:)
@@ -133,6 +159,26 @@ struct AppStateDriverDetailViewStateTests {
         let state = appState.driverDetailViewState(pubkey: fakePubkeyA)
         #expect(state?.statusLabel == "Available")
         #expect(state?.canRequestRide == true)
+    }
+
+    /// Issue #91 wiring regression: same as `threadsLiveVehicleCacheIntoListItems`
+    /// but for the detail-sheet API. Catches a future refactor that drops
+    /// `vehicle:` from the `DriverDetailViewState.from(...)` call.
+    @Test func threadsLiveVehicleCacheIntoDetailViewState() {
+        let driver = FollowedDriver(pubkey: fakePubkeyA, name: "Frank", roadflareKey: fakeKey)
+        let repo = makeRepo(drivers: [driver])
+        let kind0Profile = UserProfileContent(carMake: "Tesla", carModel: "Model 3", carColor: "Black")
+        repo.cacheDriverProfile(pubkey: fakePubkeyA, profile: kind0Profile)
+        repo.updateDriverVehicle(
+            pubkey: fakePubkeyA,
+            vehicle: VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        )
+
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+
+        let state = appState.driverDetailViewState(pubkey: fakePubkeyA)
+        #expect(state?.vehicleDescription == "Silver Toyota Camry")
     }
 
     /// Regression for #62: when a driver is removed out-of-band (background

--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -127,6 +127,49 @@ struct DriverListItemTests {
         #expect(item.vehicleDescription == "Black Tesla Model 3")
     }
 
+    // Issue #91: live Kind 30173 cache wins over the Kind 0 profile so a
+    // multi-vehicle driver who swaps active vehicles is reflected immediately.
+    @Test func vehicleDescriptionPrefersLiveCacheOverProfile() {
+        let driver = makeDriver()
+        let profile = UserProfileContent(carMake: "Tesla", carModel: "Model 3", carColor: "Black")
+        let live = VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: profile, vehicle: live,
+                                       isKeyStale: false, canPing: false)
+        #expect(item.vehicleDescription == "Silver Toyota Camry")
+    }
+
+    // Fallback: when the driver hasn't published Kind 30173 (or the rider's
+    // subscription hasn't picked one up yet), the Kind 0 profile is the safety net.
+    @Test func vehicleDescriptionFallsBackToProfileWhenNoLiveCache() {
+        let driver = makeDriver()
+        let profile = UserProfileContent(carMake: "Tesla", carModel: "Model 3", carColor: "Black")
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: profile, vehicle: nil,
+                                       isKeyStale: false, canPing: false)
+        #expect(item.vehicleDescription == "Black Tesla Model 3")
+    }
+
+    // Empty-state case: neither source has vehicle info — the rider sees nothing
+    // rather than an inferred default.
+    @Test func vehicleDescriptionNilWhenNeitherSourceHasInfo() {
+        let driver = makeDriver()
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: nil, vehicle: nil,
+                                       isKeyStale: false, canPing: false)
+        #expect(item.vehicleDescription == nil)
+    }
+
+    // Live cache supplies a vehicle even when no Kind 0 profile has been fetched.
+    @Test func vehicleDescriptionFromLiveCacheAloneWhenNoProfile() {
+        let driver = makeDriver()
+        let live = VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        let item = DriverListItem.from(driver, displayName: nil, location: nil,
+                                       profile: nil, vehicle: live,
+                                       isKeyStale: false, canPing: false)
+        #expect(item.vehicleDescription == "Silver Toyota Camry")
+    }
+
     @Test func canPingPropagated() {
         let driver = makeDriver()
         let item = DriverListItem.from(driver, displayName: nil, location: nil,
@@ -335,6 +378,35 @@ struct DriverDetailViewStateTests {
                                                location: nil, profile: nil,
                                                isKeyStale: false, canPing: false)
         #expect(state.note == "Great driver!")
+    }
+
+    // Issue #91: live Kind 30173 cache wins over the Kind 0 profile so a
+    // multi-vehicle driver's swap shows up in the driver-detail sheet immediately.
+    @Test func vehicleDescriptionPrefersLiveCacheOverProfile() {
+        let driver = makeDriver()
+        let profile = UserProfileContent(carMake: "Tesla", carModel: "Model 3", carColor: "Black")
+        let live = VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: profile, vehicle: live,
+                                               isKeyStale: false, canPing: false)
+        #expect(state.vehicleDescription == "Silver Toyota Camry")
+    }
+
+    @Test func vehicleDescriptionFallsBackToProfileWhenNoLiveCache() {
+        let driver = makeDriver()
+        let profile = UserProfileContent(carMake: "Tesla", carModel: "Model 3", carColor: "Black")
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: profile, vehicle: nil,
+                                               isKeyStale: false, canPing: false)
+        #expect(state.vehicleDescription == "Black Tesla Model 3")
+    }
+
+    @Test func vehicleDescriptionNilWhenNeitherSourceHasInfo() {
+        let driver = makeDriver()
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil, vehicle: nil,
+                                               isKeyStale: false, canPing: false)
+        #expect(state.vehicleDescription == nil)
     }
 }
 

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -844,6 +844,86 @@ struct RideCoordinatorTests {
         await coordinator.stopAll()
     }
 
+    /// The cold-start mid-ride / cache-empty-at-acceptance recovery: when no snapshot
+    /// has been captured yet, the FIRST Kind 30173 event observed for the active
+    /// driver is adopted as the snapshot. After that, further events are ignored.
+    @MainActor
+    @Test func vehicleSnapshotAdoptsFirstObservedEventWhenNilAndLocksAfter() async throws {
+        let (coordinator, _, _, _, _) = try await makeCoordinator()
+        let driverPubkey = String(repeating: "d", count: 64)
+        coordinator.driversRepository.addDriver(FollowedDriver(pubkey: driverPubkey))
+        // Acceptance with empty cache — snapshot stays nil.
+        coordinator.session.restore(
+            stage: .driverAccepted,
+            offerEventId: "offer",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: nil,
+            driverPubkey: driverPubkey,
+            pin: nil,
+            pinVerified: false,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.sessionDidChangeStage(from: .waitingForAcceptance, to: .driverAccepted)
+        #expect(coordinator.activeRideVehicle == nil)
+
+        // Simulate the first Kind 30173 event arriving via LocationCoordinator's hook.
+        coordinator.adoptVehicleIfNeeded(
+            driverPubkey: driverPubkey,
+            vehicle: VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        )
+        #expect(coordinator.activeRideVehicle?.description == "Silver Toyota Camry")
+
+        // A second event (driver swapped) must NOT mutate the locked snapshot.
+        coordinator.adoptVehicleIfNeeded(
+            driverPubkey: driverPubkey,
+            vehicle: VehicleInfo(make: "Tesla", model: "Model 3", color: nil)
+        )
+        #expect(
+            coordinator.activeRideVehicle?.description == "Silver Toyota Camry",
+            "snapshot must lock after first adoption"
+        )
+        await coordinator.stopAll()
+    }
+
+    /// Adoption ignores events for non-active drivers and events outside an active ride.
+    @MainActor
+    @Test func vehicleSnapshotAdoptionIgnoresUnrelatedEvents() async throws {
+        let (coordinator, _, _, _, _) = try await makeCoordinator()
+        let activeDriver = String(repeating: "d", count: 64)
+        let otherDriver = String(repeating: "e", count: 64)
+        coordinator.driversRepository.addDriver(FollowedDriver(pubkey: activeDriver))
+        coordinator.driversRepository.addDriver(FollowedDriver(pubkey: otherDriver))
+
+        // Idle stage — adoption should be a no-op even for any driver.
+        coordinator.adoptVehicleIfNeeded(
+            driverPubkey: activeDriver,
+            vehicle: VehicleInfo(make: "Toyota")
+        )
+        #expect(coordinator.activeRideVehicle == nil, "no adoption when not in an active ride")
+
+        coordinator.session.restore(
+            stage: .driverAccepted,
+            offerEventId: "offer",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: nil,
+            driverPubkey: activeDriver,
+            pin: nil,
+            pinVerified: false,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.sessionDidChangeStage(from: .waitingForAcceptance, to: .driverAccepted)
+
+        // Event for a different driver while in active ride — must not adopt.
+        coordinator.adoptVehicleIfNeeded(
+            driverPubkey: otherDriver,
+            vehicle: VehicleInfo(make: "Tesla")
+        )
+        #expect(coordinator.activeRideVehicle == nil, "no adoption from unrelated driver")
+        await coordinator.stopAll()
+    }
+
     @MainActor
     @Test func sessionDidReachTerminalCompletedRecordsHistoryAndKeepsUI() async throws {
         let (coordinator, _, _, history, _) = try await makeCoordinator()

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -754,6 +754,96 @@ struct RideCoordinatorTests {
         await coordinator.stopAll()
     }
 
+    // MARK: - Vehicle snapshot (issue #91)
+
+    @MainActor
+    @Test func vehicleSnapshotCapturedOnTransitionToDriverAccepted() async throws {
+        let (coordinator, _, _, _, _) = try await makeCoordinator()
+        let driverPubkey = String(repeating: "d", count: 64)
+        coordinator.driversRepository.addDriver(FollowedDriver(pubkey: driverPubkey))
+        coordinator.driversRepository.updateDriverVehicle(
+            pubkey: driverPubkey,
+            vehicle: VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        )
+        // Simulate the session reaching driverAccepted with this driverPubkey.
+        coordinator.session.restore(
+            stage: .driverAccepted,
+            offerEventId: "offer",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: nil,
+            driverPubkey: driverPubkey,
+            pin: nil,
+            pinVerified: false,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.sessionDidChangeStage(from: .waitingForAcceptance, to: .driverAccepted)
+        #expect(coordinator.activeRideVehicle?.description == "Silver Toyota Camry")
+        await coordinator.stopAll()
+    }
+
+    /// Regression for issue #91: once the driver accepts, the rider committed to
+    /// *that* car. Subsequent Kind 30173 events from the driver swapping to
+    /// another vehicle must NOT update the snapshot, even though the live cache
+    /// reflects the swap for the drivers-list/detail-sheet surfaces.
+    @MainActor
+    @Test func vehicleSnapshotDoesNotUpdateAfterAcceptance() async throws {
+        let (coordinator, _, _, _, _) = try await makeCoordinator()
+        let driverPubkey = String(repeating: "d", count: 64)
+        coordinator.driversRepository.addDriver(FollowedDriver(pubkey: driverPubkey))
+        coordinator.driversRepository.updateDriverVehicle(
+            pubkey: driverPubkey,
+            vehicle: VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
+        )
+        coordinator.session.restore(
+            stage: .driverAccepted,
+            offerEventId: "offer",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: nil,
+            driverPubkey: driverPubkey,
+            pin: nil,
+            pinVerified: false,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.sessionDidChangeStage(from: .waitingForAcceptance, to: .driverAccepted)
+
+        // Driver swaps active vehicle mid-ride.
+        coordinator.driversRepository.updateDriverVehicle(
+            pubkey: driverPubkey,
+            vehicle: VehicleInfo(make: "Tesla", model: "Model 3", color: nil)
+        )
+
+        #expect(
+            coordinator.activeRideVehicle?.description == "Silver Toyota Camry",
+            "Active-ride snapshot must remain on the originally-agreed Camry."
+        )
+        await coordinator.stopAll()
+    }
+
+    /// When acceptance fires before any Kind 30173 has been cached for the driver,
+    /// the snapshot stays nil so the view falls back to the Kind 0 profile.
+    @MainActor
+    @Test func vehicleSnapshotNilWhenCacheEmptyAtAcceptance() async throws {
+        let (coordinator, _, _, _, _) = try await makeCoordinator()
+        let driverPubkey = String(repeating: "d", count: 64)
+        coordinator.driversRepository.addDriver(FollowedDriver(pubkey: driverPubkey))
+        coordinator.session.restore(
+            stage: .driverAccepted,
+            offerEventId: "offer",
+            acceptanceEventId: rideCoordinatorAcceptanceEventId,
+            confirmationEventId: nil,
+            driverPubkey: driverPubkey,
+            pin: nil,
+            pinVerified: false,
+            paymentMethod: "zelle",
+            fiatPaymentMethods: ["zelle"]
+        )
+        coordinator.sessionDidChangeStage(from: .waitingForAcceptance, to: .driverAccepted)
+        #expect(coordinator.activeRideVehicle == nil)
+        await coordinator.stopAll()
+    }
+
     @MainActor
     @Test func sessionDidReachTerminalCompletedRecordsHistoryAndKeepsUI() async throws {
         let (coordinator, _, _, history, _) = try await makeCoordinator()

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -808,11 +808,20 @@ struct RideCoordinatorTests {
         )
         coordinator.sessionDidChangeStage(from: .waitingForAcceptance, to: .driverAccepted)
 
-        // Driver swaps active vehicle mid-ride.
+        // Driver swaps active vehicle mid-ride. Mirror the production code path
+        // exactly: LocationCoordinator.handleDriverAvailabilityEvent first writes
+        // the new vehicle to the repo cache, THEN fires onDriverVehicleUpdate ->
+        // adoptVehicleIfNeeded. The snapshot must remain on the originally-agreed
+        // Camry through both stages — a regression that removed the
+        // `guard activeRideVehicle == nil` from adoptVehicleIfNeeded would only be
+        // caught by exercising adoptVehicleIfNeeded here, not by the cache mutation
+        // alone.
+        let swapped = VehicleInfo(make: "Tesla", model: "Model 3", color: nil)
         coordinator.driversRepository.updateDriverVehicle(
             pubkey: driverPubkey,
-            vehicle: VehicleInfo(make: "Tesla", model: "Model 3", color: nil)
+            vehicle: swapped
         )
+        coordinator.adoptVehicleIfNeeded(driverPubkey: driverPubkey, vehicle: swapped)
 
         #expect(
             coordinator.activeRideVehicle?.description == "Silver Toyota Camry",

--- a/decisions/0015-kind-30173-vehicle-subscription.md
+++ b/decisions/0015-kind-30173-vehicle-subscription.md
@@ -30,14 +30,31 @@ Constraints:
 
 Add a third managed Nostr subscription to `LocationCoordinator` —
 `activeDriverAvailabilitySubscription` — modeled exactly on the existing
-`activeLocationSubscription` and `activeKeyShareSubscription`. The
-`FollowedDriversRepository` carries an in-memory `driverVehicles:
-[String: VehicleInfo]` cache with **overwrite-only semantics** (never merge).
-The `RideCoordinator` snapshots `activeRideVehicle` at the
-`.waitingForAcceptance → .driverAccepted` transition, with a *first-arrival
-adoption* fallback for restored or cache-empty rides. Presentation projections
-(`DriverDetailViewState`, `DriverListItem`) prefer the live cache and fall back
-to the Kind 0 profile.
+`activeLocationSubscription` and `activeKeyShareSubscription` (so
+`LocationCoordinator` now manages three subscriptions; ADR-0011's "two
+subscriptions" prose is superseded by this ADR). The `FollowedDriversRepository`
+carries an in-memory `driverVehicles: [String: VehicleInfo]` cache with
+**overwrite-only semantics** (never merge).
+
+`RideCoordinator.activeRideVehicle` is populated through three deliberate paths:
+
+1. **Acceptance transition** — `sessionDidChangeStage(.waitingForAcceptance →
+   .driverAccepted)` reads `driversRepository.cachedDriverVehicle(...)`. Locks
+   immediately when the cache is warm.
+2. **Cold-start direct read** — `restoreRideState()` (called from
+   `RideCoordinator.init`) reads `cachedDriverVehicle(...)` for the restored
+   driver. The cache is empty at this point in the launch sequence
+   (`restoreLiveSubscriptions()` starts the Kind 30173 stream later), so this
+   path almost always sets nil; the assignment is kept defensively in case a
+   future startup-sync change pre-populates the cache.
+3. **First-arrival adoption** — `LocationCoordinator.handleDriverAvailabilityEvent`
+   fires `onDriverVehicleUpdate` after every successful parse;
+   `RideCoordinator.adoptVehicleIfNeeded(...)` adopts the *first* event observed
+   for the active driver while the snapshot is still nil, then ignores
+   subsequent events. This is what actually rescues cold-started mid-rides.
+
+Presentation projections (`DriverDetailViewState`, `DriverListItem`) prefer the
+live cache and fall back to the Kind 0 profile.
 
 ## Rationale
 
@@ -78,16 +95,30 @@ to the Kind 0 profile.
   ride-state machine aware of vehicle, but the SDK has no protocol-level reason
   to know about vehicle data, so this would conflate UI presentation with ride
   protocol state. Rejected per ADR-0011.
+- **Replace the `onDriverVehicleUpdate` callback with `@Observable` reactive
+  observation of `driversRepository.driverVehicles`** — `RideCoordinator` is
+  itself `@Observable`, so it would naturally re-render when the repo's
+  `driverVehicles` changed. Commit `a88d1b7` (PR #38) used exactly this
+  reasoning to remove an unused `onFavoritesChanged` callback. Rejected here
+  because: (a) `withObservationTracking` is single-shot — re-establishing
+  tracking after each fire to detect the *first* arrival adds more code than
+  the closure, (b) the snapshot is set imperatively (it must lock after the
+  first observation), which is awkward to express purely through view-driven
+  re-rendering, and (c) `RideCoordinator` is the sole consumer today; if a
+  second consumer ever appears the closure can be promoted to a multicast
+  helper without disturbing the first-arrival semantics.
 
 ## Consequences
 
 - Riders see live vehicle info on all three surfaces (drivers list, detail
   sheet, active ride) and the active-ride view stays stable across mid-trip
   driver swaps.
-- The `LocationCoordinator` callback contract grows by one closure
-  (`onDriverVehicleUpdate`); `RideCoordinator` is the only consumer today, but
-  the hook is intentionally narrow so future consumers (e.g., a notification
-  layer) can attach without a refactor.
+- `LocationCoordinator` adds one package-internal `var onDriverVehicleUpdate`
+  closure (no `public` modifier; only `RoadFlareCore` callers can attach).
+  `RideCoordinator` is the sole consumer today. The single-closure shape is a
+  deliberate trade-off: it matches the snapshot semantics (one consumer that
+  needs first-arrival adoption), and the multicast case can be revisited if and
+  when a second concrete consumer appears.
 - A driver who swaps vehicles between the rider accepting and the rider
   cold-starting their app will see the rider's snapshot lock to the *new*
   vehicle on first-arrival, not the original agreement. Documented in the

--- a/decisions/0015-kind-30173-vehicle-subscription.md
+++ b/decisions/0015-kind-30173-vehicle-subscription.md
@@ -1,0 +1,110 @@
+# ADR-0015: Kind 30173 Driver-Availability Subscription for Live Vehicle Display
+
+**Status:** Active
+**Created:** 2026-05-02
+**Tags:** architecture, nostr-subscription, ride-presentation
+
+## Context
+
+Riders couldn't see drivers' currently active vehicle on `DriverDetailSheet`,
+the requestable-drivers card, or the active-ride card. iOS was reading vehicle
+data from Kind 0 (profile metadata) only — but Drivestr is multi-vehicle and
+does not reliably re-publish Kind 0 when a driver swaps which vehicle they're
+online in. The live signal for "currently active vehicle" lives on Kind 30173
+(`DriverAvailabilityEvent`); iOS had no subscription for it. PR #86 wired the
+UI to render `vehicleDescription`, which made the absence of the signal
+user-visible. See issue #91.
+
+Constraints:
+
+- Multi-vehicle is a first-class Drivestr behaviour; field-level merging would
+  silently leak old data across vehicle swaps.
+- `RidestrUI` ride surfaces are shared with Android; the on-wire Kind 30173
+  shape and `d`-tag are already pinned by the protocol.
+- ADR-0011 (coordinator boundary) constrains where Nostr-protocol logic vs.
+  iOS-presentation logic may live.
+- The active-ride view must stay locked to the vehicle the rider agreed to,
+  even when the driver swaps mid-trip.
+
+## Decision
+
+Add a third managed Nostr subscription to `LocationCoordinator` —
+`activeDriverAvailabilitySubscription` — modeled exactly on the existing
+`activeLocationSubscription` and `activeKeyShareSubscription`. The
+`FollowedDriversRepository` carries an in-memory `driverVehicles:
+[String: VehicleInfo]` cache with **overwrite-only semantics** (never merge).
+The `RideCoordinator` snapshots `activeRideVehicle` at the
+`.waitingForAcceptance → .driverAccepted` transition, with a *first-arrival
+adoption* fallback for restored or cache-empty rides. Presentation projections
+(`DriverDetailViewState`, `DriverListItem`) prefer the live cache and fall back
+to the Kind 0 profile.
+
+## Rationale
+
+- **Mirrors a well-understood pattern.** `LocationCoordinator` already manages
+  two subscriptions with the same `ManagedSubscription` + UUID-generation
+  pattern. Reusing the pattern minimises new failure modes (race between
+  cancel/start, generation-checked task body, idempotent restart).
+- **Overwrite-only matches the protocol.** Kind 30173 is a NIP-33 parameterized
+  replaceable event; the latest payload is authoritative, so per-field merging
+  would actively reintroduce stale data on vehicle swap. Tests pin this
+  (`updateDriverVehicleOverwriteSemanticsClearOmittedFields`).
+- **Snapshot-at-acceptance protects the rider's agreement.** Once the driver
+  accepts, the rider committed to *that* vehicle. Subsequent Kind 30173 events
+  must not mutate the active-ride view. The `from == .waitingForAcceptance &&
+  to == .driverAccepted` guard is the single capture point for fresh sessions.
+- **First-arrival adoption rescues restored rides.** `restoreRideState()` runs
+  inside `RideCoordinator.init`, before `restoreLiveSubscriptions()` starts the
+  Kind 30173 stream — so the cache is empty at restore time. To avoid leaving
+  the snapshot permanently nil for cold-started mid-rides, `LocationCoordinator`
+  fires `onDriverVehicleUpdate` after every successful parse, and
+  `RideCoordinator.adoptVehicleIfNeeded` adopts the *first* event observed for
+  the active driver, then locks the snapshot for the rest of the ride.
+- **ADR-0011 boundary preserved.** Parser, model, filter, and cache live in
+  `RidestrSDK` (Nostr-protocol semantics). Subscription lifecycle and the
+  `activeRideVehicle` UI snapshot live in `RoadFlareCore` (platform glue).
+
+## Alternatives Considered
+
+- **Persist `activeRideVehicle` in `PersistedRideState`** — would survive cold
+  start without first-arrival adoption. Rejected for v1 because it requires a
+  cross-platform schema bump on a contract shared with Android Ridestr; the
+  in-memory snapshot + first-arrival adoption is sufficient for the P1 fix and
+  introduces no schema risk.
+- **Compute `vehicleDescription` from the live cache directly in
+  `ActiveRideView`** — simplest implementation, but breaks the snapshot
+  semantic the moment the driver swaps mid-ride.
+- **Push the snapshot into `RiderRideSession` / `RideContext`** — keeps the
+  ride-state machine aware of vehicle, but the SDK has no protocol-level reason
+  to know about vehicle data, so this would conflate UI presentation with ride
+  protocol state. Rejected per ADR-0011.
+
+## Consequences
+
+- Riders see live vehicle info on all three surfaces (drivers list, detail
+  sheet, active ride) and the active-ride view stays stable across mid-trip
+  driver swaps.
+- The `LocationCoordinator` callback contract grows by one closure
+  (`onDriverVehicleUpdate`); `RideCoordinator` is the only consumer today, but
+  the hook is intentionally narrow so future consumers (e.g., a notification
+  layer) can attach without a refactor.
+- A driver who swaps vehicles between the rider accepting and the rider
+  cold-starting their app will see the rider's snapshot lock to the *new*
+  vehicle on first-arrival, not the original agreement. Documented in the
+  `activeRideVehicle` doc comment; revisit only if persistence becomes
+  necessary for another reason.
+- `prepareForIdentityReplacement` already calls `clearAll()`, which clears
+  `driverVehicles` — no separate cleanup hook required.
+
+## Affected Files
+
+- `RidestrSDK/Sources/RidestrSDK/Models/RoadflareModels.swift` — `VehicleInfo`, `DriverAvailabilityEventData`
+- `RidestrSDK/Sources/RidestrSDK/Nostr/RideshareEventParser.swift` — `parseDriverAvailability`
+- `RidestrSDK/Sources/RidestrSDK/Nostr/NostrFilter.swift` — `driverAvailability(driverPubkeys:)`
+- `RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift` — `driverVehicles` cache + cleanup
+- `RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift` — third subscription + `onDriverVehicleUpdate`
+- `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift` — `activeRideVehicle` + `adoptVehicleIfNeeded`
+- `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` — `restartDriverAvailabilitySubscription` + restart sites
+- `RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift`, `DriverListItem.swift` — vehicle precedence
+- `RoadFlare/RoadFlare/Views/Drivers/AddDriverSheet.swift` — restart on re-add paths
+- `RoadFlare/RoadFlare/Views/Ride/ActiveRideView.swift` — read snapshot before profile fallback


### PR DESCRIPTION
## Summary

Riders couldn't see drivers' currently active vehicle on `DriverDetailSheet`, the
requestable-drivers card, or the active-ride card. iOS was reading vehicle data
from Kind 0 (profile) only — but Drivestr is multi-vehicle and doesn't reliably
re-publish Kind 0 when a driver swaps which vehicle they're online in. The live
signal lives on Kind 30173 (`DriverAvailabilityEvent`); iOS had no subscription
for it.

This PR wires that subscription end-to-end and snapshots the agreed vehicle at
acceptance so a mid-trip driver swap doesn't mutate the rider's active-ride view.

Closes #91. Architectural decision recorded as [ADR-0015](decisions/0015-kind-30173-vehicle-subscription.md).

## Design

| Layer | Change |
| --- | --- |
| `RidestrSDK` models | New `VehicleInfo` (Sendable/Equatable) + `DriverAvailabilityEventData` next to `RoadflareLocationEvent`. |
| `RideshareEventParser` | New `parseDriverAvailability(event:)` — plaintext JSON envelope, `car_make/car_model/car_color` → `VehicleInfo`. |
| `NostrFilter` | New `driverAvailability(driverPubkeys:)` mirroring `roadflareLocations(...)`. Author-restricted to followed drivers. |
| `FollowedDriversRepository` | New in-memory `driverVehicles: [String: VehicleInfo]` cache; `updateDriverVehicle(...)` is **overwrite-only — never merge** (issue requirement #2). Cleaned up in `removeDriver` / `clearAll` / `replaceAll` (reconcile path). |
| `LocationCoordinator` | Third managed subscription (`activeDriverAvailabilitySubscription`) mirroring location/key-share lifecycle. Handler dispatches to repo, then fires the `onDriverVehicleUpdate` hook for first-arrival snapshot adoption. |
| `RideCoordinator` | `restoreLiveSubscriptions()` includes the new sub. New `activeRideVehicle: VehicleInfo?` snapshot, captured on `.waitingForAcceptance → .driverAccepted`, cleared at terminal, re-derived on `restoreRideState()` for cold-start mid-ride, with first-arrival adoption via `adoptVehicleIfNeeded(...)` to recover from the cache-empty-at-restore window. |
| `AppState` | New public `restartDriverAvailabilitySubscription()` sibling of `restartKeyShareSubscription()`; called from `removeDriver`, `refreshDriverLocations`, `sendFollowNotification`, and `AddDriverSheet`'s re-add paths. |
| Presentation | `DriverListItem` / `DriverDetailViewState` factories take an optional `vehicle:` — Kind 30173 wins, Kind 0 profile is the fallback. `AppState+Presentation` threads `driverVehicles` through. |
| `ActiveRideView` | Reads `coordinator?.activeRideVehicle?.description ?? appState.driverProfile(...)?.vehicleDescription`. |

ADR-0011 boundary preserved: SDK owns parsing/state/cache; app owns subscription lifecycle and presentation. The active-ride snapshot lives on `RideCoordinator` (UI presentation state), not in `PersistedRideState` (cross-platform contract). See [ADR-0015](decisions/0015-kind-30173-vehicle-subscription.md) for the full design rationale and trade-offs.

## Four-scenario test plan

All four required scenarios are covered, plus parser/cache/snapshot cross-cuts.

| Scenario | Test(s) |
| --- | --- |
| **1. Single-vehicle baseline** | `updateDriverVehicleSingleVehicleBaseline` (repo), `parseDriverAvailabilityFullVehicle` (parser) |
| **2. Multi-vehicle swap (the bug)** | `updateDriverVehicleOverwriteSemanticsClearOmittedFields` (repo) — Camry → Tesla with `color: nil` clears the prior Silver, regression-pinning the no-merge requirement |
| **3. Kind 30173 absent / partial → graceful fallback** | `parseDriverAvailabilityPartialVehicleClearsOmittedFields`, `parseDriverAvailabilityOfflineWithNoVehicle`, `vehicleDescriptionFallsBackToProfileWhenNoLiveCache`, `vehicleDescriptionNilWhenNeitherSourceHasInfo`, `vehicleSnapshotNilWhenCacheEmptyAtAcceptance` |
| **4. Multiple followed drivers — independent** | `updateDriverVehicleIndependentPerDriver`, `replaceAllReconcilesVehicleCacheForRemovedDrivers` |

Plus snapshot semantics — `vehicleSnapshotCapturedOnTransitionToDriverAccepted`, `vehicleSnapshotDoesNotUpdateAfterAcceptance` (mid-trip swap doesn't mutate the active ride view), `vehicleSnapshotAdoptsFirstObservedEventWhenNilAndLocksAfter` (cold-start recovery), and `vehicleSnapshotAdoptionIgnoresUnrelatedEvents`. Presentation precedence — `vehicleDescriptionPrefersLiveCacheOverProfile` for both list and detail.

## Verification

- `swift test --package-path RidestrSDK` — **837 tests passed**
- `xcodebuild -scheme RoadFlare ... build` — **BUILD SUCCEEDED**
- `xcodebuild -scheme RoadFlareTests ... test` — **253 tests passed**

## Test plan
- [x] Code review pass 1 (`/code-review`) — fixes in 55bdaca
- [x] Code review pass 2 (`/code-review`) — fixes in upcoming commit
- [ ] Code review pass 3 if needed
- [ ] Manual: rider sees driver's active vehicle on DriverDetailSheet, drivers list, and active ride card

Adjacent debt deferred to follow-ups: #94 (consolidate inline `canRequestRide` predicate into SDK call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)