### PR TITLE
fix(coordinators): unique subscription IDs in LocationCoordinator (#96)

### DIFF
--- a/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/LocationCoordinator.swift
@@ -90,8 +90,12 @@ final class LocationCoordinator {
             return
         }
 
-        let subId = SubscriptionID("roadflare-locations")
+        // Issue #96: per-invocation unique IDs prevent the empty-pubkeys → re-add race.
+        // The empty-path detached unsubscribe targets the OLD unique ID, never reused, so
+        // a late CLOSE cannot tear down a freshly-issued REQ. Same pattern in all three
+        // managed subscriptions (`startKeyShareSubscription`, `startDriverAvailabilitySubscription`).
         let generation = UUID()
+        let subId = SubscriptionID("roadflare-locations-\(generation.uuidString)")
 
         let task = Task {
             previous?.task.cancel()
@@ -168,8 +172,8 @@ final class LocationCoordinator {
             return
         }
 
-        let subId = SubscriptionID("driver-availability")
         let generation = UUID()
+        let subId = SubscriptionID("driver-availability-\(generation.uuidString)")
 
         let task = Task {
             previous?.task.cancel()
@@ -216,8 +220,8 @@ final class LocationCoordinator {
     func startKeyShareSubscription() {
         let previous = takeKeyShareSubscription()
 
-        let subId = SubscriptionID("key-shares")
         let generation = UUID()
+        let subId = SubscriptionID("key-shares-\(generation.uuidString)")
 
         let task = Task {
             previous?.task.cancel()

--- a/RoadFlare/RoadFlareTests/LocationCoordinatorSubscriptionRaceTests.swift
+++ b/RoadFlare/RoadFlareTests/LocationCoordinatorSubscriptionRaceTests.swift
@@ -15,9 +15,12 @@ import Testing
 @MainActor
 struct LocationCoordinatorSubscriptionRaceTests {
 
-    private static let locationPrefix = "roadflare-locations"
-    private static let availabilityPrefix = "driver-availability"
-    private static let keySharePrefix = "key-shares"
+    // Trailing dash anchors the match against the per-invocation UUID suffix,
+    // so a hypothetical future stable ID like `"key-shares-v2"` cannot silently
+    // satisfy these prefix checks.
+    private static let locationPrefix = "roadflare-locations-"
+    private static let availabilityPrefix = "driver-availability-"
+    private static let keySharePrefix = "key-shares-"
 
     private func makeBundle() throws -> (
         coordinator: LocationCoordinator,
@@ -115,7 +118,8 @@ struct LocationCoordinatorSubscriptionRaceTests {
                 "Re-added subscription must use a fresh ID; otherwise the empty-frame's detached unsubscribe can tear it down")
 
         // The detached unsubscribe targets the FIRST id, never the SECOND id.
-        _ = await eventually { fake.unsubscribeCalls.contains(firstID) }
+        #expect(await eventually { fake.unsubscribeCalls.contains(firstID) },
+                "Empty-pubkeys path must unsubscribe the prior subscription so the negative assertion below is meaningful")
         #expect(!fake.unsubscribeCalls.contains(secondID),
                 "A late unsubscribe targeting the new ID would prove the race is still possible")
     }

--- a/RoadFlare/RoadFlareTests/LocationCoordinatorSubscriptionRaceTests.swift
+++ b/RoadFlare/RoadFlareTests/LocationCoordinatorSubscriptionRaceTests.swift
@@ -117,11 +117,23 @@ struct LocationCoordinatorSubscriptionRaceTests {
         #expect(firstID != secondID,
                 "Re-added subscription must use a fresh ID; otherwise the empty-frame's detached unsubscribe can tear it down")
 
-        // The detached unsubscribe targets the FIRST id, never the SECOND id.
+        // The new subscription must be live on the relay BEFORE the detached
+        // unsubscribe of `firstID` lands — otherwise we cannot tell whether the
+        // teardown survived.
+        #expect(await eventually { fake.isSubscriptionActive(secondID.rawValue) },
+                "Re-added subscription must register a live relay continuation")
+
+        // Now wait for the empty-frame's detached unsubscribe to fully resolve,
+        // and assert the new subscription is STILL live afterwards. With unique
+        // IDs the unsubscribe targets `firstID` only and cannot remove
+        // `secondID`'s continuation. With the old stable-ID design, `firstID`
+        // and `secondID` would collide and this assertion would fail.
         #expect(await eventually { fake.unsubscribeCalls.contains(firstID) },
-                "Empty-pubkeys path must unsubscribe the prior subscription so the negative assertion below is meaningful")
+                "Empty-pubkeys path must unsubscribe the prior subscription")
+        #expect(fake.isSubscriptionActive(secondID.rawValue),
+                "Late detached unsubscribe of firstID must not tear down secondID — events still flow")
         #expect(!fake.unsubscribeCalls.contains(secondID),
-                "A late unsubscribe targeting the new ID would prove the race is still possible")
+                "Defense in depth: secondID must never appear in unsubscribe calls in this sequence")
     }
 
     @Test func locationSubscriptionEmptyTearsDownPriorSubscription() async throws {
@@ -195,10 +207,15 @@ struct LocationCoordinatorSubscriptionRaceTests {
 
         let secondID = fake.subscribeCalls
             .last(where: { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) })!.id
-        #expect(firstID != secondID)
+        #expect(firstID != secondID,
+                "Re-added subscription must use a fresh ID")
 
