### PR TITLE
feat(app): Universal Links for roadflare.app share pages (#63)

### DIFF
--- a/RoadFlare/RoadFlare/RoadFlare.entitlements
+++ b/RoadFlare/RoadFlare/RoadFlare.entitlements
@@ -4,6 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:roadflare.app</string>
 		<string>webcredentials:roadflare.app</string>
 	</array>
 </dict>

--- a/RoadFlare/RoadFlare/RoadFlareApp.swift
+++ b/RoadFlare/RoadFlare/RoadFlareApp.swift
@@ -35,6 +35,14 @@ struct RoadFlareApp: App {
                     // the parsed driver intent into the drivers tab.
                     appState.handleIncomingURL(url)
                 }
+                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                    // Universal Link dispatch (e.g. `https://roadflare.app/share/d/npub1...`).
+                    // Symmetric with `.onOpenURL` above; AppState extracts the
+                    // `webpageURL` and routes through the same `handleIncomingURL`
+                    // path. Requires `applinks:roadflare.app` in entitlements
+                    // plus the AASA file hosted on roadflare.app — see issue #63.
+                    appState.handleIncomingUserActivity(activity)
+                }
         }
     }
 }

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState.swift
@@ -741,6 +741,20 @@ public final class AppState {
         selectedTab = 1  // Drivers tab — see MainTabView.swift
     }
 
+    /// Route an incoming Universal Link user activity into the app.
+    ///
+    /// Universal Links from `https://roadflare.app/share/...` arrive as an
+    /// `NSUserActivity` of type `NSUserActivityTypeBrowsingWeb` with the URL
+    /// in `webpageURL`. Extract the URL and dispatch through the same path
+    /// as custom-scheme URLs — `DriverQRCodeParser` already accepts the
+    /// `https://roadflare.app/share/d/<npub>` and `/share/r/<npub>` shapes.
+    /// Requires `applinks:roadflare.app` in entitlements and the AASA file
+    /// at `https://roadflare.app/.well-known/apple-app-site-association`.
+    public func handleIncomingUserActivity(_ activity: NSUserActivity) {
+        guard let url = activity.webpageURL else { return }
+        handleIncomingURL(url)
+    }
+
     // MARK: - Ping Driver Hint
 
     /// Entry point for the "Ping a Driver" CTA in the ride flow. Switches to

--- a/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
@@ -187,4 +187,29 @@ struct HandleIncomingURLTests {
         #expect(appState.pendingDriverDeepLink != nil, "Deep link must survive identity replacement when no prior keypair existed")
         #expect(appState.selectedTab == 1, "Tab selection must survive identity replacement when no prior keypair existed")
     }
+
+    @MainActor
+    @Test func userActivityNavigationIntentSurvivesIdentityReplacementWhenNoKeypair() async throws {
+        // Cold-start regression parity for Universal Links: same invariant as
+        // `navigationIntentSurvivesIdentityReplacementWhenNoKeypair` above, but
+        // exercised through `handleIncomingUserActivity`. Universal Links are
+        // the long-term primary share path (per ADR-0012 + issue #63), so the
+        // pre-onboarding tap path needs explicit coverage on this entry point
+        // — not just the `roadflared:` shim. See PR #66 for the precedent of
+        // pinning parallel regression coverage on each new entry seam.
+        let appState = AppState()
+        let npub = try makeNpub(hex: String(repeating: "8e", count: 32))
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = URL(string: "https://roadflare.app/share/d/\(npub)")
+
+        appState.handleIncomingUserActivity(activity)
+        #expect(appState.pendingDriverDeepLink != nil)
+        #expect(appState.selectedTab == 1)
+        #expect(appState.keypair == nil)
+
+        await appState.logout()
+
+        #expect(appState.pendingDriverDeepLink != nil, "Universal Link intent must survive identity replacement when no prior keypair existed")
+        #expect(appState.selectedTab == 1, "Tab selection must survive identity replacement when no prior keypair existed")
+    }
 }

--- a/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
@@ -86,6 +86,74 @@ struct HandleIncomingURLTests {
     }
 
     @MainActor
