### PR TITLE
feat(sdk): extract ChatCoordinator message-list logic into ChatMessageStore

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/ChatMessageStore.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/ChatMessageStore.swift
@@ -35,8 +35,10 @@ public enum ChatMessageAppendOutcome: Equatable, Sendable {
 ///
 /// Owns deduplication (by message id), stable timestamp-ascending +
 /// id-tiebreak sort, fixed FIFO capacity, and unread counting gated by a
-/// caller-supplied cutoff so replayed history on subscription start does
-/// not inflate the badge.
+/// caller-supplied cutoff. Callers set the cutoff via `setUnreadCutoff(_:)`
+/// when a subscription session begins so replayed history does not inflate
+/// the badge; the cutoff defaults to `0`, so without an explicit set every
+/// remote message would count as unread.
 ///
 /// Does not parse Nostr events, decrypt content, manage subscriptions, or
 /// fire UI feedback such as haptics — callers layer those on top. This

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/ChatMessageStore.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/ChatMessageStore.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// A single message in an in-ride chat thread.
+///
+/// `id` is the underlying Nostr event id and is used as the deduplication key.
+/// `isMine` is determined by the caller (e.g. by comparing the event's pubkey
+/// to the local keypair) so the store stays free of any keypair dependency
+/// and is symmetric between rider and driver consumers.
+public struct ChatMessage: Hashable, Sendable {
+    public let id: String
+    public let text: String
+    public let isMine: Bool
+    public let timestamp: Int
+
+    public init(id: String, text: String, isMine: Bool, timestamp: Int) {
+        self.id = id
+        self.text = text
+        self.isMine = isMine
+        self.timestamp = timestamp
+    }
+}
+
+/// Result of appending a message to a `ChatMessageStore`.
+///
+/// `.duplicate` is returned when a message with the same `id` is already
+/// present; the store is unchanged. `.inserted` is returned when the message
+/// is accepted; `incrementedUnread` is `true` iff the message was remote
+/// (`!isMine`) and its timestamp was at or after the current unread cutoff.
+public enum ChatMessageAppendOutcome: Equatable, Sendable {
+    case duplicate
+    case inserted(incrementedUnread: Bool)
+}
+
+/// Platform-neutral in-memory store for an in-ride chat thread.
+///
+/// Owns deduplication (by message id), stable timestamp-ascending +
+/// id-tiebreak sort, fixed FIFO capacity, and unread counting gated by a
+/// caller-supplied cutoff so replayed history on subscription start does
+/// not inflate the badge.
+///
+/// Does not parse Nostr events, decrypt content, manage subscriptions, or
+/// fire UI feedback such as haptics — callers layer those on top. This
+/// keeps the store usable from both rider and driver consumers without
+/// pulling in iOS-specific dependencies.
+///
+/// Thread safety: All mutations are protected by an internal `NSLock`.
+/// Safe to call from any single thread; not safe under concurrent writers
+/// (matches sibling SDK repo pattern). Current callers are
+/// `@MainActor`-serialized.
+@Observable
+public final class ChatMessageStore: @unchecked Sendable {
+    public static let defaultCapacity = 500
+
+    public private(set) var messages: [ChatMessage] = []
+    public private(set) var unreadCount: Int = 0
+
+    public let capacity: Int
+
+    private var messageIds: Set<String> = []
+    private var unreadCutoff: Int = 0
+    private let lock = NSLock()
+
+    public init(capacity: Int = ChatMessageStore.defaultCapacity) {
+        precondition(capacity > 0, "ChatMessageStore capacity must be positive")
+        self.capacity = capacity
+    }
+
+    /// Set the unread-counting cutoff (Unix seconds). Subsequent remote
+    /// messages with `timestamp >= cutoff` will bump `unreadCount`.
+    /// Callers typically invoke this when a new subscription session begins.
+    public func setUnreadCutoff(_ timestamp: Int) {
+        lock.withLock { self.unreadCutoff = timestamp }
+    }
+
+    /// Append a message. Deduplicates by `id`, inserts in stable sort order
+    /// (timestamp ascending, id tiebreak), evicts oldest if capacity is
+    /// exceeded, and updates `unreadCount`.
+    @discardableResult
+    public func append(_ message: ChatMessage) -> ChatMessageAppendOutcome {
+        lock.withLock {
+            guard !messageIds.contains(message.id) else { return .duplicate }
+            messageIds.insert(message.id)
+            messages.append(message)
+            messages.sort { lhs, rhs in
+                lhs.timestamp != rhs.timestamp
+                    ? lhs.timestamp < rhs.timestamp
+                    : lhs.id < rhs.id
+            }
+            while messages.count > capacity {
+                let removed = messages.removeFirst()
+                messageIds.remove(removed.id)
+            }
+            let incrementedUnread = !message.isMine && message.timestamp >= unreadCutoff
+            if incrementedUnread {
+                unreadCount += 1
+            }
+            return .inserted(incrementedUnread: incrementedUnread)
+        }
+    }
+
+    public func markRead() {
+        lock.withLock { unreadCount = 0 }
+    }
+
+    /// Clear all messages and reset `unreadCount`. The unread cutoff is
+    /// preserved so an ongoing subscription session keeps its cutoff after
+    /// a local clear; callers that want to reset the cutoff too should
+    /// call `setUnreadCutoff(_:)` explicitly.
+    public func reset() {
+        lock.withLock {
+            messages = []
+            messageIds = []
+            unreadCount = 0
+        }
+    }
+}

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/ChatMessageStore.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/ChatMessageStore.swift
@@ -68,6 +68,11 @@ public final class ChatMessageStore: @unchecked Sendable {
     /// Set the unread-counting cutoff (Unix seconds). Subsequent remote
     /// messages with `timestamp >= cutoff` will bump `unreadCount`.
     /// Callers typically invoke this when a new subscription session begins.
+    ///
+    /// The cutoff defaults to `0`, which means every remote message would
+    /// count as unread if `append(_:)` is called before a cutoff is set.
+    /// In normal use, the subscription-managing caller sets the cutoff at
+    /// subscribe-time before any events are routed in.
     public func setUnreadCutoff(_ timestamp: Int) {
         lock.withLock { self.unreadCutoff = timestamp }
     }

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/ChatMessageStoreTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/ChatMessageStoreTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Testing
+@testable import RidestrSDK
+
+@Suite("ChatMessageStore Tests")
+struct ChatMessageStoreTests {
+    private func makeStore(capacity: Int = ChatMessageStore.defaultCapacity) -> ChatMessageStore {
+        ChatMessageStore(capacity: capacity)
+    }
+
+    private func message(
+        id: String,
+        text: String = "hi",
+        isMine: Bool = false,
+        timestamp: Int = 1_000
+    ) -> ChatMessage {
+        ChatMessage(id: id, text: text, isMine: isMine, timestamp: timestamp)
+    }
+
+    // MARK: - Fresh state
+
+    @Test func defaultsEmpty() {
+        let store = makeStore()
+        #expect(store.messages.isEmpty)
+        #expect(store.unreadCount == 0)
+        #expect(store.capacity == ChatMessageStore.defaultCapacity)
+    }
+
+    @Test func defaultCapacityMatchesLegacyCoordinator() {
+        #expect(ChatMessageStore.defaultCapacity == 500)
+    }
+
+    // MARK: - Append + dedup
+
+    @Test func appendInsertsNewMessage() {
+        let store = makeStore()
+        let outcome = store.append(message(id: "a", timestamp: 100))
+        #expect(outcome == .inserted(incrementedUnread: true))
+        #expect(store.messages.count == 1)
+        #expect(store.messages[0].id == "a")
+    }
+
+    @Test func appendDeduplicatesSameId() {
+        let store = makeStore()
+        _ = store.append(message(id: "a", text: "first", timestamp: 100))
+        let second = store.append(message(id: "a", text: "second-text", timestamp: 200))
+        #expect(second == .duplicate)
+        #expect(store.messages.count == 1)
+        #expect(store.messages[0].text == "first")
+        #expect(store.unreadCount == 1)
+    }
+
+    @Test func appendDeduplicatesAcrossPubkeyAndTimestampCollisions() {
+        // Same event id from two distinct senders/timestamps should still be a duplicate:
+        // the dedup key is the event id only.
+        let store = makeStore()
+        _ = store.append(message(id: "evt-1", isMine: false, timestamp: 100))
+        let outcome = store.append(message(id: "evt-1", isMine: true, timestamp: 500))
+        #expect(outcome == .duplicate)
+        #expect(store.messages.count == 1)
+    }
+
+    // MARK: - Sort
+
+    @Test func sortsAscendingByTimestamp() {
+        let store = makeStore()
+        _ = store.append(message(id: "b", timestamp: 200))
+        _ = store.append(message(id: "a", timestamp: 100))
+        _ = store.append(message(id: "c", timestamp: 300))
+        #expect(store.messages.map(\.id) == ["a", "b", "c"])
+    }
+
+    @Test func sortTieBreaksByIdAscending() {
+        let store = makeStore()
+        _ = store.append(message(id: "z", timestamp: 100))
+        _ = store.append(message(id: "a", timestamp: 100))
+        _ = store.append(message(id: "m", timestamp: 100))
+        #expect(store.messages.map(\.id) == ["a", "m", "z"])
+    }
+
+    @Test func sortIsDeterministicAcrossOutOfOrderArrivals() {
+        let store = makeStore()
+        _ = store.append(message(id: "c", timestamp: 300))
+        _ = store.append(message(id: "a", timestamp: 100))
+        _ = store.append(message(id: "b2", timestamp: 200))
+        _ = store.append(message(id: "b1", timestamp: 200))
+        #expect(store.messages.map(\.id) == ["a", "b1", "b2", "c"])
+    }
+
+    // MARK: - Capacity
+
+    @Test func evictsOldestWhenOverCapacity() {
+        let store = makeStore(capacity: 3)
+        _ = store.append(message(id: "a", timestamp: 100))
+        _ = store.append(message(id: "b", timestamp: 200))
+        _ = store.append(message(id: "c", timestamp: 300))
+        _ = store.append(message(id: "d", timestamp: 400))
+        #expect(store.messages.map(\.id) == ["b", "c", "d"])
+    }
+
+    @Test func evictedIdsCanBeReinserted() {
+        // After eviction, the message id is no longer "known" — re-appending
+        // it (as could happen with a relay replay much later) inserts again.
+        let store = makeStore(capacity: 2)
+        _ = store.append(message(id: "a", timestamp: 100))
+        _ = store.append(message(id: "b", timestamp: 200))
+        _ = store.append(message(id: "c", timestamp: 300)) // evicts a
+        let outcome = store.append(message(id: "a", timestamp: 400))
+        #expect(outcome != .duplicate)
+        #expect(store.messages.map(\.id) == ["c", "a"])
+    }
+
+    @Test func arrivingOlderMessageOverCapacityIsEvictedImmediately() {
+        // Edge case: a stale message that sorts to the front of an already-full
+        // store gets evicted in the same call. Documents the existing behaviour
+        // inherited from the coordinator.
+        let store = makeStore(capacity: 2)
+        _ = store.append(message(id: "b", timestamp: 200))
+        _ = store.append(message(id: "c", timestamp: 300))
+        let outcome = store.append(message(id: "a", timestamp: 100))
+        if case .inserted = outcome {} else { Issue.record("expected inserted outcome") }
+        #expect(store.messages.map(\.id) == ["b", "c"])
+    }
+
+    // MARK: - Unread tracking
+
+    @Test func unreadDoesNotIncrementForOwnMessages() {
+        let store = makeStore()
+        let outcome = store.append(message(id: "a", isMine: true, timestamp: 100))
+        #expect(outcome == .inserted(incrementedUnread: false))
+        #expect(store.unreadCount == 0)
+    }
+
+    @Test func unreadIncrementsForRemoteMessages() {
+        let store = makeStore()
+        _ = store.append(message(id: "a", isMine: false, timestamp: 100))
+        _ = store.append(message(id: "b", isMine: false, timestamp: 200))
+        #expect(store.unreadCount == 2)
+    }
+
+    @Test func unreadCutoffSuppressesReplayedHistory() {
+        let store = makeStore()
+        store.setUnreadCutoff(500)
+        let stale = store.append(message(id: "old", isMine: false, timestamp: 400))
+        let live = store.append(message(id: "new", isMine: false, timestamp: 600))
+        #expect(stale == .inserted(incrementedUnread: false))
+        #expect(live == .inserted(incrementedUnread: true))
+        #expect(store.unreadCount == 1)
+    }
+
+    @Test func unreadCutoffIsInclusiveAtBoundary() {
+        // Matches existing coordinator: `event.createdAt >= subscriptionStartTime`.
+        let store = makeStore()
+        store.setUnreadCutoff(500)
+        let atBoundary = store.append(message(id: "boundary", isMine: false, timestamp: 500))
+        #expect(atBoundary == .inserted(incrementedUnread: true))
+        #expect(store.unreadCount == 1)
+    }
+
+    @Test func duplicateMessageDoesNotIncrementUnread() {
+        let store = makeStore()
+        _ = store.append(message(id: "a", isMine: false, timestamp: 100))
+        _ = store.append(message(id: "a", isMine: false, timestamp: 100))
+        #expect(store.unreadCount == 1)
+    }
+
+    @Test func markReadZeroesUnreadCount() {
+        let store = makeStore()
+        _ = store.append(message(id: "a", isMine: false, timestamp: 100))
+        _ = store.append(message(id: "b", isMine: false, timestamp: 200))
+        #expect(store.unreadCount == 2)
+        store.markRead()
+        #expect(store.unreadCount == 0)
+    }
+
+    @Test func markReadDoesNotPreventFutureUnreadIncrements() {
+        let store = makeStore()
+        _ = store.append(message(id: "a", isMine: false, timestamp: 100))
+        store.markRead()
+        _ = store.append(message(id: "b", isMine: false, timestamp: 200))
+        #expect(store.unreadCount == 1)
+    }
+
+    // MARK: - Reset
+
+    @Test func resetClearsMessagesAndUnreadButPreservesCutoff() {
+        let store = makeStore()
+        store.setUnreadCutoff(500)
+        _ = store.append(message(id: "a", isMine: false, timestamp: 600))
+        #expect(store.unreadCount == 1)
+        store.reset()
+        #expect(store.messages.isEmpty)
+        #expect(store.unreadCount == 0)
+        // Cutoff preserved: a message at timestamp 400 should NOT increment unread.
+        let outcome = store.append(message(id: "b", isMine: false, timestamp: 400))
+        #expect(outcome == .inserted(incrementedUnread: false))
+        #expect(store.unreadCount == 0)
+    }
+
+    @Test func resetAllowsReinsertingPreviouslyDedupedId() {
+        let store = makeStore()
+        _ = store.append(message(id: "a", timestamp: 100))
+        store.reset()
+        let outcome = store.append(message(id: "a", timestamp: 100))
+        if case .inserted = outcome {} else { Issue.record("expected inserted after reset") }
+        #expect(store.messages.count == 1)
+    }
+
+    // MARK: - Configuration
+
+    @Test func customCapacityIsHonored() {
+        let store = makeStore(capacity: 5)
+        for i in 0..<10 {
+            _ = store.append(message(id: "m-\(i)", timestamp: 100 + i))
+        }
+        #expect(store.messages.count == 5)
+        #expect(store.messages.map(\.id) == ["m-5", "m-6", "m-7", "m-8", "m-9"])
+    }
+}

--- a/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/ChatMessageStoreTests.swift
+++ b/RidestrSDK/Tests/RidestrSDKTests/RoadFlare/ChatMessageStoreTests.swift
@@ -113,13 +113,16 @@ struct ChatMessageStoreTests {
     @Test func arrivingOlderMessageOverCapacityIsEvictedImmediately() {
         // Edge case: a stale message that sorts to the front of an already-full
         // store gets evicted in the same call. Documents the existing behaviour
-        // inherited from the coordinator.
+        // inherited from the coordinator: `unreadCount` is still incremented
+        // for the evicted message (the unread check runs after eviction).
+        // Locked in by the assertion below; revisit if that semantics changes.
         let store = makeStore(capacity: 2)
-        _ = store.append(message(id: "b", timestamp: 200))
-        _ = store.append(message(id: "c", timestamp: 300))
-        let outcome = store.append(message(id: "a", timestamp: 100))
-        if case .inserted = outcome {} else { Issue.record("expected inserted outcome") }
+        _ = store.append(message(id: "b", isMine: true, timestamp: 200))
+        _ = store.append(message(id: "c", isMine: true, timestamp: 300))
+        let outcome = store.append(message(id: "a", isMine: false, timestamp: 100))
+        #expect(outcome == .inserted(incrementedUnread: true))
         #expect(store.messages.map(\.id) == ["b", "c"])
+        #expect(store.unreadCount == 1)
     }
 
     // MARK: - Unread tracking

--- a/RoadFlare/RoadFlareCore/ViewModels/ChatCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/ChatCoordinator.swift
@@ -3,11 +3,12 @@ import RidestrSDK
 
 /// Manages in-ride chat messaging (Kind 3178).
 ///
-/// Owns the subscription lifetime (start/stop, generation-counter guard) and
-/// the iOS-side feedback (haptics on incoming remote messages). All message
-/// list state — dedup, sort, capacity, unread counting — lives in the
-/// SDK-side `ChatMessageStore` so it can be reused by a driver-side
-/// consumer.
+/// Owns the subscription lifetime (start/stop, generation-counter guard),
+/// outbound message publishing via `sendChatMessage(_:)`, the iOS-side
+/// haptic feedback on incoming remote messages, and surfaces send failures
+/// via `lastError`. All message-list state — dedup, sort, capacity, unread
+/// counting — lives in the SDK-side `ChatMessageStore` so it can be reused
+/// by a driver-side consumer.
 @Observable
 @MainActor
 public final class ChatCoordinator {

--- a/RoadFlare/RoadFlareCore/ViewModels/ChatCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/ChatCoordinator.swift
@@ -2,16 +2,22 @@ import Foundation
 import RidestrSDK
 
 /// Manages in-ride chat messaging (Kind 3178).
+///
+/// Owns the subscription lifetime (start/stop, generation-counter guard) and
+/// the iOS-side feedback (haptics on incoming remote messages). All message
+/// list state — dedup, sort, capacity, unread counting — lives in the
+/// SDK-side `ChatMessageStore` so it can be reused by a driver-side
+/// consumer.
 @Observable
 @MainActor
 public final class ChatCoordinator {
     private let relayManager: any RelayManagerProtocol
     private let keypair: NostrKeypair
+    let store: ChatMessageStore
 
-    public var chatMessages: [(id: String, text: String, isMine: Bool, timestamp: Int)] = []
-    public var unreadCount: Int = 0
-    private var chatMessageIds: Set<String> = []
-    private var subscriptionStartTime: Int = 0
+    public var chatMessages: [ChatMessage] { store.messages }
+    public var unreadCount: Int { store.unreadCount }
+
     private struct ActiveSubscription {
         let id: SubscriptionID
         let generation: UUID
@@ -24,13 +30,14 @@ public final class ChatCoordinator {
     public init(relayManager: any RelayManagerProtocol, keypair: NostrKeypair) {
         self.relayManager = relayManager
         self.keypair = keypair
+        self.store = ChatMessageStore()
     }
 
     // MARK: - Subscribe
 
     func subscribeToChat(driverPubkey: String, confirmationEventId: String) {
         let previous = takeActiveSubscription()
-        subscriptionStartTime = Int(Date.now.timeIntervalSince1970)
+        store.setUnreadCutoff(Int(Date.now.timeIntervalSince1970))
         let subId = SubscriptionID("chat-\(confirmationEventId)")
         let generation = UUID()
         let task = Task {
@@ -85,23 +92,13 @@ public final class ChatCoordinator {
                 expectedSenderPubkey: expectedSenderPubkey,
                 expectedConfirmationEventId: expectedConfirmationEventId
             )
-            let isMine = event.pubkey == keypair.publicKeyHex
-            guard !chatMessageIds.contains(event.id) else { return }
-            chatMessageIds.insert(event.id)
-            chatMessages.append((id: event.id, text: content.message, isMine: isMine, timestamp: event.createdAt))
-            // Sort by timestamp; tie-break by event ID for deterministic ordering
-            chatMessages.sort { $0.timestamp != $1.timestamp ? $0.timestamp < $1.timestamp : $0.id < $1.id }
-            // Cap at 500 messages to prevent memory bloat
-            if chatMessages.count > 500 {
-                let removed = chatMessages.removeFirst()
-                chatMessageIds.remove(removed.id)
-            }
-            if !isMine {
-                // Only count as unread if the message arrived after subscription start,
-                // to avoid inflating the badge with replayed history on app restart.
-                if event.createdAt >= subscriptionStartTime {
-                    unreadCount += 1
-                }
+            let message = ChatMessage(
+                id: event.id,
+                text: content.message,
+                isMine: event.pubkey == keypair.publicKeyHex,
+                timestamp: event.createdAt
+            )
+            if case .inserted = store.append(message), !message.isMine {
                 HapticManager.messageReceived()
             }
         } catch {
@@ -120,19 +117,12 @@ public final class ChatCoordinator {
                 keypair: keypair
             )
             _ = try await relayManager.publish(event)
-            guard !chatMessageIds.contains(event.id) else { return }
-            chatMessageIds.insert(event.id)
-            chatMessages.append((
+            store.append(ChatMessage(
                 id: event.id,
                 text: text,
                 isMine: true,
                 timestamp: event.createdAt
             ))
-            chatMessages.sort { $0.timestamp != $1.timestamp ? $0.timestamp < $1.timestamp : $0.id < $1.id }
-            if chatMessages.count > 500 {
-                let removed = chatMessages.removeFirst()
-                chatMessageIds.remove(removed.id)
-            }
         } catch {
             lastError = "Failed to send message: \(error.localizedDescription)"
         }
@@ -159,13 +149,11 @@ public final class ChatCoordinator {
     }
 
     public func markRead() {
-        unreadCount = 0
+        store.markRead()
     }
 
     func reset() {
-        chatMessages = []
-        chatMessageIds = []
-        unreadCount = 0
+        store.reset()
     }
 
     private func takeActiveSubscription() -> ActiveSubscription? {

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -75,7 +75,7 @@ public final class RideCoordinator {
     }
 
     var driversRepository: FollowedDriversRepository { location.driversRepository }
-    public var chatMessages: [(id: String, text: String, isMine: Bool, timestamp: Int)] { chat.chatMessages }
+    public var chatMessages: [ChatMessage] { chat.chatMessages }
     public var activeRidePaymentMethods: [String] {
         if !session.fiatPaymentMethods.isEmpty {
             return session.fiatPaymentMethods

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -999,7 +999,7 @@ struct RideCoordinatorTests {
         coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
         coordinator.selectedPaymentMethod = "zelle"
         coordinator.lastError = "stale"
-        coordinator.chat.chatMessages = [(id: "m1", text: "hello", isMine: false, timestamp: 1)]
+        coordinator.chat.store.append(ChatMessage(id: "m1", text: "hello", isMine: false, timestamp: 1))
 
         coordinator.sessionDidReachTerminal(.cancelledByRider(reason: "Changed plans"))
 
@@ -1019,7 +1019,7 @@ struct RideCoordinatorTests {
         coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
         coordinator.selectedPaymentMethod = "zelle"
         coordinator.lastError = "stale"
-        coordinator.chat.chatMessages = [(id: "m1", text: "hello", isMine: false, timestamp: 1)]
+        coordinator.chat.store.append(ChatMessage(id: "m1", text: "hello", isMine: false, timestamp: 1))
 
         coordinator.sessionDidReachTerminal(.cancelledByDriver(reason: "No longer available"))
 
@@ -1039,7 +1039,7 @@ struct RideCoordinatorTests {
         coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
         coordinator.selectedPaymentMethod = "zelle"
         coordinator.lastError = "stale"
-        coordinator.chat.chatMessages = [(id: "m1", text: "hello", isMine: false, timestamp: 1)]
+        coordinator.chat.store.append(ChatMessage(id: "m1", text: "hello", isMine: false, timestamp: 1))
 
         coordinator.sessionDidReachTerminal(.expired(stage: .waitingForAcceptance))
 
@@ -1059,7 +1059,7 @@ struct RideCoordinatorTests {
         coordinator.currentFareEstimate = FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
         coordinator.selectedPaymentMethod = "zelle"
         coordinator.lastError = "stale"
-        coordinator.chat.chatMessages = [(id: "m1", text: "hello", isMine: false, timestamp: 1)]
+        coordinator.chat.store.append(ChatMessage(id: "m1", text: "hello", isMine: false, timestamp: 1))
 
         coordinator.sessionDidReachTerminal(.bruteForcePin)
 

--- a/decisions/0018-chat-message-store.md
+++ b/decisions/0018-chat-message-store.md
@@ -1,0 +1,233 @@
+# ADR-0018: ChatMessageStore — SDK-side chat message-list state
+
+**Status:** Active
+**Created:** 2026-05-11
+**Tags:** refactor, architecture, ridestr-sdk, chat, coordinator-boundary
+
+## Context
+
+ADR-0011 (coordinator boundary review) concluded that `ChatCoordinator`'s
+*subscription lifetime* belongs in `RoadFlareCore` while its *message-list
+state machine* (dedup by event id, timestamp+id sort, 500-message FIFO cap,
+unread counting gated by a subscription cutoff) is platform-neutral and a
+candidate for SDK extraction — but deferred the work to "when a driver-side
+consumer exists." Issue #111 (driver-side iOS planning, filed 2026-05-11) is
+that trigger. Issue #60 tracked the extraction itself.
+
+The Nostr protocol surface (Kind 3178 in-ride chat) is unchanged: a rider
+and a driver bound to the same ride confirmation publish encrypted text
+events between two known pubkeys. The constraint is that an iOS driver app
+sharing the same SDK must consume the same store without paying for any
+rider-specific assumption, and must remain wire-compatible with the
+existing Ridestr/Drivestr Kind 3178 stream produced by `RideshareEventBuilder`
+and parsed by `RideshareEventParser`.
+
+This ADR captures the design decisions made when extracting the type — the
+big-picture deferral was already justified in ADR-0011, but the
+implementation-level choices (concurrency model, append API shape, capacity
+plumbing, default cutoff) belong here so a future reader does not have to
+infer them from git blame.
+
+## Decision
+
+Introduce `RidestrSDK/Sources/RidestrSDK/RoadFlare/ChatMessageStore.swift` as
+the SDK-side owner of in-ride chat message-list state. The public surface is:
+
+```swift
+public struct ChatMessage: Hashable, Sendable {
+    public let id: String         // event id; dedup key
+    public let text: String       // decrypted plaintext
+    public let isMine: Bool       // caller determines (event.pubkey == self)
+    public let timestamp: Int     // event.createdAt (Unix seconds)
+}
+
+public enum ChatMessageAppendOutcome: Equatable, Sendable {
+    case duplicate
+    case inserted(incrementedUnread: Bool)
+}
+
+@Observable
+public final class ChatMessageStore: @unchecked Sendable {
+    public static let defaultCapacity = 500
+    public init(capacity: Int = ChatMessageStore.defaultCapacity)
+    public func setUnreadCutoff(_ timestamp: Int)
+    @discardableResult
+    public func append(_ message: ChatMessage) -> ChatMessageAppendOutcome
+    public func markRead()
+    public func reset()                  // preserves cutoff
+    public private(set) var messages: [ChatMessage]
+    public private(set) var unreadCount: Int
+    public let capacity: Int
+}
+```
+
+Specific decisions captured:
+
+1. **Concurrency model:** `@unchecked Sendable` + `NSLock` + `@Observable`.
+2. **Dedup key:** event id only.
+3. **Sort:** ascending `timestamp`, tiebreak ascending `id` — deterministic.
+4. **Capacity:** init parameter with default `500`. FIFO eviction (drop
+   `removeFirst()` after sort).
+5. **Append API:** returns `enum AppendOutcome { duplicate, inserted(incrementedUnread:) }`.
+6. **Unread cutoff:** caller-supplied via `setUnreadCutoff(_:)`, defaults to
+   `0`, inclusive check (`timestamp >= cutoff`).
+7. **`reset()` semantics:** clears messages, message-id set, and
+   `unreadCount` — preserves `unreadCutoff`.
+8. **Field set on `ChatMessage`:** `id`, `text`, `isMine`, `timestamp` — no
+   `senderPubkey`.
+9. **`ChatCoordinator` keeps its rider-framing parameter names**
+   (`driverPubkey`) and stays in `RoadFlareCore` per ADR-0011. The driver
+   iOS app will build its own coordinator atop the same SDK store.
+
+## Rationale
+
+**Concurrency — `@unchecked Sendable` + `NSLock` + `@Observable`.** The
+sibling SDK repos in `RidestrSDK/RoadFlare/` (`UserSettingsRepository`,
+`FollowedDriversRepository`, `SavedLocationsRepository`) all use this
+pattern, and `.claude/CLAUDE.md` codifies it ("SDK repos that need callbacks
+use `@unchecked Sendable` + `NSLock`"). The store therefore does not pin
+itself to `@MainActor`, leaving room for future non-UI consumers (background
+sync, server-side replays, tests) without re-architecting. `@MainActor`
+would have been a simpler drop-in for the existing rider `ChatCoordinator`
+but conflicts with sibling-repo convention. `actor` was rejected because
+Swift's `@Observable` does not compose cleanly with `actor` — SwiftUI
+consumers would need an `AsyncStream` or a separate observable projection,
+which adds meaningful complexity for no current benefit.
+
+**Dedup by event id.** Nostr events are uniquely identified by their id
+(SHA-256 over a canonical serialization). Two events with identical ids
+have identical content by construction. Pubkey/timestamp collisions are not
+deduplication keys — they would either over-dedupe (different events from
+the same pubkey at the same second) or under-dedupe. The legacy coordinator
+keyed dedup on event id, and this matches.
+
+**Sort by timestamp then id.** The protocol's `created_at` is the canonical
+order. Ties happen — multiple events can share a second — so an explicit
+tiebreak is required to keep the list deterministic across out-of-order
+arrivals. Lexicographic id ascending is the chosen tiebreak (cheap, total
+order, identical to the legacy coordinator).
+
+**Capacity as init parameter with default 500.** The 500 magic number lived
+in the legacy coordinator with no explicit justification beyond "enough
+chat history for a single ride." Threading it through an init parameter
+costs essentially nothing, lets tests exercise the boundary with small
+capacities (`capacity: 2` and `capacity: 5` in the test suite), and gives
+future consumers a config knob without forcing a refactor.
+
+**Append outcome enum.** `Bool` would have told callers *whether* a message
+was inserted but not whether it bumped the unread counter — and the
+coordinator's haptic decision needs to know both. The enum bundles the two
+signals atomically without polling the counter or recomputing the cutoff
+check externally.
+
+**Default cutoff of 0.** This makes "no cutoff set" equivalent to "every
+remote message is unread," which is the safe default for a fresh store
+that hasn't yet been told when its subscription session started. The
+single subscription-managing caller (`ChatCoordinator.subscribeToChat`)
+sets the cutoff synchronously before any events can flow in, so the
+default is unreachable in normal use. Documented inline.
+
+**`reset()` preserves cutoff.** The legacy coordinator's `reset()` cleared
+messages and unread but left `subscriptionStartTime` alone — and that
+was intentional, because `reset()` runs on terminal session events
+(`sessionDidReachTerminal`) while a fresh subscription cutoff is supplied
+separately when `subscribeToChat` runs for the next ride. Preserving this
+matches legacy and avoids a "stale cutoff after reset" footgun where the
+cutoff would silently revert to 0 (the unread-everything default) the
+moment a ride ended.
+
+**No `senderPubkey` on `ChatMessage`.** Kind 3178 in-ride chat is a
+2-party encrypted channel between a rider and a driver, scoped to a single
+`confirmationEventId`. The two participant pubkeys are known to the
+coordinator at subscription time (they are the `counterpartyPubkey` and
+`myPubkey` arguments to `NostrFilter.chatMessages`). `isMine` therefore
+fully disambiguates sender: "me" = local pubkey, "not me" = the known
+counterparty. Adding `senderPubkey` would be redundant for the 2-party
+case. The driver iOS app's UI layer will resolve the counterparty's
+display name and avatar through the same `FollowedDriversRepository` /
+profile lookup machinery it already uses for the ride header — not from
+the message struct.
+
+**Protocol compatibility.** The store consumes already-parsed
+`ChatMessage` values; parsing, decryption, and `event.pubkey == myPubkey`
+determination all stay in the SDK's `RideshareEventParser` /
+`RideshareEventBuilder` (which an Android Drivestr peer interoperates with
+bit-for-bit). No protocol-surface changes are introduced.
+
+**Rider-framing parameter names on `ChatCoordinator`.** This coordinator
+is the rider's app-layer adapter. Per ADR-0011 it stays in `RoadFlareCore`
+and is not shared infrastructure — only the SDK store is. The driver iOS
+app will write a sibling `DriverChatCoordinator` (or whatever
+generalization makes sense at the time) that consumes `ChatMessageStore`
+directly. Renaming `driverPubkey` to `counterpartyPubkey` was deferred
+because it would touch many existing rider callers for zero functional
+gain and the driver coordinator will not call this type at all.
+
+## Alternatives Considered
+
+- **`@MainActor` class.** Simpler binding to SwiftUI; matches the existing
+  `ChatCoordinator`. Rejected because it conflicts with the sibling-repo
+  convention codified in CLAUDE.md and pins future non-UI consumers.
+
+- **`actor`.** Strongest isolation. Rejected because `@Observable` does
+  not compose cleanly with `actor`; SwiftUI consumers would have to bridge
+  through `AsyncStream` or a projection class.
+
+- **Hardcoded `static let capacity = 500`, no init parameter.** Less new
+  public surface. Rejected because the parameter cost is one line and the
+  test-seam value (running boundary tests with `capacity: 2` instead of
+  pushing 501 messages) was outsized.
+
+- **`@discardableResult func append(_:) -> Bool`.** Simpler. Rejected
+  because the coordinator's haptic decision needs to know whether the
+  message also bumped unread; `Bool` would have forced callers to poll
+  `unreadCount` deltas, which is brittle.
+
+- **Construct with cutoff in init, no `setUnreadCutoff(_:)`.** Removes
+  the default-0 footgun. Rejected because the subscription-managing caller
+  needs to re-set the cutoff per subscription session (not per store
+  lifetime); a settable cutoff is the right shape.
+
+- **Reset cutoff in `reset()`.** Symmetric. Rejected because terminal-session
+  resets happen before the next subscription's cutoff is known, and
+  leaving the cutoff at 0 between rides would cause replayed history on
+  the next subscribe to inflate the badge until the new cutoff lands.
+
+- **Add `senderPubkey: String` to `ChatMessage` for driver-app readiness.**
+  Rejected for now: in 2-party chat the sender is `me | counterparty`,
+  both pubkeys are known to the coordinator, and the UI layer already
+  resolves profiles by pubkey through other paths. Easy to add later if
+  group chat or third-party display ever materializes.
+
+- **Generalize `ChatCoordinator` to be role-symmetric** (rename
+  `driverPubkey` to `counterpartyPubkey`). Rejected — the coordinator
+  stays rider-only per ADR-0011; the driver app builds its own. Renaming
+  would touch many rider call sites for no driver benefit.
+
+## Consequences
+
+- A future driver iOS app gets `ChatMessageStore` for free: same dedup,
+  sort, cap, and unread semantics as the rider, with no rider-specific
+  types or assumptions. The driver coordinator owns its own subscription
+  lifetime + haptic feedback (or push, when that lands) and delegates
+  message-list state to the store.
+- The legacy edge case where the unread badge increments for a message
+  that was immediately evicted by the capacity cap is preserved and
+  locked in by tests. Revisit if product calls for stricter unread/visible
+  invariants.
+- `ChatCoordinator.store` is internal (not `public`) so the test seam in
+  `RideCoordinatorTests` works in-module. If the driver coordinator is
+  ever extracted into a separate module, the seam needs revisiting (move
+  the store to `public`, or change the access path).
+- Kind 3178 wire format is unchanged. Ridestr / Drivestr peers continue
+  to interoperate.
+- 859 SDK tests pass, plus 21 new in `ChatMessageStoreTests`. Full Xcode
+  project builds and `RoadFlareTests` scheme passes.
+
+## Affected Files
+
+- `RidestrSDK/Sources/RidestrSDK/RoadFlare/ChatMessageStore.swift` (new)
+- `RidestrSDK/Tests/RidestrSDKTests/RoadFlare/ChatMessageStoreTests.swift` (new)
+- `RoadFlare/RoadFlareCore/ViewModels/ChatCoordinator.swift` (delegates to store)
+- `RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift` (forwarder type)
+- `RoadFlare/RoadFlareTests/RideCoordinatorTests.swift` (test-seed migration)


### PR DESCRIPTION
## Summary

Extracts the message-list state machine from `ChatCoordinator` into a new platform-neutral SDK type `ChatMessageStore` (per ADR-0011's deferred-extraction note + issue #60). Triggered by #111 (driver-side iOS planning) reopening the "second consumer is coming" condition.

- New `RidestrSDK/Sources/RidestrSDK/RoadFlare/ChatMessageStore.swift` — owns dedup by event id, timestamp+id sort, FIFO capacity (default 500), and unread counting gated by a caller-supplied cutoff. No keypair / parsing / subscription / haptic dependency, so it is symmetric for rider and driver consumers.
- `ChatCoordinator` keeps the iOS-side concerns — subscription lifetime, generation-counter guard, `RideshareEventParser`/`Builder` usage, and `HapticManager.messageReceived()` — and delegates message-list state to the store.
- 21 new SDK-level tests covering dedup (incl. across pubkey/timestamp collisions), out-of-order sort + tiebreak, capacity eviction (incl. the over-cap stale-arrival edge case), unread cutoff (inclusive at boundary), `markRead`/`reset` semantics, and configurable capacity.

## Design notes

- **Concurrency:** `@unchecked Sendable` + `NSLock` + `@Observable`, matching sibling SDK repos (`UserSettingsRepository`, `FollowedDriversRepository`) and the CLAUDE.md guidance. Chosen over `@MainActor` so the type does not pin future non-UI consumers; chosen over `actor` because `@Observable` does not compose cleanly with `actor` for SwiftUI binding.
- **Dedup key:** event id only (matches existing coordinator).
- **Sort:** ascending `timestamp`, tiebreak ascending `id` — deterministic, matches existing behavior bit-for-bit.
- **Capacity:** init param with default 500 (matches existing magic number) so tests can use small caps for boundary verification.
- **Append API:** returns `enum AppendOutcome { case duplicate, inserted(incrementedUnread: Bool) }` so callers can layer haptics on top without polling counters.
- **Unread cutoff:** inclusive (`timestamp >= cutoff`), matches the legacy `event.createdAt >= subscriptionStartTime` check exactly.
- The `store` property on `ChatCoordinator` is internal (not `private`) so existing `@testable`-using `RideCoordinatorTests` seed messages via `chat.store.append(...)` instead of the now-removed public-mutable `chatMessages` array.

## Test plan

- [x] `swift test` in `RidestrSDK/` — 859 tests pass (21 new in `ChatMessageStoreTests`)
- [x] `xcodebuild -scheme RoadFlare build` — succeeds
- [x] `xcodebuild test -scheme RoadFlareTests` — TEST SUCCEEDED
- [ ] Reviewer: confirm the haptic still fires for incoming remote messages in a real chat (manual exercise of the in-ride chat sheet)
- [ ] Reviewer: confirm unread badge in `ActiveRideView` still increments on incoming messages and clears on `markRead`

Closes #60.
Related: #111 (driver-side iOS planning — the reopen trigger; this store is the first SDK piece sized for both rider + driver).
ADR-0011 (decisions/0011-coordinator-boundary.md) — implements the deferred extraction it scoped.