### PR TITLE
chore(adr): renumber onboarding-publish-failure-surface 0015 -> 0016

### DIFF
--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -97,7 +97,7 @@ public final class AppState {
     // MARK: - Onboarding Publish Surface
 
     /// Current state of the onboarding-publish failure banner. See
-    /// `OnboardingPublishStatus` and ADR-0015.
+    /// `OnboardingPublishStatus` and ADR-0016.
     public var onboardingPublishStatus: OnboardingPublishStatus = .idle
 
     /// Time the user must be online with the publish still dirty before the

--- a/decisions/0016-onboarding-publish-failure-surface.md
+++ b/decisions/0016-onboarding-publish-failure-surface.md
@@ -1,4 +1,4 @@
-# ADR-0015: Onboarding Publish Failure Surface
+# ADR-0016: Onboarding Publish Failure Surface
 
 **Status:** Active
 **Created:** 2026-05-05
@@ -71,4 +71,4 @@ Add a thin observation layer on `AppState` and a banner pinned to the top of `Ro
 - `RoadFlare/RoadFlare/Views/Shared/OnboardingPublishFailureBanner.swift` — new view.
 - `RoadFlare/RoadFlare/Views/RootView.swift` — VStack-rooted layout with banner above `@ViewBuilder` `authStateContent`.
 - `RoadFlare/RoadFlareTests/AppState/OnboardingPublishWatchdogTests.swift` — 9 watchdog tests via the test seam.
-- `decisions/0015-onboarding-publish-failure-surface.md` — this file.
+- `decisions/0016-onboarding-publish-failure-surface.md` — this file.


### PR DESCRIPTION
## Summary

PR #93 (Kind 30173 vehicle subscription) and PR #95 (onboarding publish-failure banner) both landed `decisions/0015-*.md` files during the same review window. PR #93 merged first, so this PR renumbers the onboarding-publish ADR to 0016.

## Changes

- `decisions/0015-onboarding-publish-failure-surface.md` → `decisions/0016-onboarding-publish-failure-surface.md` (git rename, full history preserved)
- Title inside file: `ADR-0015` → `ADR-0016`
- Self-reference at end of "Affected Files": same renumber
- `AppState.swift:100` doc cross-reference: `ADR-0015` → `ADR-0016`

## Verification

- `grep -rn "ADR-0015\|0015-onboarding"` against the worktree returns zero stale references (the only remaining `0015-` mentions are PR #93's `0015-kind-30173-vehicle-subscription.md`, which is intentional).
- `xcodebuild -scheme RoadFlare ... build` → BUILD SUCCEEDED

## Why now

The repo has tolerated prior 0011 / 0012 collisions but this is the chance to clean one up while the cross-references are localized to a single doc comment. Rolls out as a pure rename + 3 string updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)