+    @Test func universalLinkDriverShareRoutesToDriversTab() throws {
+        // Universal Links from `https://roadflare.app/share/d/<npub>` arrive
+        // via `.onContinueUserActivity(NSUserActivityTypeBrowsingWeb)`.
+        // `handleIncomingUserActivity` extracts `webpageURL` and dispatches
+        // through the same `handleIncomingURL` path used by the custom scheme.
+        // Issue #63.
+        let appState = AppState()
+        appState.selectedTab = 0
+        let npub = try makeNpub(hex: String(repeating: "6f", count: 32))
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = URL(string: "https://roadflare.app/share/d/\(npub)?name=Universal%20Linker")
+
+        appState.handleIncomingUserActivity(activity)
+
+        #expect(appState.pendingDriverDeepLink == ParsedDriverQRCode(pubkeyInput: npub, scannedName: "Universal Linker"))
+        #expect(appState.selectedTab == 1)
+    }
+
+    @MainActor
+    @Test func universalLinkRiderShareRoutesToDriversTab() throws {
+        // `/share/r/<npub>` URLs go through the same parser path — the
+        // parser extracts the embedded npub regardless of `d` vs `r` segment.
+        // Routing them to the drivers tab is consistent with the parser's
+        // existing behavior for the matching custom-scheme inputs.
+        let appState = AppState()
+        appState.selectedTab = 0
+        let npub = try makeNpub(hex: String(repeating: "7a", count: 32))
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = URL(string: "https://roadflare.app/share/r/\(npub)")
+
+        appState.handleIncomingUserActivity(activity)
+
+        #expect(appState.pendingDriverDeepLink == ParsedDriverQRCode(pubkeyInput: npub, scannedName: nil))
+        #expect(appState.selectedTab == 1)
+    }
+
+    @MainActor
+    @Test func userActivityWithoutWebpageURLIsDropped() {
+        // If the activity arrives without a `webpageURL` (shouldn't happen
+        // for `NSUserActivityTypeBrowsingWeb` in practice, but defend anyway),
+        // nothing happens — tab stays put, no deep-link intent populated.
+        let appState = AppState()
+        appState.selectedTab = 0
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+
+        appState.handleIncomingUserActivity(activity)
+
+        #expect(appState.pendingDriverDeepLink == nil)
+        #expect(appState.selectedTab == 0)
+    }
+
+    @MainActor
+    @Test func universalLinkUnknownPathIsDropped() {
+        // Unknown roadflare.app paths (no embedded npub) drop silently —
+        // the AASA `components` filter should keep them out of the app in
+        // production, but the in-app parser is the second line of defense.
+        let appState = AppState()
+        appState.selectedTab = 0
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = URL(string: "https://roadflare.app/about")
+
+        appState.handleIncomingUserActivity(activity)
+
+        #expect(appState.pendingDriverDeepLink == nil)
+        #expect(appState.selectedTab == 0)
+    }
+
+    @MainActor
     @Test func navigationIntentSurvivesIdentityReplacementWhenNoKeypair() async throws {
         // Cold-start regression: when a `roadflared:` URL arrives before the
         // user has created an account (keypair is nil), the conditional in


### PR DESCRIPTION
Closes #63.

## Summary

Tap `https://roadflare.app/share/d/<npub>` or `/share/r/<npub>` on a
device with RoadFlare installed → app opens with the Add Driver sheet
pre-filled. Falls back to the existing share page (with App Store CTA)
when the app isn't installed — the long-term primary share UX, replacing
the custom `roadflared:` scheme from PR #66 as the marketing-link path
once the AASA file ships.

## Architecture

This is the deferred Universal Links work anticipated by [ADR-0012](decisions/0012-roadflared-url-scheme.md)
(\"the `AppState.handleIncomingURL` plumbing is reusable when Universal
Links land\"). No new ADR — the routing pattern is the same one the ADR
documents, just with a second SwiftUI scene modifier feeding into it.

Routing pattern: **`.onContinueUserActivity` → `AppState.handleIncomingUserActivity` → existing `handleIncomingURL` → existing parser → existing `pendingDriverDeepLink` → existing `DriversTab` observer → existing `AddDriverSheet(prefill:)`**.

Symmetric with the `.onOpenURL` modifier added in PR #66. The
`DriverQRCodeParser.parseURLOrEmbeddedNpub` arm already accepts the
`https://roadflare.app/share/...` URL shape, so this PR is purely
routing-layer wiring.

## What's in the diff

| File | Change |
|---|---|
| `RoadFlare/RoadFlare/RoadFlare.entitlements` | Add `applinks:roadflare.app` alongside the existing `webcredentials:` entry |
| `RoadFlare/RoadFlare/RoadFlareApp.swift` | Add `.onContinueUserActivity(NSUserActivityTypeBrowsingWeb)` modifier mirroring `.onOpenURL` |
| `RoadFlare/RoadFlareCore/ViewModels/AppState.swift` | Add `handleIncomingUserActivity(_ activity: NSUserActivity)` — thin wrapper that extracts `webpageURL` and routes through `handleIncomingURL` |
| `RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift` | 4 new Swift Testing cases |

Total: 4 files, 91 insertions, 0 deletions. All additive — no existing signatures change. No parser changes; no view changes; no SDK changes.

## :warning: AASA prerequisite — required for production

The Associated Domains entitlement is only half of Universal Links.
**Apple's CDN must be able to fetch a valid `apple-app-site-association`
file from `https://roadflare.app/.well-known/apple-app-site-association`**
or this PR is a no-op in production.

The site work is tracked separately at [roadflare-site#4](https://github.com/variablefate/roadflare-site/pull/4) (related draft). The AASA JSON should look like:

```json
{
  \"applinks\": {
    \"details\": [
      {
        \"appIDs\": [\"6Y98438M9X.com.roadflare.RoadFlare\"],
        \"components\": [
          { \"/\": \"/share/d/*\", \"comment\": \"Driver profile share\" },
          { \"/\": \"/share/r/*\", \"comment\": \"Rider profile share\" }
        ]
      }
    ]
  },
  \"webcredentials\": {
    \"apps\": [\"6Y98438M9X.com.roadflare.RoadFlare\"]
  }
}
```

Team ID `6Y98438M9X` and Bundle ID `com.roadflare.RoadFlare` confirmed against `RoadFlare.xcodeproj/project.pbxproj`. The `webcredentials` section preserves the existing Sign in with Apple Passwords integration.

Notes for shipping:
- Must be served with `Content-Type: application/json` (GitHub Pages does this by default for `.well-known/` static files).
- Apple's CDN caches AASA aggressively. New installs pull fresh; existing installs may need `Settings → Developer → Associated Domains Development` to re-fetch during testing.
- HTTPS is required (it is — `roadflare.app` is HTTPS-only).

## Tests

4 new tests in `HandleIncomingURLTests`:

- `universalLinkDriverShareRoutesToDriversTab` — `https://roadflare.app/share/d/<npub>?name=...` populates `pendingDriverDeepLink` with the parsed npub + display name, switches `selectedTab` to drivers
- `universalLinkRiderShareRoutesToDriversTab` — `/share/r/<npub>` goes through the same parser path (parser is segment-agnostic; existing `DriverLookupDraftTests` confirms this is consistent with the rest of the codebase)
- `userActivityWithoutWebpageURLIsDropped` — `NSUserActivity` without a `webpageURL` is a no-op
- `universalLinkUnknownPathIsDropped` — `https://roadflare.app/about` (no embedded npub) is dropped silently

The tests construct synthetic `NSUserActivity` instances with the browsing-web type and exercise the AppState entry point directly. The SwiftUI `.onContinueUserActivity` modifier itself is a one-liner that just calls `appState.handleIncomingUserActivity(activity)` and isn't unit-testable without a host app + simulator, but it's covered by the manual test plan below.

## Verification

```
xcodebuild -scheme RoadFlare -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' build
** BUILD SUCCEEDED **

xcodebuild -scheme RoadFlareTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO test
** TEST SUCCEEDED **
Test run with 295 tests in 35 suites passed
```

`HandleIncomingURLTests` itself: 11 tests passed (7 pre-existing + 4 new).

## Manual test checklist (run after merge + AASA is live)

- [ ] Confirm AASA fetch: `curl -i https://roadflare.app/.well-known/apple-app-site-association` returns 200 with `Content-Type: application/json` and the JSON above
- [ ] Install fresh App Store build (delete TestFlight first if installed)
- [ ] Long-press a `https://roadflare.app/share/d/npub1...` link in Messages → \"Open in RoadFlare\" option appears
- [ ] Tap the link → app opens, Drivers tab selected, Add Driver sheet pre-filled with that npub
- [ ] Repeat the cold-start case (force-quit between attempts) — the AppState.pendingDriverDeepLink + DriversTab `.onChange(of:initial:)` path from ADR-0012 handles this
- [ ] Tap a `https://roadflare.app/about` link → opens in Safari (no embedded npub, AASA `components` filter doesn't claim it)
- [ ] Existing `roadflared:npub1...` flow from PR #66 still works unchanged

## Two-app partitioning

Same partitioning notes from PR #66 apply: rider shares (`/share/r/*`) currently route to the rider app's Add Driver sheet (consistent with existing parser + `DriverLookupDraft` behavior). Once a dedicated iOS driver app exists, the AASA `details` array can be split per app — the `apple-app-site-association` format supports multiple appID entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)