### PR TITLE
chore(presentation): consolidate canRequestRide via SDK helper

### DIFF
--- a/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/DriverDetailViewState.swift
@@ -79,6 +79,9 @@ public struct DriverDetailViewState: Equatable, Sendable, Identifiable {
     ///     for drivers whose Drivestr session never published Kind 30173. See issue #91.
     ///   - isKeyStale: Whether this driver's key has been flagged as stale.
     ///   - canPing: Whether the ping action is currently available for this driver.
+    ///   - canRequestRide: Whether a ride can currently be requested from this driver.
+    ///     Callers resolve this via `FollowedDriversRepository.canRequestRide(_:)` so the
+    ///     UI shares one atomic snapshot of the SDK contract — see issue #94.
     ///   - referenceDate: Used for relative timestamp formatting (injectable for testing).
     ///   - locale: Locale used for the relative timestamp. Defaults to `.current` so
     ///     production output follows the device locale; tests may inject a fixed locale.
@@ -90,6 +93,7 @@ public struct DriverDetailViewState: Equatable, Sendable, Identifiable {
         vehicle: VehicleInfo? = nil,
         isKeyStale: Bool,
         canPing: Bool,
+        canRequestRide: Bool,
         referenceDate: Date = .now,
         locale: Locale = .current
     ) -> DriverDetailViewState {
@@ -97,7 +101,6 @@ public struct DriverDetailViewState: Equatable, Sendable, Identifiable {
             ?? driver.name
             ?? (String(driver.pubkey.prefix(8)) + "...")
 
-        let canRequestRide = driver.hasKey && !isKeyStale && location?.status == "online"
         let status = resolveDriverPresentationStatus(
             hasKey: driver.hasKey, isKeyStale: isKeyStale, location: location
         )

--- a/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
+++ b/RoadFlare/RoadFlareCore/Presentation/RideRequestDriverOption.swift
@@ -3,9 +3,9 @@ import RidestrSDK
 
 /// Display-ready representation of an online driver option in the ride request flow.
 ///
-/// Only drivers that are requestable — have a key, the key is not stale, and
-/// they are broadcasting "online" — should be projected into this type.
-/// The factory enforces that precondition and returns `nil` otherwise.
+/// Only drivers that are requestable — as determined by
+/// `FollowedDriversRepository.canRequestRide(_:)` — should be projected into
+/// this type. The factory enforces that precondition and returns `nil` otherwise.
 public struct RideRequestDriverOption: Equatable, Sendable, Identifiable {
 
     // MARK: - Identity
@@ -19,22 +19,22 @@ public struct RideRequestDriverOption: Equatable, Sendable, Identifiable {
 
     // MARK: - Factory
 
-    /// Project an online `FollowedDriver` into a ride-request driver option.
+    /// Project a `FollowedDriver` into a ride-request driver option.
     ///
-    /// Returns `nil` if the driver is not eligible (no key, stale key, or not online).
+    /// Returns `nil` when `canRequestRide` is `false`. The eligibility decision
+    /// itself is the SDK's responsibility (`FollowedDriversRepository.canRequestRide(_:)`);
+    /// this factory is a pure projection that trusts the resolved boolean. See issue #94.
     ///
     /// - Parameters:
     ///   - driver: The followed driver domain model.
     ///   - displayName: Display name from the repository if known; the factory falls back to driver.name then a short pubkey prefix.
-    ///   - location: The driver's latest cached location broadcast.
-    ///   - isKeyStale: Whether this driver's key has been flagged as stale.
+    ///   - canRequestRide: Whether a ride can currently be requested from this driver.
     public static func from(
         _ driver: FollowedDriver,
         displayName: String?,
-        location: CachedDriverLocation?,
-        isKeyStale: Bool
+        canRequestRide: Bool
     ) -> RideRequestDriverOption? {
-        guard driver.hasKey, !isKeyStale, location?.status == "online" else { return nil }
+        guard canRequestRide else { return nil }
 
         let resolvedName = displayName
             ?? driver.name
@@ -44,33 +44,5 @@ public struct RideRequestDriverOption: Equatable, Sendable, Identifiable {
             pubkey: driver.pubkey,
             displayName: resolvedName
         )
-    }
-
-    // MARK: - Convenience
-
-    /// Build the full list of available driver options from a repository snapshot.
-    ///
-    /// Drivers are included only when they have a key, the key is not stale, and they are broadcasting "online".
-    ///
-    /// - Parameters:
-    ///   - drivers: All followed drivers.
-    ///   - driverNames: Cached display name map from the repository.
-    ///   - driverLocations: Cached location map from the repository.
-    ///   - staleKeyPubkeys: Set of pubkeys whose keys are currently stale (from `FollowedDriversRepository.staleKeyPubkeys`).
-    ///     Always pass this — omitting it silently includes stale-key drivers in the result.
-    public static func onlineOptions(
-        from drivers: [FollowedDriver],
-        driverNames: [String: String],
-        driverLocations: [String: CachedDriverLocation],
-        staleKeyPubkeys: Set<String>
-    ) -> [RideRequestDriverOption] {
-        drivers.compactMap { driver in
-            from(
-                driver,
-                displayName: driverNames[driver.pubkey],
-                location: driverLocations[driver.pubkey],
-                isKeyStale: staleKeyPubkeys.contains(driver.pubkey)
-            )
-        }
     }
 }

--- a/RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/AppState+Presentation.swift
@@ -38,19 +38,21 @@ extension AppState {
             profile: repo.driverProfiles[pubkey],
             vehicle: repo.driverVehicles[pubkey],
             isKeyStale: repo.staleKeyPubkeys.contains(pubkey),
-            canPing: repo.canPingDriver(driver)
+            canPing: repo.canPingDriver(driver),
+            canRequestRide: repo.canRequestRide(driver)
         )
     }
 
     /// Available driver options for a new ride request (online, non-stale drivers only).
     public func onlineDriverOptions() -> [RideRequestDriverOption] {
         guard let repo = driversRepository else { return [] }
-        return RideRequestDriverOption.onlineOptions(
-            from: repo.drivers,
-            driverNames: repo.driverNames,
-            driverLocations: repo.driverLocations,
-            staleKeyPubkeys: repo.staleKeyPubkeys
-        )
+        return repo.drivers.compactMap { driver in
+            RideRequestDriverOption.from(
+                driver,
+                displayName: repo.cachedDriverName(pubkey: driver.pubkey),
+                canRequestRide: repo.canRequestRide(driver)
+            )
+        }
     }
 
     /// `true` when any followed driver is currently a valid ping target.

--- a/RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/AppStatePresentationTests.swift
@@ -247,6 +247,96 @@ struct AppStateOnlineDriverOptionsTests {
     }
 }
 
+// MARK: - Issue #94: canRequestRide consolidation matrix
+
+/// Pins the contract from issue #94: both `driverDetailViewState(pubkey:).canRequestRide`
+/// and the `onlineDriverOptions()` membership predicate must agree with
+/// `FollowedDriversRepository.canRequestRide(_:)` across the canonical state matrix.
+///
+/// If a future change re-introduces an inline predicate at either projection
+/// site (or drifts the SDK helper from these expectations), this suite fails —
+/// no silent divergence between the SDK contract and the UI's view of "can ride
+/// be requested from this driver".
+@Suite("AppState canRequestRide matrix")
+@MainActor
+struct AppStateCanRequestRideMatrixTests {
+
+    /// Drives one row of (hasKey × keyStale × locationStatus) → expected outcome.
+    /// `locationStatus: nil` means no location broadcast was ever received.
+    struct Row: CustomStringConvertible, Sendable {
+        let hasKey: Bool
+        let keyStale: Bool
+        let locationStatus: String?
+        let expectedCanRequestRide: Bool
+
+        var description: String {
+            "hasKey=\(hasKey) stale=\(keyStale) status=\(locationStatus ?? "nil")"
+        }
+    }
+
+    /// Hand-rolled full matrix so any change to the truth table is explicit in the diff.
+    /// `true` only when the driver has a key, the key is not stale, AND the last broadcast
+    /// status is exactly "online" — the same conditions enforced by the SDK helper.
+    static let matrix: [Row] = [
+        // hasKey == false → always false, regardless of status / staleness.
+        .init(hasKey: false, keyStale: false, locationStatus: nil,        expectedCanRequestRide: false),
+        .init(hasKey: false, keyStale: false, locationStatus: "online",   expectedCanRequestRide: false),
+        .init(hasKey: false, keyStale: false, locationStatus: "offline",  expectedCanRequestRide: false),
+        .init(hasKey: false, keyStale: false, locationStatus: "on_ride",  expectedCanRequestRide: false),
+        .init(hasKey: false, keyStale: false, locationStatus: "unknown",  expectedCanRequestRide: false),
+        // hasKey + keyStale → always false.
+        .init(hasKey: true,  keyStale: true,  locationStatus: "online",   expectedCanRequestRide: false),
+        .init(hasKey: true,  keyStale: true,  locationStatus: "offline",  expectedCanRequestRide: false),
+        .init(hasKey: true,  keyStale: true,  locationStatus: "on_ride",  expectedCanRequestRide: false),
+        // hasKey + fresh, but status not online → false.
+        .init(hasKey: true,  keyStale: false, locationStatus: nil,        expectedCanRequestRide: false),
+        .init(hasKey: true,  keyStale: false, locationStatus: "offline",  expectedCanRequestRide: false),
+        .init(hasKey: true,  keyStale: false, locationStatus: "on_ride",  expectedCanRequestRide: false),
+        .init(hasKey: true,  keyStale: false, locationStatus: "unknown",  expectedCanRequestRide: false),
+        // The single "true" cell.
+        .init(hasKey: true,  keyStale: false, locationStatus: "online",   expectedCanRequestRide: true),
+    ]
+
+    private func setUp(_ row: Row) -> (AppState, FollowedDriversRepository, FollowedDriver) {
+        let driver = FollowedDriver(
+            pubkey: fakePubkeyA, name: "Matrix",
+            roadflareKey: row.hasKey ? fakeKey : nil
+        )
+        let repo = makeRepo(drivers: [driver])
+        if let status = row.locationStatus {
+            _ = repo.updateDriverLocation(pubkey: fakePubkeyA, latitude: 0, longitude: 0,
+                                          status: status, timestamp: 1_000_000, keyVersion: 1)
+        }
+        if row.keyStale { repo.markKeyStale(pubkey: fakePubkeyA) }
+        let appState = AppState()
+        appState.installDriverPingTestContext(driversRepository: repo)
+        return (appState, repo, driver)
+    }
+
+    @Test(arguments: AppStateCanRequestRideMatrixTests.matrix)
+    func sdkHelperAgreesWithMatrix(row: Row) {
+        let (_, repo, driver) = setUp(row)
+        #expect(repo.canRequestRide(driver) == row.expectedCanRequestRide,
+                "SDK helper diverged from matrix at \(row)")
+    }
+
+    @Test(arguments: AppStateCanRequestRideMatrixTests.matrix)
+    func driverDetailViewStateMatchesHelper(row: Row) {
+        let (appState, _, _) = setUp(row)
+        let state = appState.driverDetailViewState(pubkey: fakePubkeyA)
+        #expect(state?.canRequestRide == row.expectedCanRequestRide,
+                "DriverDetailViewState.canRequestRide diverged at \(row)")
+    }
+
+    @Test(arguments: AppStateCanRequestRideMatrixTests.matrix)
+    func onlineDriverOptionsMembershipMatchesHelper(row: Row) {
+        let (appState, _, _) = setUp(row)
+        let included = appState.onlineDriverOptions().contains { $0.pubkey == fakePubkeyA }
+        #expect(included == row.expectedCanRequestRide,
+                "onlineDriverOptions() membership diverged at \(row)")
+    }
+}
+
 // MARK: - AppState.hasPingableDriver
 
 @Suite("AppState.hasPingableDriver")

