### PR TITLE
docs(tests): retarget stale ADR-0012 ref to ADR-0019

### DIFF
--- a/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift
@@ -193,7 +193,7 @@ struct HandleIncomingURLTests {
         // Cold-start regression parity for Universal Links: same invariant as
         // `navigationIntentSurvivesIdentityReplacementWhenNoKeypair` above, but
         // exercised through `handleIncomingUserActivity`. Universal Links are
-        // the long-term primary share path (per ADR-0012 + issue #63), so the
+        // the long-term primary share path (per ADR-0019 + issue #63), so the
         // pre-onboarding tap path needs explicit coverage on this entry point
         // — not just the `roadflared:` shim. See PR #66 for the precedent of
         // pinning parallel regression coverage on each new entry seam.


### PR DESCRIPTION
One-line cleanup miss from PR #113.

## Context

While PR #113 (Universal Links) was in flight, [PR #112](https://github.com/variablefate/roadflare-ios/pull/112) renumbered the roadflared scheme ADR from `0012` → `0019` (commit \`7c08ac8\` — \`docs(adr): retarget Swift \"See ADR-0012\" refs to ADR-0019\`). The squash merge of #113 onto main correctly auto-resolved existing \`ADR-0012\` references in [HandleIncomingURLTests.swift](https://github.com/variablefate/roadflare-ios/blob/c0f5eb4/RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift#L166) and [AppState.swift](https://github.com/variablefate/roadflare-ios/blob/c0f5eb4/RoadFlare/RoadFlareCore/ViewModels/AppState.swift#L1115) via 3-way merge — but couldn't catch a **brand-new line** added on the #113 branch:

> `RoadFlare/RoadFlareTests/AppState/HandleIncomingURLTests.swift:196` says \`per ADR-0012 + issue #63\` — should be \`per ADR-0019\`.

This isn't just a stale number — \`decisions/0012-coordinator-ride-identity-cache.md\` is now an unrelated ADR after the renumbering, so the reference points to the wrong subject.

## Diff

\`\`\`diff
- // the long-term primary share path (per ADR-0012 + issue #63), so the
+ // the long-term primary share path (per ADR-0019 + issue #63), so the
\`\`\`

One file, one line changed.

## Verification

\`HandleIncomingURLTests\` target: 12 tests, 0 failures (comment-only change, no logic touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)