### PR TITLE
fix(settings): show actual app version in App Info, not SDK version

### DIFF
--- a/RoadFlare/RoadFlare/Extensions/Bundle+AppVersion.swift
+++ b/RoadFlare/RoadFlare/Extensions/Bundle+AppVersion.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension Bundle {
+    var appVersionLabel: String {
+        let info = infoDictionary
+        let marketing = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        return "Version \(marketing) (\(build))"
+    }
+}

--- a/RoadFlare/RoadFlare/Views/Settings/AppInfoScreen.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/AppInfoScreen.swift
@@ -1,11 +1,17 @@
 import SwiftUI
-import RidestrSDK
 
 struct AppInfoScreen: View {
     @Environment(\.openURL) private var openURL
 
     private let repoURL = "https://github.com/variablefate/roadflare-ios"
     private let licenseURL = "https://github.com/variablefate/roadflare-ios/blob/main/LICENSE"
+
+    private var appVersionLabel: String {
+        let info = Bundle.main.infoDictionary
+        let marketing = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        return "Version \(marketing) (\(build))"
+    }
 
     var body: some View {
         ZStack {
@@ -34,7 +40,7 @@ struct AppInfoScreen: View {
                                 .foregroundColor(Color.rfPrimary)
                         }
 
-                        Text("Version \(RidestrSDKVersion.version)")
+                        Text(appVersionLabel)
                             .font(RFFont.caption(13))
                             .foregroundColor(Color.rfOnSurfaceVariant)
                     }

--- a/RoadFlare/RoadFlare/Views/Settings/AppInfoScreen.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/AppInfoScreen.swift
@@ -6,13 +6,6 @@ struct AppInfoScreen: View {
     private let repoURL = "https://github.com/variablefate/roadflare-ios"
     private let licenseURL = "https://github.com/variablefate/roadflare-ios/blob/main/LICENSE"
 
-    private var appVersionLabel: String {
-        let info = Bundle.main.infoDictionary
-        let marketing = info?["CFBundleShortVersionString"] as? String ?? "?"
-        let build = info?["CFBundleVersion"] as? String ?? "?"
-        return "Version \(marketing) (\(build))"
-    }
-
     var body: some View {
         ZStack {
             Color.rfSurface.ignoresSafeArea()
@@ -40,7 +33,7 @@ struct AppInfoScreen: View {
                                 .foregroundColor(Color.rfPrimary)
                         }
 
-                        Text(appVersionLabel)
+                        Text(Bundle.main.appVersionLabel)
                             .font(RFFont.caption(13))
                             .foregroundColor(Color.rfOnSurfaceVariant)
                     }

--- a/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
@@ -11,13 +11,6 @@ struct SettingsTab: View {
     @State private var showConnectivity = false
     @State private var showDeleteAccount = false
 
-    private var appVersionLabel: String {
-        let info = Bundle.main.infoDictionary
-        let marketing = info?["CFBundleShortVersionString"] as? String ?? "?"
-        let build = info?["CFBundleVersion"] as? String ?? "?"
-        return "Version \(marketing) (\(build))"
-    }
-
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -157,7 +150,7 @@ struct SettingsTab: View {
                                             .font(RFFont.body(15))
                                             .foregroundColor(Color.rfOnSurface)
                                         Spacer()
-                                        Text(appVersionLabel)
+                                        Text(Bundle.main.appVersionLabel)
                                             .font(RFFont.body(14))
                                             .foregroundColor(Color.rfOnSurfaceVariant)
                                         Image(systemName: "chevron.right")

--- a/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
+++ b/RoadFlare/RoadFlare/Views/Settings/SettingsTab.swift
@@ -11,6 +11,13 @@ struct SettingsTab: View {
     @State private var showConnectivity = false
     @State private var showDeleteAccount = false
 
+    private var appVersionLabel: String {
+        let info = Bundle.main.infoDictionary
+        let marketing = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        return "Version \(marketing) (\(build))"
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -150,7 +157,7 @@ struct SettingsTab: View {
                                             .font(RFFont.body(15))
                                             .foregroundColor(Color.rfOnSurface)
                                         Spacer()
-                                        Text("Version \(RidestrSDKVersion.version)")
+                                        Text(appVersionLabel)
                                             .font(RFFont.body(14))
                                             .foregroundColor(Color.rfOnSurfaceVariant)
                                         Image(systemName: "chevron.right")


### PR DESCRIPTION
## Summary

The App Info screen has been showing **\"Version 0.2.0\"** since day one — that's `RidestrSDKVersion.version`, a hard-coded constant inside the SDK package that has nothing to do with the shipping app's version.

Switches to reading `CFBundleShortVersionString` and `CFBundleVersion` from `Bundle.main.infoDictionary`. With `GENERATE_INFOPLIST_FILE = YES`, Xcode bakes `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` from `project.pbxproj` into those keys at build time, so the screen now tracks the real shipping version automatically — no further code changes needed when versions bump.

Display format: **\"Version 1.0.2 (2)\"** — marketing version + build number in parens. Both are useful when users include the version in bug reports.

Drops the now-unused `import RidestrSDK` from this one file.

## Verification

- `xcodebuild` Debug iOS-Simulator build succeeded.
- `PlistBuddy` against the built `.app/Info.plist` confirms `CFBundleShortVersionString = 1.0.2`, `CFBundleVersion = 2`, so the runtime lookup will produce \"Version 1.0.2 (2)\".

## Test plan

- [ ] Open the app, navigate to Settings → App Info, confirm the version line reads \"Version 1.0.2 (2)\" (or whatever the current pbxproj values are at build time)
- [ ] Verify the App Info screen still renders all five link rows (Terms, Privacy, Source, License, Submit Issue) with no layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)