--- a/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
+++ b/RoadFlare/RoadFlareTests/Presentation/PresentationTypesTests.swift
@@ -209,7 +209,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver(name: "Carol")
         let state = DriverDetailViewState.from(driver, displayName: "Carol (repo)",
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.displayName == "Carol (repo)")
     }
 
@@ -217,7 +218,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: makeLocation(status: "online"),
-                                               profile: nil, isKeyStale: false, canPing: false)
+                                               profile: nil, isKeyStale: false, canPing: false,
+                                               canRequestRide: true)
         #expect(state.statusLabel == "Available")
         #expect(state.canRequestRide == true)
         #expect(state.lastLocationStatus == "online")
@@ -227,7 +229,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: makeLocation(status: "on_ride"),
-                                               profile: nil, isKeyStale: false, canPing: false)
+                                               profile: nil, isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.statusLabel == "On a ride")
         #expect(state.canRequestRide == false)
         #expect(state.lastLocationStatus == "on_ride")
@@ -237,7 +240,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.statusLabel == "Offline")
         #expect(state.canRequestRide == false)
     }
@@ -246,7 +250,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver(key: nil)
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.statusLabel == "Pending approval")
         #expect(state.hasKey == false)
     }
@@ -256,7 +261,8 @@ struct DriverDetailViewStateTests {
         let online = makeLocation(status: "online")
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: online, profile: nil,
-                                               isKeyStale: true, canPing: false)
+                                               isKeyStale: true, canPing: false,
+                                               canRequestRide: false)
         #expect(state.statusLabel == "Key outdated")
         #expect(state.canRequestRide == false)
         #expect(state.isKeyStale == true)
