### PR TITLE
fix(drivers): drop vehicle line from Drivers tab list cards

### DIFF
--- a/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
+++ b/RoadFlare/RoadFlare/Views/Drivers/DriversTab.swift
@@ -233,20 +233,10 @@ struct DriverCard: View {
                         .foregroundColor(Color.rfOnSurface)
                         .lineLimit(1)
 
-                    HStack(spacing: 0) {
-                        if let vehicle = item.vehicleDescription {
-                            Text(vehicle.uppercased())
-                                .font(RFFont.caption(11))
-                                .foregroundColor(Color.rfOnSurfaceVariant)
-                            Text(" · ")
-                                .font(RFFont.caption(11))
-                                .foregroundColor(Color.rfOffline)
-                        }
-                        Text(statusText)
-                            .font(RFFont.caption(11))
-                            .foregroundColor(statusColor)
-                    }
-                    .lineLimit(1)
+                    Text(statusText)
+                        .font(RFFont.caption(11))
+                        .foregroundColor(statusColor)
+                        .lineLimit(1)
 
                     // Status badge / request button
                     if item.canRequestRide {


### PR DESCRIPTION
## Summary

- Drops the vehicle text + ` · ` separator from the driver list card on the Drivers tab — it was crowding the row, and the info isn't actionable until you're picking a driver (detail sheet) or matching the car curbside (ride flow).
- Detail sheet (`DriverDetailSheet.swift:26-28`) still renders `LabeledContent("Vehicle", …)`.
- Ride-flow `RideStatusCard` (`RidestrUI/Sources/RidestrUI/Components/RideStatusCard.swift`) still renders `vehicleDescriptionLabel`.
- Underlying kind 30173 subscription / `UserProfileContent.vehicleDescription` parsing (#91) is untouched — vehicle data is still available, just not on the list cards.

Closes #107

## Test plan

- [ ] Drivers tab → list cards: only display name + status caption (no vehicle line)
- [ ] Tap a driver card → detail sheet still shows "Vehicle" row
- [ ] Start a ride → `RideStatusCard` in active ride still shows vehicle description
- [ ] Drivers without `vehicleDescription` → status caption renders identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)