+        #expect(await eventually { fake.isSubscriptionActive(secondID.rawValue) },
+                "Re-added subscription must register a live relay continuation")
         #expect(await eventually { fake.unsubscribeCalls.contains(firstID) },
-                "Empty-pubkeys path must unsubscribe the prior subscription so the negative assertion below is meaningful")
+                "Empty-pubkeys path must unsubscribe the prior subscription")
+        #expect(fake.isSubscriptionActive(secondID.rawValue),
+                "Late detached unsubscribe of firstID must not tear down secondID — events still flow")
         #expect(!fake.unsubscribeCalls.contains(secondID))
     }
 

--- a/RoadFlare/RoadFlareTests/LocationCoordinatorSubscriptionRaceTests.swift
+++ b/RoadFlare/RoadFlareTests/LocationCoordinatorSubscriptionRaceTests.swift
@@ -197,7 +197,8 @@ struct LocationCoordinatorSubscriptionRaceTests {
             .last(where: { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) })!.id
         #expect(firstID != secondID)
 
-        _ = await eventually { fake.unsubscribeCalls.contains(firstID) }
+        #expect(await eventually { fake.unsubscribeCalls.contains(firstID) },
+                "Empty-pubkeys path must unsubscribe the prior subscription so the negative assertion below is meaningful")
         #expect(!fake.unsubscribeCalls.contains(secondID))
     }
 