@@ -275,7 +281,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: makeLocation(status: "online"),
-                                               profile: nil, isKeyStale: false, canPing: false)
+                                               profile: nil, isKeyStale: false, canPing: false,
+                                               canRequestRide: true)
         #expect(state.isKeyStale == false)
     }
 
@@ -288,7 +295,8 @@ struct DriverDetailViewStateTests {
         let loc = makeLocation(status: status)
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: loc, profile: nil,
-                                               isKeyStale: true, canPing: false)
+                                               isKeyStale: true, canPing: false,
+                                               canRequestRide: false)
         #expect(state.statusLabel == "Key outdated")
         #expect(state.canRequestRide == false)
         #expect(state.lastLocationStatus == nil)
@@ -300,7 +308,8 @@ struct DriverDetailViewStateTests {
         let profile = UserProfileContent(picture: "https://example.com/pic.jpg")
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: profile,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.pictureURL == "https://example.com/pic.jpg")
     }
 
@@ -308,7 +317,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.pictureURL == nil)
     }
 
@@ -316,7 +326,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: true)
+                                               isKeyStale: false, canPing: true,
+                                               canRequestRide: false)
         #expect(state.canPing == true)
     }
 
@@ -324,7 +335,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()  // fakeKey has version 3
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.hasKey == true)
         #expect(state.keyVersion == 3)
     }
