### PR TITLE
fix(settings): hide build number from in-app version label

### DIFF
--- a/RoadFlare/RoadFlare/Extensions/Bundle+AppVersion.swift
+++ b/RoadFlare/RoadFlare/Extensions/Bundle+AppVersion.swift
@@ -2,9 +2,7 @@ import Foundation
 
 extension Bundle {
     var appVersionLabel: String {
-        let info = infoDictionary
-        let marketing = info?["CFBundleShortVersionString"] as? String ?? "?"
-        let build = info?["CFBundleVersion"] as? String ?? "?"
-        return "Version \(marketing) (\(build))"
+        let marketing = infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        return "Version \(marketing)"
     }
 }


### PR DESCRIPTION
## Summary
- Drop the `(build)` suffix from `Bundle.appVersionLabel` so the in-app version reads `Version 1.0.2` instead of `Version 1.0.2 (2)`
- Affects the Settings tab and the App Info screen, both of which render `Bundle.main.appVersionLabel`

Closes #109

## Test plan
- [x] `xcodebuild` build succeeds for the RoadFlare scheme
- [ ] Manually verify Settings tab shows `Version <marketing>` without trailing build number
- [ ] Manually verify App Info screen shows the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)