--- a/RoadFlare/RoadFlareTests/LocationCoordinatorSubscriptionRaceTests.swift
+++ b/RoadFlare/RoadFlareTests/LocationCoordinatorSubscriptionRaceTests.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Testing
+@testable import RoadFlareCore
+@testable import RidestrSDK
+
+/// Tests for issue #96: subscription IDs in `LocationCoordinator` must be unique per
+/// invocation so the empty-pubkeys → re-add path cannot let a stale CLOSE silently
+/// tear down a freshly-issued REQ that happens to share the same stable ID.
+///
+/// The load-bearing invariant pinned here is: across any sequence of
+/// `start*Subscription[s]()` calls, no two REQs are ever issued with the same
+/// `SubscriptionID.rawValue`. Detached unsubscribe Tasks from a prior generation
+/// then cannot collide with a later generation's subscription.
+@Suite("LocationCoordinator subscription race (issue #96)")
+@MainActor
+struct LocationCoordinatorSubscriptionRaceTests {
+
+    private static let locationPrefix = "roadflare-locations"
+    private static let availabilityPrefix = "driver-availability"
+    private static let keySharePrefix = "key-shares"
+
+    private func makeBundle() throws -> (
+        coordinator: LocationCoordinator,
+        fake: FakeRelayManager,
+        repo: FollowedDriversRepository,
+        keypair: NostrKeypair
+    ) {
+        let fake = FakeRelayManager()
+        fake.keepSubscriptionsAlive = true
+        let keypair = try NostrKeypair.generate()
+        let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+        let coordinator = LocationCoordinator(
+            relayManager: fake,
+            keypair: keypair,
+            driversRepository: repo
+        )
+        return (coordinator, fake, repo, keypair)
+    }
+
+    private func eventually(
+        timeout: Duration = .seconds(1),
+        pollInterval: Duration = .milliseconds(10),
+        _ condition: () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while !condition() {
+            if clock.now >= deadline { return false }
+            try? await Task.sleep(for: pollInterval)
+        }
+        return true
+    }
+
+    private func makeDriver() throws -> FollowedDriver {
+        let kp = try NostrKeypair.generate()
+        return FollowedDriver(pubkey: kp.publicKeyHex)
+    }
+
+    // MARK: - Location subscription (Kind 30014)
+
+    @Test func locationSubscriptionAssignsUniqueIDPerInvocation() async throws {
+        let (coordinator, fake, repo, _) = try makeBundle()
+        try await fake.connect(to: [URL(string: "wss://test")!])
+
+        repo.addDriver(try makeDriver())
+        coordinator.startLocationSubscriptions()
+        #expect(await eventually {
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix(Self.locationPrefix) }.count >= 1
+        })
+
+        coordinator.startLocationSubscriptions()
+        #expect(await eventually {
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix(Self.locationPrefix) }.count >= 2
+        })
+
+        let ids = fake.subscribeCalls
+            .map(\.id.rawValue)
+            .filter { $0.hasPrefix(Self.locationPrefix) }
+        #expect(Set(ids).count == ids.count, "Subscription IDs must be unique across invocations")
+    }
+
+    @Test func locationSubscriptionEmptyThenReaddDoesNotReuseID() async throws {
+        // Reproduces the issue #96 race shape: a transient empty-pubkeys frame
+        // between two non-empty frames must not let the second frame reuse the
+        // first frame's subscription ID. With unique IDs the detached
+        // unsubscribe from the empty frame can never collide with the new REQ.
+        let (coordinator, fake, repo, _) = try makeBundle()
+        try await fake.connect(to: [URL(string: "wss://test")!])
+
+        let driverA = try makeDriver()
+        let driverB = try makeDriver()
+
+        repo.addDriver(driverA)
+        coordinator.startLocationSubscriptions()
+        #expect(await eventually {
+            fake.subscribeCalls.contains { $0.id.rawValue.hasPrefix(Self.locationPrefix) }
+        })
+        let firstID = fake.subscribeCalls
+            .last(where: { $0.id.rawValue.hasPrefix(Self.locationPrefix) })!.id
+
+        repo.removeDriver(pubkey: driverA.pubkey)
+        coordinator.startLocationSubscriptions()  // empty-pubkeys path
+
+        repo.addDriver(driverB)
+        coordinator.startLocationSubscriptions()
+
+        #expect(await eventually {
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix(Self.locationPrefix) }.count >= 2
+        })
+
+        let secondID = fake.subscribeCalls
+            .last(where: { $0.id.rawValue.hasPrefix(Self.locationPrefix) })!.id
+
+        #expect(firstID != secondID,
+                "Re-added subscription must use a fresh ID; otherwise the empty-frame's detached unsubscribe can tear it down")
+
+        // The detached unsubscribe targets the FIRST id, never the SECOND id.
+        _ = await eventually { fake.unsubscribeCalls.contains(firstID) }
+        #expect(!fake.unsubscribeCalls.contains(secondID),
+                "A late unsubscribe targeting the new ID would prove the race is still possible")
+    }
+
+    @Test func locationSubscriptionEmptyTearsDownPriorSubscription() async throws {
+        let (coordinator, fake, repo, _) = try makeBundle()
+        try await fake.connect(to: [URL(string: "wss://test")!])
+
+        let driver = try makeDriver()
+        repo.addDriver(driver)
+        coordinator.startLocationSubscriptions()
+        #expect(await eventually {
+            fake.subscribeCalls.contains { $0.id.rawValue.hasPrefix(Self.locationPrefix) }
+        })
+        let priorID = fake.subscribeCalls
+            .last(where: { $0.id.rawValue.hasPrefix(Self.locationPrefix) })!.id
+
+        repo.removeDriver(pubkey: driver.pubkey)
+        coordinator.startLocationSubscriptions()  // empty path
+
+        #expect(await eventually {
+            fake.unsubscribeCalls.contains(priorID)
+        }, "Empty-pubkeys path must unsubscribe the prior subscription by its unique ID")
+    }
+
+    // MARK: - Driver availability subscription (Kind 30173)
+
+    @Test func driverAvailabilitySubscriptionAssignsUniqueIDPerInvocation() async throws {
+        let (coordinator, fake, repo, _) = try makeBundle()
+        try await fake.connect(to: [URL(string: "wss://test")!])
+
+        repo.addDriver(try makeDriver())
+        coordinator.startDriverAvailabilitySubscription()
+        #expect(await eventually {
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) }.count >= 1
+        })
+
+        coordinator.startDriverAvailabilitySubscription()
+        #expect(await eventually {
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) }.count >= 2
+        })
+
+        let ids = fake.subscribeCalls
+            .map(\.id.rawValue)
+            .filter { $0.hasPrefix(Self.availabilityPrefix) }
+        #expect(Set(ids).count == ids.count, "Subscription IDs must be unique across invocations")
+    }
+
+    @Test func driverAvailabilityEmptyThenReaddDoesNotReuseID() async throws {
+        let (coordinator, fake, repo, _) = try makeBundle()
+        try await fake.connect(to: [URL(string: "wss://test")!])
+
+        let driverA = try makeDriver()
+        let driverB = try makeDriver()
+
+        repo.addDriver(driverA)
+        coordinator.startDriverAvailabilitySubscription()
+        #expect(await eventually {
+            fake.subscribeCalls.contains { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) }
+        })
+        let firstID = fake.subscribeCalls
+            .last(where: { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) })!.id
+
+        repo.removeDriver(pubkey: driverA.pubkey)
+        coordinator.startDriverAvailabilitySubscription()  // empty path
+
+        repo.addDriver(driverB)
+        coordinator.startDriverAvailabilitySubscription()
+
+        #expect(await eventually {
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) }.count >= 2
+        })
+
+        let secondID = fake.subscribeCalls
+            .last(where: { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) })!.id
+        #expect(firstID != secondID)
+
+        _ = await eventually { fake.unsubscribeCalls.contains(firstID) }
+        #expect(!fake.unsubscribeCalls.contains(secondID))
+    }
+
+    @Test func driverAvailabilityEmptyTearsDownPriorSubscription() async throws {
+        let (coordinator, fake, repo, _) = try makeBundle()
+        try await fake.connect(to: [URL(string: "wss://test")!])
+
+        let driver = try makeDriver()
+        repo.addDriver(driver)
+        coordinator.startDriverAvailabilitySubscription()
+        #expect(await eventually {
+            fake.subscribeCalls.contains { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) }
+        })
+        let priorID = fake.subscribeCalls
+            .last(where: { $0.id.rawValue.hasPrefix(Self.availabilityPrefix) })!.id
+
+        repo.removeDriver(pubkey: driver.pubkey)
+        coordinator.startDriverAvailabilitySubscription()
+
+        #expect(await eventually {
+            fake.unsubscribeCalls.contains(priorID)
+        })
+    }
+
+    // MARK: - Key share subscription (Kind 3186)
+
+    // Key-share has no empty-pubkeys branch (it filters on the rider's own pubkey),
+    // but the same uniqueness pattern applies: rapid consecutive restarts must not
+    // reuse the stable string ID. This pins the pattern uniformly across all three
+    // managed subscriptions.
+    @Test func keyShareSubscriptionAssignsUniqueIDPerInvocation() async throws {
+        let (coordinator, fake, _, _) = try makeBundle()
+        try await fake.connect(to: [URL(string: "wss://test")!])
+
+        coordinator.startKeyShareSubscription()
+        #expect(await eventually {
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix(Self.keySharePrefix) }.count >= 1
+        })
+
+        coordinator.startKeyShareSubscription()
+        #expect(await eventually {
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix(Self.keySharePrefix) }.count >= 2
+        })
+
+        let ids = fake.subscribeCalls
+            .map(\.id.rawValue)
+            .filter { $0.hasPrefix(Self.keySharePrefix) }
+        #expect(Set(ids).count == ids.count, "Subscription IDs must be unique across invocations")
+    }
+
+    @Test func keyShareSubscriptionTearsDownPriorOnRestart() async throws {
+        let (coordinator, fake, _, _) = try makeBundle()
+        try await fake.connect(to: [URL(string: "wss://test")!])
+
+        coordinator.startKeyShareSubscription()
+        #expect(await eventually {
+            fake.subscribeCalls.contains { $0.id.rawValue.hasPrefix(Self.keySharePrefix) }
+        })
+        let priorID = fake.subscribeCalls
+            .last(where: { $0.id.rawValue.hasPrefix(Self.keySharePrefix) })!.id
+
+        coordinator.startKeyShareSubscription()
+        #expect(await eventually {
+            fake.unsubscribeCalls.contains(priorID)
+        })
+        // Wait for the second subscribe to actually land before reading the latest id —
+        // the unsubscribe of the prior id happens before the new subscribe inside the
+        // restart Task, so the two events are not simultaneous.
+        #expect(await eventually {
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix(Self.keySharePrefix) }.count >= 2
+        })
+
+        let secondID = fake.subscribeCalls
+            .last(where: { $0.id.rawValue.hasPrefix(Self.keySharePrefix) })!.id
+        #expect(priorID != secondID)
+    }
+}

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -239,7 +239,7 @@ struct RideCoordinatorTests {
         // Step 1: establish initial location subscription so there is something to tear down.
         coordinator.location.startLocationSubscriptions()
         let initialSubscribed = await eventually {
-            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix("roadflare-locations") }.count >= 1
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix("roadflare-locations-") }.count >= 1
         }
         #expect(initialSubscribed, "initial subscribe must be established before key share arrives")
 