@@ -333,7 +345,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver(key: nil)
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.keyVersion == nil)
     }
 
@@ -341,7 +354,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.lastLocationTimestampLabel == nil)
         #expect(state.lastLocationStatus == nil)
     }
@@ -358,6 +372,7 @@ struct DriverDetailViewStateTests {
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: loc, profile: nil,
                                                isKeyStale: false, canPing: false,
+                                               canRequestRide: true,
                                                referenceDate: referenceDate,
                                                locale: Locale(identifier: "en_US"))
         let label = try #require(state.lastLocationTimestampLabel)
@@ -368,7 +383,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver(note: nil)
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.note == "")
     }
 
@@ -376,7 +392,8 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver(note: "Great driver!")
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.note == "Great driver!")
     }
 
@@ -388,7 +405,8 @@ struct DriverDetailViewStateTests {
         let live = VehicleInfo(make: "Toyota", model: "Camry", color: "Silver")
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: profile, vehicle: live,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.vehicleDescription == "Silver Toyota Camry")
     }
 
@@ -397,7 +415,8 @@ struct DriverDetailViewStateTests {
         let profile = UserProfileContent(carMake: "Tesla", carModel: "Model 3", carColor: "Black")
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: profile, vehicle: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.vehicleDescription == "Black Tesla Model 3")
     }
 
