### PR TITLE
feat(drivers): pulse bell icons when arriving via Ping a Driver

### DIFF
--- a/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
@@ -27,6 +27,13 @@ struct DriversTab: View {
     @State private var sharingDriver: DriverListItem?
     @State private var pingToastMessage: String?
     @State private var pingToastIsError = false
+    /// Local trigger forwarded to every visible `DriverCard`. Issue #92: when
+    /// the user lands here via "Ping a Driver" in the ride flow, every bell
+    /// pulses once to teach the affordance. The value is mirrored from
+    /// `appState.pendingPingHint` (consumed below); we keep a local copy so
+    /// the cards' `.phaseAnimator` sees a clean nil → UUID transition AFTER
+    /// they have mounted, even on the first navigation to this tab.
+    @State private var bellPulseTrigger: UUID?
 
     var body: some View {
         NavigationStack {
@@ -42,6 +49,7 @@ struct DriversTab: View {
                             ForEach(appState.driverListItems()) { item in
                                 DriverCard(
                                     item: item,
+                                    bellPulseTrigger: bellPulseTrigger,
                                     onRequest: {
                                         appState.requestRideDriverPubkey = item.pubkey
                                         appState.selectedTab = 0
@@ -152,6 +160,17 @@ struct DriversTab: View {
                 guard let parsed = newValue else { return }
                 addDriverPresentation = AddDriverPresentation(prefill: parsed)
             }
+            .onChange(of: appState.pendingPingHint, initial: true) { _, newValue in
+                // "Ping a Driver" in the ride flow raised the hint. `initial:
+                // true` covers the first-mount case where the CTA fired before
+                // this tab's body had ever evaluated. We mirror to a local
+                // trigger and clear the AppState signal so the cards see a
+                // distinct nil → UUID transition AFTER they're already in the
+                // view tree (issue #92).
+                guard let token = newValue else { return }
+                bellPulseTrigger = token
+                appState.pendingPingHint = nil
+            }
             .toast($pingToastMessage, isError: pingToastIsError)
         }
     }
@@ -192,6 +211,9 @@ struct DriversTab: View {
 
 struct DriverCard: View {
     let item: DriverListItem
+    /// Changes when the parent wants every visible bell to pulse once
+    /// (issue #92). Nil means no pulse; a new UUID retriggers.
+    var bellPulseTrigger: UUID? = nil
     let onRequest: () -> Void
     let onShare: () -> Void
     let onPing: () -> Void
@@ -272,7 +294,7 @@ struct DriverCard: View {
                         Button(action: onPing) {
                             Image(systemName: "bell")
                                 .font(.system(size: 16))
-                                .foregroundColor(Color.rfOnSurfaceVariant)
+                                .modifier(BellPulseModifier(trigger: bellPulseTrigger))
                                 .frame(width: 44, height: 44)
                                 .background(Color.rfSurfaceContainerHigh)
                                 .clipShape(RoundedRectangle(cornerRadius: 10))
@@ -377,6 +399,41 @@ struct DriverCard: View {
         case .keyStale:        return .rfError
         case .pendingApproval: return .rfTertiary
         case .offline:         return .rfOffline
+        }
+    }
+}
+
+// MARK: - Bell Pulse
+
+/// One-shot pulse hint for the bell icon — issue #92. Cycles foreground
+/// colour, scale, and opacity through three soft peaks so a first-time user
+/// arriving via "Ping a Driver" learns the bell is the tappable target.
+/// `phaseAnimator` runs the sequence once each time `trigger` becomes a new
+/// non-nil value; the final phase is the rest state, so the icon settles
+/// back to its normal appearance with no leftover styling. Honours Reduce
+/// Motion by short-circuiting to the static rest style.
+private struct BellPulseModifier: ViewModifier {
+    let trigger: UUID?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// 0.0 = rest, 1.0 = peak. Seven entries, six transitions = three
+    /// full pulse oscillations; ending on 0.0 leaves the icon at rest.
+    private static let phases: [Double] = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]
+
+    func body(content: Content) -> some View {
+        Group {
+            if reduceMotion {
+                content.foregroundColor(Color.rfOnSurfaceVariant)
+            } else {
+                content.phaseAnimator(Self.phases, trigger: trigger) { view, intensity in
+                    view
+                        .foregroundColor(intensity > 0.5 ? .orange : Color.rfOnSurfaceVariant)
+                        .scaleEffect(1.0 + 0.15 * intensity)
+                        .opacity(1.0 - 0.3 * intensity)
+                } animation: { _ in
+                    .easeInOut(duration: 0.25)
+                }
+            }
         }
     }
 }

--- a/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
@@ -405,13 +405,15 @@ struct DriverCard: View {
 
 // MARK: - Bell Pulse
 
-/// One-shot pulse hint for the bell icon — issue #92. Cycles foreground
-/// colour, scale, and opacity through three soft peaks so a first-time user
-/// arriving via "Ping a Driver" learns the bell is the tappable target.
-/// `phaseAnimator` runs the sequence once each time `trigger` becomes a new
-/// non-nil value; the final phase is the rest state, so the icon settles
-/// back to its normal appearance with no leftover styling. Honours Reduce
-/// Motion by short-circuiting to the static rest style.
+/// One-shot pulse hint for the bell icon — issue #92. At each peak the
+/// outline bell swaps to the filled `bell.fill` variant tinted orange, then
+/// drains back to the outline rest state, three times. `phaseAnimator` runs
+/// the sequence once each time `trigger` becomes a new non-nil value; the
+/// final phase is rest, so the icon settles back to its normal appearance
+/// with no leftover styling. The `.contentTransition(.symbolEffect(.replace))`
+/// smooths the outline ↔ fill swap so the bell appears to fill in rather
+/// than snap. Honours Reduce Motion by short-circuiting to the static rest
+/// style.
 private struct BellPulseModifier: ViewModifier {
     let trigger: UUID?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -425,14 +427,17 @@ private struct BellPulseModifier: ViewModifier {
             if reduceMotion {
                 content.foregroundColor(Color.rfOnSurfaceVariant)
             } else {
-                content.phaseAnimator(Self.phases, trigger: trigger) { view, intensity in
-                    view
-                        .foregroundColor(intensity > 0.5 ? .orange : Color.rfOnSurfaceVariant)
-                        .scaleEffect(1.0 + 0.15 * intensity)
-                        .opacity(1.0 - 0.3 * intensity)
-                } animation: { _ in
-                    .easeInOut(duration: 0.25)
-                }
+                content
+                    .contentTransition(.symbolEffect(.replace))
+                    .phaseAnimator(Self.phases, trigger: trigger) { view, intensity in
+                        view
+                            .symbolVariant(intensity > 0.5 ? .fill : .none)
+                            .foregroundColor(intensity > 0.5 ? .orange : Color.rfOnSurfaceVariant)
+                            .scaleEffect(1.0 + 0.15 * intensity)
+                            .opacity(1.0 - 0.3 * intensity)
+                    } animation: { _ in
+                        .easeInOut(duration: 0.25)
+                    }
             }
         }
     }

--- a/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
+++ b/RoadFlare/RoadFlare/Views/Ride/RideRequestView.swift
@@ -78,7 +78,7 @@ struct RideRequestView: View {
                                 .padding(.horizontal, 32)
                             if appState.hasPingableDriver {
                                 Button("Ping a Driver") {
-                                    appState.selectedTab = 1
+                                    appState.requestPingDriverHint()
                                 }
                                 .buttonStyle(RFPrimaryButtonStyle())
                                 .padding(.horizontal, 48)

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -123,6 +123,14 @@ public final class AppState {
     /// `AddDriverSheet` pre-filled; the consumer is responsible for clearing
     /// it back to `nil` after the sheet is dismissed. See `handleIncomingURL`.
     public var pendingDriverDeepLink: ParsedDriverQRCode?
+    /// One-shot signal raised by `requestPingDriverHint()` when the user taps
+    /// the "Ping a Driver" CTA in the ride flow. `DriversTab` observes this
+    /// and pulses the bell icon on every visible driver card to teach the
+    /// affordance — issue #92. The value is a UUID rather than a Bool so that
+    /// successive taps register as distinct changes (an idempotent `true`
+    /// would not retrigger SwiftUI observers). The consumer is responsible
+    /// for clearing it back to `nil` after consuming.
+    public var pendingPingHint: UUID?
 
     // MARK: - SDK Services
 
@@ -733,6 +741,21 @@ public final class AppState {
         selectedTab = 1  // Drivers tab — see MainTabView.swift
     }
 
+    // MARK: - Ping Driver Hint
+
+    /// Entry point for the "Ping a Driver" CTA in the ride flow. Switches to
+    /// the Drivers tab and raises a one-shot bell-pulse signal so DriversTab
+    /// can teach first-time users that the bell icon is the tappable target.
+    /// Issue #92.
+    ///
+    /// Direct `selectedTab = 1` assignments (Add-a-Driver empty state,
+    /// SettingsTab quick links, deep links) bypass this method on purpose —
+    /// only the Ping-a-Driver path should trigger the pulse.
+    public func requestPingDriverHint() {
+        pendingPingHint = UUID()
+        selectedTab = 1
+    }
+
     // MARK: - Connection & Foreground
 
     /// Called when app returns to foreground. Reconnects relays and restarts subscriptions if needed.
@@ -1080,6 +1103,7 @@ public final class AppState {
             requestRideDriverPubkey = nil
             selectedTab = 0
             pendingDriverDeepLink = nil
+            pendingPingHint = nil
         }
         pingCooldowns = [:]
         keyRefreshCooldowns = [:]

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -1089,16 +1089,16 @@ public final class AppState {
 
         // 5. UI state
         // Navigation intents (`selectedTab`, `requestRideDriverPubkey`,
-        // `pendingDriverDeepLink`) are only cleared on actual REPLACEMENT
-        // of a prior identity (logout, key import/regen with a prior
-        // keypair). On first-time setup (`keypair == nil`), preserve them
-        // so cold-start state — e.g. a `roadflared:` URL tapped before
-        // onboarding sets `selectedTab = 1` and `pendingDriverDeepLink` —
-        // survives the user's first `generateNewKey` / `createWithPasskey`
-        // / `importKey` call (each of which routes through this function
-        // BEFORE establishing the new identity) and is consumed by
-        // `DriversTab` once the user reaches the main tab view post-`.ready`.
-        // See ADR-0012.
+        // `pendingDriverDeepLink`, `pendingPingHint`) are only cleared on
+        // actual REPLACEMENT of a prior identity (logout, key import/regen
+        // with a prior keypair). On first-time setup (`keypair == nil`),
+        // preserve them so cold-start state — e.g. a `roadflared:` URL
+        // tapped before onboarding sets `selectedTab = 1` and
+        // `pendingDriverDeepLink` — survives the user's first
+        // `generateNewKey` / `createWithPasskey` / `importKey` call (each
+        // of which routes through this function BEFORE establishing the
+        // new identity) and is consumed by `DriversTab` once the user
+        // reaches the main tab view post-`.ready`. See ADR-0012.
         if keypair != nil {
             requestRideDriverPubkey = nil
             selectedTab = 0

--- a/RoadFlare/RoadFlareTests/AppState/RequestPingDriverHintTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/RequestPingDriverHintTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import RoadFlareCore
+
+/// `AppState.requestPingDriverHint()` is the entry point for the "Ping a
+/// Driver" CTA in the ride flow (RideRequestView). It must (a) switch to the
+/// Drivers tab and (b) raise a one-shot `pendingPingHint` signal that the
+/// Drivers tab consumes to pulse the bell icons on driver cards. See
+/// issue #92 — the pulse teaches first-time users that the bell is the
+/// tappable target for sending a ping. Other code paths that switch to the
+/// Drivers tab (Add a Driver, deep link, settings) must NOT raise the hint;
+/// the pulse is specifically a "you got here from Ping a Driver" affordance.
+@Suite("AppState.requestPingDriverHint")
+struct RequestPingDriverHintTests {
+
+    @MainActor
+    @Test func setsPendingPingHint() {
+        let appState = AppState()
+        #expect(appState.pendingPingHint == nil)
+
+        appState.requestPingDriverHint()
+
+        #expect(appState.pendingPingHint != nil)
+    }
+
+    @MainActor
+    @Test func switchesToDriversTab() {
+        let appState = AppState()
+        appState.selectedTab = 0
+
+        appState.requestPingDriverHint()
+
+        #expect(appState.selectedTab == 1)
+    }
+
+    @MainActor
+    @Test func eachCallProducesDistinctHint() {
+        // The hint is a UUID? not a Bool — successive calls must mint a new
+        // value so DriversTab's `.onChange` observer re-fires when the user
+        // taps "Ping a Driver" twice (e.g. went back to ride flow, hit it
+        // again). With a Bool, a re-tap while the value is still `true`
+        // would not register as a change and the second pulse would be
+        // skipped.
+        let appState = AppState()
+        appState.requestPingDriverHint()
+        let first = appState.pendingPingHint
+        appState.requestPingDriverHint()
+        let second = appState.pendingPingHint
+
+        #expect(first != nil)
+        #expect(second != nil)
+        #expect(first != second)
+    }
+
+    @MainActor
+    @Test func directTabSwitchDoesNotRaiseHint() {
+        // Sanity: setting `selectedTab` directly (e.g. the "Add a Driver"
+        // empty-state CTA at RideRequestView.swift:60, the deep-link path,
+        // SettingsTab quick links) must NOT raise the bell-pulse hint. The
+        // pulse is specifically scoped to arrival via "Ping a Driver".
+        let appState = AppState()
+
+        appState.selectedTab = 1
+
+        #expect(appState.pendingPingHint == nil)
+    }
+}

--- a/RoadFlare/RoadFlareTests/AppState/RequestPingDriverHintTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/RequestPingDriverHintTests.swift
@@ -64,4 +64,31 @@ struct RequestPingDriverHintTests {
 
         #expect(appState.pendingPingHint == nil)
     }
+
+    @MainActor
+    @Test func pendingPingHintSurvivesIdentityReplacementWhenNoKeypair() async throws {
+        // Parallels `HandleIncomingURLTests.navigationIntentSurvivesIdentity-
+        // ReplacementWhenNoKeypair`: `prepareForIdentityReplacement` clears
+        // navigation intents only when there's a prior keypair. With no prior
+        // keypair (cold-start), the conditional must preserve `pendingPingHint`
+        // alongside `selectedTab`, `requestRideDriverPubkey`, and
+        // `pendingDriverDeepLink`. This pins the contract so a future refactor
+        // of the conditional doesn't accidentally drop `pendingPingHint` from
+        // the preservation set. See ADR-0012.
+        //
+        // The keypair-SET branch cannot be unit-tested here: RoadFlareTests
+        // lacks Keychain entitlement, so generateNewKey/createWithPasskey/
+        // importKey all fail with errSecMissingEntitlement (-34018). That
+        // branch is verified via the manual test plan in this PR.
+        let appState = AppState()
+        appState.requestPingDriverHint()
+        #expect(appState.pendingPingHint != nil)
+        #expect(appState.selectedTab == 1)
+        #expect(appState.keypair == nil)
+
+        await appState.logout()
+
+        #expect(appState.pendingPingHint != nil, "Ping hint must survive identity replacement when no prior keypair existed")
+        #expect(appState.selectedTab == 1, "Tab selection must survive identity replacement when no prior keypair existed")
+    }
 }


### PR DESCRIPTION
Closes #92.

## Summary

- New users tapping **Ping a Driver** in the ride flow had no visual cue that the bell on each driver card was the tappable target. This pulses every visible bell once on arrival to teach the affordance.
- `AppState` gains `pendingPingHint: UUID?` and `requestPingDriverHint()`. The CTA routes through the new method; other tab-switch entry points (Add a Driver, deep link, settings) bypass it on purpose so they never raise the hint.
- `DriversTab` mirrors the hint into a local `@State` trigger via `.onChange(initial: true)` and forwards it to each `DriverCard`. The bell uses a `phaseAnimator` (3 orange peaks, ~1.5s, easeInOut) and short-circuits to the static rest style under Reduce Motion.

## Animation rationale

`phaseAnimator` is the iOS 17+ idiom that fits a one-shot, multi-cycle effect: declare the phase sequence once, and SwiftUI runs it end-to-end whenever the trigger value changes. The phase array is `[0,1,0,1,0,1,0]` — six transitions, three full pulses, ending on rest so the icon settles back to its normal styling with no leftover state. The `.symbolEffect(.pulse)` already used elsewhere in the codebase only varies opacity; this hint also needs the orange tint and a slight scale, so a custom phase sequence was the clean fit.

The UUID-based trigger (rather than a `Bool`) is important: a re-tap of "Ping a Driver" while a previous `true` was still set would not register as a change and the second pulse would silently drop. Each tap mints a new UUID, so re-arriving fires the animation again.

## Tests

`RoadFlare/RoadFlareTests/AppState/RequestPingDriverHintTests.swift` pins the trigger contract:

- `setsPendingPingHint` — calling raises the hint.
- `switchesToDriversTab` — calling lands on the Drivers tab (`selectedTab = 1`).
- `eachCallProducesDistinctHint` — successive taps mint distinct UUIDs (re-trigger works).
- `directTabSwitchDoesNotRaiseHint` — direct `selectedTab = 1` (Add a Driver, deep link, settings) does NOT raise the hint.

Pulse animation behavior is purely declarative SwiftUI and verified visually on simulator.

## Test plan

- [x] `xcodebuild build` (RoadFlare scheme, iPhone 17, iOS 26.4) — clean
- [x] `xcodebuild test` (RoadFlareTests scheme) — all 19 suites pass, new suite included
- [ ] Manual: tap **Ping a Driver** from RideTab empty-state → land on Drivers tab → bells pulse orange ~1.5s, settle back to rest
- [ ] Manual: switch to Drivers tab via tab bar (no CTA) → no pulse
- [ ] Manual: re-tap **Ping a Driver** after pulse settles → bells pulse again
- [ ] Manual: enable Reduce Motion → no animation, bells stay at rest style
- [ ] Manual: VoiceOver still announces "Ping driver" / "Sends a notification..." unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)