@@ -272,10 +272,10 @@ struct RideCoordinatorTests {
         // count >= 2 proves startLocationSubscriptions() fired twice.
         // unsubscribeCalls proves the old subscription was torn down first (LocationCoordinator.swift:71).
         let restarted = await eventually {
-            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix("roadflare-locations") }.count >= 2
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix("roadflare-locations-") }.count >= 2
         }
         #expect(restarted, "startLocationSubscriptions() must fire a second time after appliedNewer")
-        let unsubscribed = fake.unsubscribeCalls.contains { $0.rawValue.hasPrefix("roadflare-locations") }
+        let unsubscribed = fake.unsubscribeCalls.contains { $0.rawValue.hasPrefix("roadflare-locations-") }
         #expect(unsubscribed, "old location subscription must be torn down before the new one starts")
         #expect(fake.publishedEvents.contains { $0.kind == EventKind.followedDriversList.rawValue },
                 "appliedNewer key share must republish the followed-drivers list (Kind 30011)")
@@ -665,7 +665,7 @@ struct RideCoordinatorTests {
         await coordinator.restoreLiveSubscriptions()
 
         let wired = await eventually {
-            fake.subscribeCalls.contains { $0.id.rawValue.hasPrefix("key-shares") } &&
+            fake.subscribeCalls.contains { $0.id.rawValue.hasPrefix("key-shares-") } &&
                 fake.subscribeCalls.contains { $0.id.rawValue == "driver-state-\(rideCoordinatorConfirmationEventId)" } &&
                 fake.subscribeCalls.contains { $0.id.rawValue == "cancel-\(rideCoordinatorConfirmationEventId)" } &&
                 fake.subscribeCalls.contains { $0.id.rawValue == "chat-\(rideCoordinatorConfirmationEventId)" }

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -239,7 +239,7 @@ struct RideCoordinatorTests {
         // Step 1: establish initial location subscription so there is something to tear down.
         coordinator.location.startLocationSubscriptions()
         let initialSubscribed = await eventually {
-            fake.subscribeCalls.filter { $0.id.rawValue == "roadflare-locations" }.count >= 1
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix("roadflare-locations") }.count >= 1
         }
         #expect(initialSubscribed, "initial subscribe must be established before key share arrives")
 
@@ -272,10 +272,10 @@ struct RideCoordinatorTests {
         // count >= 2 proves startLocationSubscriptions() fired twice.
         // unsubscribeCalls proves the old subscription was torn down first (LocationCoordinator.swift:71).
         let restarted = await eventually {
-            fake.subscribeCalls.filter { $0.id.rawValue == "roadflare-locations" }.count >= 2
+            fake.subscribeCalls.filter { $0.id.rawValue.hasPrefix("roadflare-locations") }.count >= 2
         }
         #expect(restarted, "startLocationSubscriptions() must fire a second time after appliedNewer")
-        let unsubscribed = fake.unsubscribeCalls.contains { $0.rawValue == "roadflare-locations" }
+        let unsubscribed = fake.unsubscribeCalls.contains { $0.rawValue.hasPrefix("roadflare-locations") }
         #expect(unsubscribed, "old location subscription must be torn down before the new one starts")
         #expect(fake.publishedEvents.contains { $0.kind == EventKind.followedDriversList.rawValue },
                 "appliedNewer key share must republish the followed-drivers list (Kind 30011)")
@@ -665,7 +665,7 @@ struct RideCoordinatorTests {
         await coordinator.restoreLiveSubscriptions()
 
         let wired = await eventually {
-            fake.subscribeCalls.contains { $0.id.rawValue == "key-shares" } &&
+            fake.subscribeCalls.contains { $0.id.rawValue.hasPrefix("key-shares") } &&
                 fake.subscribeCalls.contains { $0.id.rawValue == "driver-state-\(rideCoordinatorConfirmationEventId)" } &&
                 fake.subscribeCalls.contains { $0.id.rawValue == "cancel-\(rideCoordinatorConfirmationEventId)" } &&
                 fake.subscribeCalls.contains { $0.id.rawValue == "chat-\(rideCoordinatorConfirmationEventId)" }


### PR DESCRIPTION
Closes #96.

## The race

All three managed subscriptions in `LocationCoordinator` shared a stable string ID:
`roadflare-locations`, `driver-availability`, and `key-shares`. On the
empty-pubkeys → re-add path the empty frame schedules `unsubscribe(staleId)` in
a detached `Task`, then a fast non-empty follow-up reuses the same stable ID
for a new `subscribe(...)`. If the detached unsubscribe resolves *after* the
new subscribe lands, the relay silently tears down the freshly-issued REQ —
events stop flowing until something unrelated restarts the subscription.

The race window is small (relays usually order REQ/CLOSE on a single connection)
and empty → non-empty pubkey transitions are uncommon, which is why nothing has
been visibly broken in production. Lost events are silent: the app never observes
"I expected an event and didn't get one."

Surfaced as F4 during the PR #93 review and skipped there with the note
"would create inconsistency; fixing all three is separate scope."

## The unified pattern

For each `start*Subscription[s]()` call, append the generation UUID to the
subscription ID:

```swift
let generation = UUID()
let subId = SubscriptionID("roadflare-locations-\(generation.uuidString)")
```

The detached unsubscribe from a prior generation targets an ID that is **never
reused**, so a late CLOSE can no longer collide with any future REQ. Applied
identically in `startLocationSubscriptions`, `startDriverAvailabilitySubscription`,
and `startKeyShareSubscription`. Key-share has no empty-pubkeys branch, but
inheriting the same uniqueness pattern keeps the three call sites in lockstep
so future edits cannot reintroduce the race in one of them.

No callers depend on the string format — the IDs only round-trip through
`ManagedSubscription`. Two existing tests in `RideCoordinatorTests` that
asserted exact equality with the old hardcoded strings are switched to
`hasPrefix`.

## Why this pattern over alternatives

- **Debounce teardown** — adds a timing knob and still loses the first event
  burst on the new sub if N is too short.
- **Single subscription with dynamic filter** — would require the relay manager
  to expose filter mutation, a much larger change touching the SDK boundary.
- **Generation counter alone** — already present (`activeXSubscription?.generation`
  guards in-flight task bodies) but does not protect the relay-side ID, which is
  what was racing.

Per-invocation unique IDs are the smallest change that closes the race for all
three subscriptions identically.

## Tests

`RoadFlare/RoadFlareTests/LocationCoordinatorSubscriptionRaceTests.swift` (new)
pins the no-collision invariant per subscription:

- **Location:** unique ID per invocation; empty → re-add does not reuse ID;
  empty path tears down the prior subscription by its unique ID.
- **Driver availability:** same triplet.
- **Key share:** unique ID per invocation; restart unsubscribes the prior ID
  before issuing a fresh one.

`RoadFlare/RoadFlareTests/RideCoordinatorTests.swift` updated to use
`hasPrefix("roadflare-locations")` / `hasPrefix("key-shares")` instead of exact
equality on the now-unique IDs.

## Test plan

- [x] `xcodebuild ... -scheme RoadFlareTests test` — full suite green
- [x] `swift test --package-path RidestrSDK` — 838 tests green
- [x] New `LocationCoordinatorSubscriptionRaceTests` — 8/8 cases stable across
  5 consecutive runs (initial run surfaced one timing-sensitive assertion in
  `keyShareSubscriptionTearsDownPriorOnRestart`, hardened by waiting for the
  second subscribe to land before reading the latest ID)