@@ -405,8 +424,24 @@ struct DriverDetailViewStateTests {
         let driver = makeDriver()
         let state = DriverDetailViewState.from(driver, displayName: nil,
                                                location: nil, profile: nil, vehicle: nil,
-                                               isKeyStale: false, canPing: false)
+                                               isKeyStale: false, canPing: false,
+                                               canRequestRide: false)
         #expect(state.vehicleDescription == nil)
+    }
+
+    // Pin issue #94 contract: `canRequestRide` is a pass-through from the resolved
+    // boolean (computed by `AppState+Presentation` via the SDK helper). The factory
+    // must not re-derive it from raw inputs — otherwise stale/online/has-key
+    // changes here would diverge from the SDK definition. We pass arguments that
+    // would have produced `false` under the old inline predicate, with
+    // `canRequestRide: true`, to prove the input boolean wins.
+    @Test func canRequestRidePassesThroughResolvedBoolean() {
+        let driver = makeDriver(key: nil)  // would short-circuit old predicate to false
+        let state = DriverDetailViewState.from(driver, displayName: nil,
+                                               location: nil, profile: nil,
+                                               isKeyStale: true, canPing: false,
+                                               canRequestRide: true)
+        #expect(state.canRequestRide == true)
     }
 }
 
@@ -415,110 +450,48 @@ struct DriverDetailViewStateTests {
 @Suite("RideRequestDriverOption")
 struct RideRequestDriverOptionTests {
 
-    @Test func returnsNilWhenNoKey() {
-        let driver = makeDriver(key: nil)
+    // Issue #94: the factory is a pure projection — it trusts `canRequestRide`
+    // as its single eligibility gate. The SDK predicate (covered by
+    // `CanRequestRideTests` in the SDK target) is the source of truth for
+    // what that boolean means.
+    @Test func returnsNilWhenCanRequestRideIsFalse() {
+        let driver = makeDriver(name: "Dave")
         let result = RideRequestDriverOption.from(driver, displayName: nil,
-                                                   location: makeLocation(status: "online"),
-                                                   isKeyStale: false)
+                                                   canRequestRide: false)
         #expect(result == nil)
     }
 
-    @Test func returnsNilWhenOffline() {
-        let driver = makeDriver()
-        let result = RideRequestDriverOption.from(driver, displayName: nil,
-                                                   location: makeLocation(status: "offline"),
-                                                   isKeyStale: false)
-        #expect(result == nil)
-    }
-
-    @Test func returnsNilWhenNoLocation() {
-        let driver = makeDriver()
-        let result = RideRequestDriverOption.from(driver, displayName: nil,
-                                                   location: nil, isKeyStale: false)
-        #expect(result == nil)
-    }
-
-    @Test func returnsNilWhenKeyIsStale() {
-        let driver = makeDriver()
-        let result = RideRequestDriverOption.from(driver, displayName: nil,
-                                                   location: makeLocation(status: "online"),
-                                                   isKeyStale: true)
-        #expect(result == nil)
-    }
-
-    @Test func returnsOptionWhenOnline() throws {
+    @Test func returnsOptionWhenCanRequestRideIsTrue() throws {
         let driver = makeDriver(name: "Dave")
         let result = RideRequestDriverOption.from(driver, displayName: "Dave (cached)",
-                                                   location: makeLocation(status: "online"),
-                                                   isKeyStale: false)
+                                                   canRequestRide: true)
         let option = try #require(result)
         #expect(option.pubkey == fakePubkey)
         #expect(option.displayName == "Dave (cached)")
     }
 
+    @Test func displayNameFallsBackToDriverName() throws {
+        let driver = makeDriver(name: "Eve")
+        let option = try #require(
+            RideRequestDriverOption.from(driver, displayName: nil, canRequestRide: true)
+        )
+        #expect(option.displayName == "Eve")
+    }
+
+    @Test func displayNameFallsBackToShortPubkey() throws {
+        let driver = makeDriver(name: nil)
+        let option = try #require(
+            RideRequestDriverOption.from(driver, displayName: nil, canRequestRide: true)
+        )
+        #expect(option.displayName == String(fakePubkey.prefix(8)) + "...")
+    }
+
     @Test func idMatchesPubkey() throws {
         let driver = makeDriver()
         let option = try #require(
-            RideRequestDriverOption.from(driver, displayName: nil,
-                                          location: makeLocation(status: "online"),
-                                          isKeyStale: false)
+            RideRequestDriverOption.from(driver, displayName: nil, canRequestRide: true)
         )
         #expect(option.id == option.pubkey)
-    }
-
-    @Test func onlineOptionsFiltersOfflineDrivers() {
-        let pubkey2 = String(repeating: "d", count: 64)
-        let onlineDriver  = makeDriver(pubkey: fakePubkey)
-        let offlineDriver = makeDriver(pubkey: pubkey2)
-        let names: [String: String] = [:]
-        let locations: [String: CachedDriverLocation] = [
-            fakePubkey: makeLocation(pubkey: fakePubkey, status: "online"),
-            pubkey2:    makeLocation(pubkey: pubkey2, status: "offline"),
-        ]
-        let options = RideRequestDriverOption.onlineOptions(
-            from: [onlineDriver, offlineDriver],
-            driverNames: names,
-            driverLocations: locations,
-            staleKeyPubkeys: []
-        )
-        #expect(options.count == 1)
-        #expect(options.first?.pubkey == fakePubkey)
-    }
-
-    @Test func onlineOptionsFiltersOnRideDrivers() {
-        let pubkey2 = String(repeating: "d", count: 64)
-        let onlineDriver = makeDriver(pubkey: fakePubkey)
-        let onRideDriver = makeDriver(pubkey: pubkey2)
-        let locations: [String: CachedDriverLocation] = [
-            fakePubkey: makeLocation(pubkey: fakePubkey, status: "online"),
-            pubkey2:    makeLocation(pubkey: pubkey2, status: "on_ride"),
-        ]
-        let options = RideRequestDriverOption.onlineOptions(
-            from: [onlineDriver, onRideDriver],
-            driverNames: [:],
-            driverLocations: locations,
-            staleKeyPubkeys: []
-        )
-        #expect(options.count == 1)
-        #expect(options.first?.pubkey == fakePubkey)
-    }
-
-    @Test func onlineOptionsFiltersStaleKeyDrivers() {
-        let pubkey2 = String(repeating: "d", count: 64)
-        let freshDriver = makeDriver(pubkey: fakePubkey)
-        let staleDriver = makeDriver(pubkey: pubkey2)
-        let locations: [String: CachedDriverLocation] = [
-            fakePubkey: makeLocation(pubkey: fakePubkey, status: "online"),
-            pubkey2:    makeLocation(pubkey: pubkey2, status: "online"),
-        ]
-        let options = RideRequestDriverOption.onlineOptions(
-            from: [freshDriver, staleDriver],
-            driverNames: [:],
-            driverLocations: locations,
-            staleKeyPubkeys: [pubkey2]
-        )
-        #expect(options.count == 1)
-        #expect(options.first?.pubkey == fakePubkey)
     }
 }
 

--- a/decisions/0011-presentation-projection-layer.md
+++ b/decisions/0011-presentation-projection-layer.md
@@ -34,7 +34,8 @@ Initial types: `DriverListItem`, `DriverDetailViewState`, `RideRequestDriverOpti
 - All new screen state types follow this pattern: `public struct Foo: Equatable, Sendable` with `static func from(...)`.
 - Views import `RoadFlareCore` only; zero direct `RidestrSDK` imports in view files.
 - Factory signatures are the contract: adding a new display field means adding a parameter (or deriving it from existing ones), keeping the call site explicit about what data each type needs.
-- Callers must supply `isKeyStale:` for driver-facing types; this comes from `FollowedDriversRepository.staleKeyPubkeys`.
+- Callers must supply `isKeyStale:` for the driver-facing types that surface key-staleness as a separate status field — currently `DriverListItem` and `DriverDetailViewState`. The boolean comes from `FollowedDriversRepository.staleKeyPubkeys`.
+- Cross-cutting SDK-owned domain rules (e.g. ride-request eligibility) are resolved by `AppState+Presentation` via the SDK helper that owns the rule and passed in as a resolved boolean — not re-derived inside the factory. `canRequestRide: Bool` follows this pattern via `FollowedDriversRepository.canRequestRide(_:)`; see issue #94 / PR #117.
 
 ## Affected Files
 


### PR DESCRIPTION
## Summary

Closes #94.

- Replaces the inline `driver.hasKey && !isKeyStale && location?.status == "online"` predicate in `DriverDetailViewState.from()` and `RideRequestDriverOption.from()` with a `canRequestRide: Bool` parameter resolved by `AppState+Presentation` via `FollowedDriversRepository.canRequestRide(_:)`. The SDK helper is now the single source of truth.
- `RideRequestDriverOption.from(...)` drops its now-vestigial `location:` and `isKeyStale:` parameters (they only ever fed the inline predicate, never the projected struct). `RideRequestDriverOption.onlineOptions(...)` is deleted; the one caller (`AppState+Presentation.onlineDriverOptions()`) becomes a 4-line `compactMap` that mirrors `driverDetailViewState(pubkey:)`.
- Existing tests updated to feed the resolved boolean. New `AppStateCanRequestRideMatrixTests` pins the `(hasKey × keyStale × locationStatus)` matrix simultaneously against the SDK helper, `DriverDetailViewState.canRequestRide`, and `onlineDriverOptions()` membership — making any future drift between the three definitions visible in CI.

## Why this is safe

The inline predicate was always a strict-subset re-derivation of the SDK helper. The helper additionally guards "driver exists in repo" (pinned by `CanRequestRideTests.staleCallerSnapshot_hasKeyButRepoMissingKey_returnsFalse`); the inline form trusted the caller's snapshot. In practice the answer was the same — `AppState+Presentation` always sources drivers from the repo — but switching to the helper is a strict tightening and closes that gap.

Atomicity also improves: the helper reads `drivers` / `staleKeyPubkeys` / `driverLocations` under one lock; the inline form did three independent reads.

## Test plan

- [x] `xcodebuild build` on the RoadFlare scheme (iPhone 17 simulator) succeeds.
- [x] Full `RoadFlareTests` suite passes.
- [x] New `AppStateCanRequestRideMatrixTests` exercises 13 rows × 3 functions (39 cases) — all pass.
- [x] Updated `DriverDetailViewStateTests` + rewritten `RideRequestDriverOptionTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)