### PR TITLE
fix(ride): send-time preflight gates sendRideOffer against stale-key race

### DIFF
--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
@@ -194,7 +194,26 @@ public final class FollowedDriversRepository: @unchecked Sendable {
     /// RoadFlare key rotation); staleness only blocks Kind 30014 location
     /// decryption mid-ride, recovered by Kind 3188 → 3186 refresh (ADR-0013).
     public func canRequestRide(_ driver: FollowedDriver) -> Bool {
-        lock.withLock { canRequestRideLocked(driverPubkey: driver.pubkey) }
+        lock.withLock { rideOfferPreflightLocked(driverPubkey: driver.pubkey) == nil }
+    }
+
+    /// Shared send-time validation for Kind 3177 ride offers.
+    ///
+    /// Returns `nil` when the offer may proceed, or a `RideOfferPreflightFailure`
+    /// case identifying the specific structural reason the driver is not
+    /// currently a valid offer target. The lookup and eligibility check share
+    /// the same lock so a background sync cannot race the caller into observing
+    /// different driver, key-staleness, or location snapshots across separate
+    /// reads.
+    ///
+    /// Callers run this at send time (just before publishing the offer event)
+    /// because the UI predicate `canRequestRide(_:)` can drift in the gap
+    /// between button tap and publish: a stale-key signal can arrive, a
+    /// driver can flip to offline, or the driver can be removed from the
+    /// followed list. This is the ride-side parallel of
+    /// `driverPingPreflight(driverPubkey:)`.
+    public func rideOfferPreflight(driverPubkey: String) -> RideOfferPreflightFailure? {
+        lock.withLock { rideOfferPreflightLocked(driverPubkey: driverPubkey) }
     }
 
     // MARK: - Driver Names
@@ -495,13 +514,14 @@ public final class FollowedDriversRepository: @unchecked Sendable {
         return nil
     }
 
-    private func canRequestRideLocked(driverPubkey: String) -> Bool {
+    private func rideOfferPreflightLocked(driverPubkey: String) -> RideOfferPreflightFailure? {
         guard let driver = drivers.first(where: { $0.pubkey == driverPubkey }) else {
-            return false
+            return .driverNotFollowed
         }
-        guard driver.hasKey else { return false }
-        guard !staleKeyPubkeys.contains(driverPubkey) else { return false }
-        return driverLocations[driverPubkey]?.status == "online"
+        guard driver.hasKey else { return .missingKey }
+        guard !staleKeyPubkeys.contains(driverPubkey) else { return .staleKey }
+        guard driverLocations[driverPubkey]?.status == "online" else { return .offline }
+        return nil
     }
 }
 

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/FollowedDriversRepository.swift
@@ -520,8 +520,14 @@ public final class FollowedDriversRepository: @unchecked Sendable {
         }
         guard driver.hasKey else { return .missingKey }
         guard !staleKeyPubkeys.contains(driverPubkey) else { return .staleKey }
-        guard driverLocations[driverPubkey]?.status == "online" else { return .offline }
-        return nil
+        switch driverLocations[driverPubkey]?.status {
+        case "online":
+            return nil
+        case "on_ride":
+            return .onRide
+        default:
+            return .offline
+        }
     }
 }
 

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideOfferPreflightFailure.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideOfferPreflightFailure.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Structural reason a driver is not a valid target for a Kind 3177 ride
+/// offer at the moment the offer would publish.
+///
+/// Mirrors `DriverPingResult` but scoped to the eligibility-only subset:
+/// the ride-offer path surfaces publish failures, fare-pricing errors,
+/// and identity errors through other channels, so this enum only carries
+/// the structural-preflight outcomes (driver-not-followed, no key, key
+/// stale, driver offline).
+///
+/// Returned from `FollowedDriversRepository.rideOfferPreflight(driverPubkey:)`.
+/// `nil` from that call means the driver is eligible.
+public enum RideOfferPreflightFailure: Sendable, Equatable {
+    /// The driver is not in the rider's followed list.
+    case driverNotFollowed
+    /// The driver is followed but has not yet shared a current RoadFlare key.
+    case missingKey
+    /// A stale-key signal has been observed for this driver since the last
+    /// key share; the rider's view of the driver's key may not decrypt.
+    case staleKey
+    /// The driver is currently not broadcasting an `online` status.
+    case offline
+}

--- a/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideOfferPreflightFailure.swift
+++ b/RidestrSDK/Sources/RidestrSDK/RoadFlare/RideOfferPreflightFailure.swift
@@ -3,11 +3,14 @@ import Foundation
 /// Structural reason a driver is not a valid target for a Kind 3177 ride
 /// offer at the moment the offer would publish.
 ///
-/// Mirrors `DriverPingResult` but scoped to the eligibility-only subset:
-/// the ride-offer path surfaces publish failures, fare-pricing errors,
-/// and identity errors through other channels, so this enum only carries
-/// the structural-preflight outcomes (driver-not-followed, no key, key
-/// stale, driver offline).
+/// The ride-offer path surfaces publish failures, fare-pricing errors,
+/// and identity errors through other channels; this enum carries only the
+/// structural-preflight outcomes (driver-not-followed, no key, key stale,
+/// driver offline, driver on another ride). Analogous in role to the
+/// eligibility subset of `DriverPingResult` but distinct in surface — the
+/// ride-offer path has no rate-limit or publish-failure variants here, and
+/// `.staleKey` and `.onRide` are explicit cases rather than being folded
+/// into a generic `.ineligible`.
 ///
 /// Returned from `FollowedDriversRepository.rideOfferPreflight(driverPubkey:)`.
 /// `nil` from that call means the driver is eligible.
@@ -19,6 +22,11 @@ public enum RideOfferPreflightFailure: Sendable, Equatable {
     /// A stale-key signal has been observed for this driver since the last
     /// key share; the rider's view of the driver's key may not decrypt.
     case staleKey
-    /// The driver is currently not broadcasting an `online` status.
+    /// The driver is not currently broadcasting any status, or is broadcasting
+    /// an unrecognised non-`online` status (i.e., effectively offline).
     case offline
+    /// The driver is broadcasting `on_ride` — present and reachable, but
+    /// currently servicing a different ride and not available to accept a
+    /// new offer.
+    case onRide
 }

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -290,6 +290,25 @@ public final class RideCoordinator {
         destination: Location,
         fareEstimate: FareEstimate
     ) async {
+        // Re-validate driver eligibility at send time. The UI gates the
+        // "Request ride" button on `canRequestRide(_:)`, but a stale-key
+        // event, status flip to offline, or driver removal can land in
+        // the gap between button tap and this publish. Mirrors the
+        // send-time preflight pattern from `AppState.sendDriverPing`.
+        if let preflight = driversRepository.rideOfferPreflight(driverPubkey: driverPubkey) {
+            switch preflight {
+            case .driverNotFollowed:
+                lastError = "Driver is no longer available."
+            case .missingKey:
+                lastError = "Driver hasn't shared a key yet. Try again in a moment."
+            case .staleKey:
+                lastError = "Driver's key needs a refresh."
+            case .offline:
+                lastError = "Driver just went offline."
+            }
+            return
+        }
+
         guard let fareSats = bitcoinPrice.usdToSats(fareEstimate.fareUSD) else {
             lastError = "Bitcoin price not available. Try again in a moment."
             return

--- a/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
+++ b/RoadFlare/RoadFlareCore/ViewModels/RideCoordinator.swift
@@ -290,6 +290,10 @@ public final class RideCoordinator {
         destination: Location,
         fareEstimate: FareEstimate
     ) async {
+        // Clear any error from a prior attempt so a successful retry does
+        // not leave the previous failure string visible in the UI.
+        lastError = nil
+
         // Re-validate driver eligibility at send time. The UI gates the
         // "Request ride" button on `canRequestRide(_:)`, but a stale-key
         // event, status flip to offline, or driver removal can land in
@@ -305,6 +309,8 @@ public final class RideCoordinator {
                 lastError = "Driver's key needs a refresh."
             case .offline:
                 lastError = "Driver just went offline."
+            case .onRide:
+                lastError = "Driver is currently on another ride."
             }
             return
         }

--- a/RoadFlare/RoadFlareTests/AppState/CanRequestRideTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/CanRequestRideTests.swift
@@ -116,14 +116,16 @@ struct RideOfferPreflightTests {
         #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .offline)
     }
 
-    @Test func onRide_returnsOffline() {
+    @Test func onRide_returnsOnRide() {
         let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
         let repo = makeRepo(driver: driver)
         _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
                                       status: "on_ride", timestamp: 1_000_000, keyVersion: 1)
-        // "on_ride" is not "online" — the preflight surfaces this as .offline
-        // (i.e. "not available for a new offer right now").
-        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .offline)
+        // "on_ride" is distinct from "offline" — the driver is present and
+        // reachable but servicing another ride. The preflight surfaces this
+        // as `.onRide` so callers can show a more accurate message than
+        // "Driver just went offline."
+        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .onRide)
     }
 
     @Test func onlineWithCurrentKey_returnsNil() {

--- a/RoadFlare/RoadFlareTests/AppState/CanRequestRideTests.swift
+++ b/RoadFlare/RoadFlareTests/AppState/CanRequestRideTests.swift
@@ -83,3 +83,74 @@ struct CanRequestRideTests {
         #expect(repo.canRequestRide(staleSnapshot) == false)
     }
 }
+
+@Suite("FollowedDriversRepository.rideOfferPreflight")
+struct RideOfferPreflightTests {
+
+    @Test func unknownDriver_returnsDriverNotFollowed() {
+        let repo = FollowedDriversRepository(persistence: InMemoryFollowedDriversPersistence())
+        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .driverNotFollowed)
+    }
+
+    @Test func missingKey_returnsMissingKey() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: nil)
+        let repo = makeRepo(driver: driver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "online", timestamp: 1_000_000, keyVersion: 1)
+        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .missingKey)
+    }
+
+    @Test func staleKey_returnsStaleKey() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: driver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "online", timestamp: 1_000_000, keyVersion: 1)
+        repo.markKeyStale(pubkey: testPubkey)
+        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .staleKey)
+    }
+
+    @Test func offline_returnsOffline() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: driver)
+        // No location update → status nil → not online
+        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .offline)
+    }
+
+    @Test func onRide_returnsOffline() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: driver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "on_ride", timestamp: 1_000_000, keyVersion: 1)
+        // "on_ride" is not "online" — the preflight surfaces this as .offline
+        // (i.e. "not available for a new offer right now").
+        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .offline)
+    }
+
+    @Test func onlineWithCurrentKey_returnsNil() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: driver)
+        _ = repo.updateDriverLocation(pubkey: testPubkey, latitude: 0, longitude: 0,
+                                      status: "online", timestamp: 1_000_000, keyVersion: 1)
+        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == nil)
+    }
+
+    // MARK: - Stale-key surfaces over offline / missing-key priority
+
+    @Test func staleKeyTakesPrecedenceOverOffline() {
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: testKey)
+        let repo = makeRepo(driver: driver)
+        // No location → would be .offline. But stale key takes precedence.
+        repo.markKeyStale(pubkey: testPubkey)
+        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .staleKey)
+    }
+
+    @Test func missingKeyTakesPrecedenceOverStaleKey() {
+        // Stale-key tracking is keyed by pubkey, so a driver without any key
+        // who somehow ended up in staleKeyPubkeys should still surface
+        // .missingKey — the key gate runs before the stale gate.
+        let driver = FollowedDriver(pubkey: testPubkey, name: "Bob", roadflareKey: nil)
+        let repo = makeRepo(driver: driver)
+        repo.markKeyStale(pubkey: testPubkey)
+        #expect(repo.rideOfferPreflight(driverPubkey: testPubkey) == .missingKey)
+    }
+}

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -632,6 +632,78 @@ struct RideCoordinatorTests {
         #expect(!fake.publishedEvents.contains { $0.kind == EventKind.rideOffer.rawValue })
     }
 
+    @MainActor
+    @Test func sendRideOfferAbortsWhenDriverGoesOnRideBeforeSend() async throws {
+        // Driver is broadcasting `on_ride` — present and reachable but
+        // servicing another ride. The send must surface this distinctly
+        // from a generic offline ("Driver just went offline") so the rider
+        // sees an accurate message and doesn't retry expecting a transient
+        // connection blip.
+        let (coordinator, fake, _, _, _) = try await makeCoordinator()
+        let driver = try makeEligibleDriver(in: coordinator)
+
+        _ = coordinator.driversRepository.updateDriverLocation(
+            pubkey: driver.publicKeyHex,
+            latitude: 0, longitude: 0,
+            status: "on_ride",
+            timestamp: 2_000_000,
+            keyVersion: 1
+        )
+
+        await coordinator.sendRideOffer(
+            driverPubkey: driver.publicKeyHex,
+            pickup: Location(latitude: 40.71, longitude: -74.01),
+            destination: Location(latitude: 40.76, longitude: -73.98),
+            fareEstimate: FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+        )
+
+        #expect(coordinator.session.stage == .idle)
+        #expect(coordinator.lastError?.contains("another ride") == true)
+        #expect(!fake.publishedEvents.contains { $0.kind == EventKind.rideOffer.rawValue })
+    }
+
+    @MainActor
+    @Test func sendRideOfferClearsStaleLastErrorOnSuccessfulRetry() async throws {
+        // After a preflight failure leaves `lastError` set, a subsequent
+        // successful send must wipe the stale string so the UI does not
+        // continue to display the prior failure message.
+        let (coordinator, fake, _, _, _) = try await makeCoordinator()
+        let driver = try makeEligibleDriver(in: coordinator)
+
+        _ = coordinator.driversRepository.updateDriverLocation(
+            pubkey: driver.publicKeyHex,
+            latitude: 0, longitude: 0,
+            status: "offline",
+            timestamp: 2_000_000,
+            keyVersion: 1
+        )
+        await coordinator.sendRideOffer(
+            driverPubkey: driver.publicKeyHex,
+            pickup: Location(latitude: 40.71, longitude: -74.01),
+            destination: Location(latitude: 40.76, longitude: -73.98),
+            fareEstimate: FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+        )
+        #expect(coordinator.lastError?.contains("offline") == true)
+
+        _ = coordinator.driversRepository.updateDriverLocation(
+            pubkey: driver.publicKeyHex,
+            latitude: 0, longitude: 0,
+            status: "online",
+            timestamp: 3_000_000,
+            keyVersion: 1
+        )
+        await coordinator.sendRideOffer(
+            driverPubkey: driver.publicKeyHex,
+            pickup: Location(latitude: 40.71, longitude: -74.01),
+            destination: Location(latitude: 40.76, longitude: -73.98),
+            fareEstimate: FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+        )
+
+        #expect(coordinator.lastError == nil)
+        #expect(coordinator.session.stage == .waitingForAcceptance)
+        #expect(fake.publishedEvents.contains { $0.kind == EventKind.rideOffer.rawValue })
+    }
+
     // MARK: - Restore
 
     @MainActor

--- a/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
+++ b/RoadFlare/RoadFlareTests/RideCoordinatorTests.swift
@@ -61,6 +61,30 @@ struct RideCoordinatorTests {
         return (coordinator, fake, keypair, history, persistence)
     }
 
+    /// Add a freshly-generated driver to the coordinator's repo with a current
+    /// RoadFlare key and an `online` location, so `sendRideOffer`'s send-time
+    /// preflight passes and the test can exercise the publish path.
+    @MainActor
+    private func makeEligibleDriver(in coordinator: RideCoordinator) throws -> NostrKeypair {
+        let driver = try NostrKeypair.generate()
+        let roadflareKey = RoadflareKey(
+            privateKeyHex: String(repeating: "b", count: 64),
+            publicKeyHex: String(repeating: "c", count: 64),
+            version: 1, keyUpdatedAt: nil
+        )
+        coordinator.driversRepository.addDriver(
+            FollowedDriver(pubkey: driver.publicKeyHex, name: "Driver", roadflareKey: roadflareKey)
+        )
+        _ = coordinator.driversRepository.updateDriverLocation(
+            pubkey: driver.publicKeyHex,
+            latitude: 0, longitude: 0,
+            status: "online",
+            timestamp: 1_000_000,
+            keyVersion: 1
+        )
+        return driver
+    }
+
     @MainActor
     private func eventually(
         timeout: Duration = .seconds(1),
@@ -315,7 +339,7 @@ struct RideCoordinatorTests {
     @MainActor
     @Test func sendRideOfferPublishesOfferTransitionsSessionAndPersists() async throws {
         let (coordinator, fake, _, _, persistence) = try await makeCoordinator()
-        let driver = try NostrKeypair.generate()
+        let driver = try makeEligibleDriver(in: coordinator)
         let fare = FareEstimate(distanceMiles: 5.0, durationMinutes: 15, fareUSD: 12.50)
         let pickup = Location(latitude: 40.71, longitude: -74.01, address: "Penn Station")
         let destination = Location(latitude: 40.76, longitude: -73.98, address: "Central Park")
@@ -338,7 +362,7 @@ struct RideCoordinatorTests {
         let (coordinator, fake, riderKeypair, _, _) = try await makeCoordinator(
             roadflarePaymentMethods: ["venmo-business", "zelle", "cash"]
         )
-        let driver = try NostrKeypair.generate()
+        let driver = try makeEligibleDriver(in: coordinator)
 
         await coordinator.sendRideOffer(
             driverPubkey: driver.publicKeyHex,
@@ -363,10 +387,11 @@ struct RideCoordinatorTests {
     @MainActor
     @Test func sendRideOfferFailureSurfacesError() async throws {
         let (coordinator, fake, _, _, _) = try await makeCoordinator()
+        let driver = try makeEligibleDriver(in: coordinator)
         fake.shouldFailPublish = true
 
         await coordinator.sendRideOffer(
-            driverPubkey: String(repeating: "d", count: 64),
+            driverPubkey: driver.publicKeyHex,
             pickup: Location(latitude: 40.71, longitude: -74.01),
             destination: Location(latitude: 40.76, longitude: -73.98),
             fareEstimate: FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
@@ -427,7 +452,7 @@ struct RideCoordinatorTests {
         let (coordinator, fake, riderKeypair, _, _) = try await makeCoordinator(
             roadflarePaymentMethods: ["zelle"]
         )
-        let driver = try NostrKeypair.generate()
+        let driver = try makeEligibleDriver(in: coordinator)
 
         await coordinator.sendRideOffer(
             driverPubkey: driver.publicKeyHex,
@@ -456,7 +481,7 @@ struct RideCoordinatorTests {
         let (coordinator, fake, riderKeypair, _, _) = try await makeCoordinator(
             roadflarePaymentMethods: []
         )
-        let driver = try NostrKeypair.generate()
+        let driver = try makeEligibleDriver(in: coordinator)
 
         await coordinator.sendRideOffer(
             driverPubkey: driver.publicKeyHex,
@@ -483,7 +508,7 @@ struct RideCoordinatorTests {
         let (coordinator, fake, riderKeypair, _, _) = try await makeCoordinator(
             roadflarePaymentMethods: ["bitcoin", "cash"]
         )
-        let driver = try NostrKeypair.generate()
+        let driver = try makeEligibleDriver(in: coordinator)
 
         await coordinator.sendRideOffer(
             driverPubkey: driver.publicKeyHex,
@@ -510,7 +535,7 @@ struct RideCoordinatorTests {
         let (coordinator, fake, riderKeypair, _, _) = try await makeCoordinator(
             roadflarePaymentMethods: ["cash", "bitcoin"]
         )
-        let driver = try NostrKeypair.generate()
+        let driver = try makeEligibleDriver(in: coordinator)
 
         await coordinator.sendRideOffer(
             driverPubkey: driver.publicKeyHex,
@@ -530,6 +555,81 @@ struct RideCoordinatorTests {
         #expect(parsed.fiatFare?.amount == "12.50")
         #expect(parsed.fiatFare?.currency == "USD")
         #expect(parsed.paymentMethod == PaymentMethod.cash.rawValue)
+    }
+
+    // MARK: - Send-time preflight
+
+    @MainActor
+    @Test func sendRideOfferAbortsWhenDriverIsNotFollowed() async throws {
+        // UI predicate (`canRequestRide(_:)`) would have rejected this, but
+        // the coordinator must also re-check at send time because state can
+        // drift between button tap and publish. Pass a pubkey that is not
+        // in the repo and assert the offer never goes out.
+        let (coordinator, fake, _, _, _) = try await makeCoordinator()
+        let unknownDriver = String(repeating: "d", count: 64)
+
+        await coordinator.sendRideOffer(
+            driverPubkey: unknownDriver,
+            pickup: Location(latitude: 40.71, longitude: -74.01),
+            destination: Location(latitude: 40.76, longitude: -73.98),
+            fareEstimate: FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+        )
+
+        #expect(coordinator.session.stage == .idle)
+        #expect(coordinator.lastError != nil)
+        #expect(!fake.publishedEvents.contains { $0.kind == EventKind.rideOffer.rawValue })
+    }
+
+    @MainActor
+    @Test func sendRideOfferAbortsWhenStaleKeyArrivesBeforeSend() async throws {
+        // Simulate the race that motivates the send-time preflight: the UI
+        // gated on `canRequestRide(_:)` (true), the rider tapped Request,
+        // and a Kind 3188 stale-key event landed in the gap. The send must
+        // bail with a key-related message rather than publish an offer the
+        // driver cannot decrypt.
+        let (coordinator, fake, _, _, _) = try await makeCoordinator()
+        let driver = try makeEligibleDriver(in: coordinator)
+
+        coordinator.driversRepository.markKeyStale(pubkey: driver.publicKeyHex)
+
+        await coordinator.sendRideOffer(
+            driverPubkey: driver.publicKeyHex,
+            pickup: Location(latitude: 40.71, longitude: -74.01),
+            destination: Location(latitude: 40.76, longitude: -73.98),
+            fareEstimate: FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+        )
+
+        #expect(coordinator.session.stage == .idle)
+        #expect(coordinator.lastError?.contains("key") == true)
+        #expect(!fake.publishedEvents.contains { $0.kind == EventKind.rideOffer.rawValue })
+    }
+
+    @MainActor
+    @Test func sendRideOfferAbortsWhenDriverGoesOfflineBeforeSend() async throws {
+        // Driver was eligible at UI-predicate time; their next location
+        // event flips status away from "online". The send must catch this
+        // and not publish.
+        let (coordinator, fake, _, _, _) = try await makeCoordinator()
+        let driver = try makeEligibleDriver(in: coordinator)
+
+        _ = coordinator.driversRepository.updateDriverLocation(
+            pubkey: driver.publicKeyHex,
+            latitude: 0, longitude: 0,
+            status: "offline",
+            timestamp: 2_000_000,
+            keyVersion: 1
+        )
+
+        await coordinator.sendRideOffer(
+            driverPubkey: driver.publicKeyHex,
+            pickup: Location(latitude: 40.71, longitude: -74.01),
+            destination: Location(latitude: 40.76, longitude: -73.98),
+            fareEstimate: FareEstimate(distanceMiles: 5, durationMinutes: 15, fareUSD: 12.5)
+        )
+
+        #expect(coordinator.session.stage == .idle)
+        #expect(coordinator.lastError?.contains("offline") == true)
+        #expect(!fake.publishedEvents.contains { $0.kind == EventKind.rideOffer.rawValue })
     }
 
     // MARK: - Restore
@@ -1295,7 +1395,7 @@ struct RideCoordinatorTests {
     @MainActor
     @Test func cancelRidePublishesTerminationAndClearsPersistence() async throws {
         let (coordinator, fake, _, _, persistence) = try await makeCoordinator()
-        let driver = try NostrKeypair.generate()
+        let driver = try makeEligibleDriver(in: coordinator)
 
         await coordinator.sendRideOffer(
             driverPubkey: driver.publicKeyHex,


### PR DESCRIPTION
## Summary

PR #58's fourth-pass review flagged this as a follow-up: \`RideCoordinator.sendRideOffer\` had no send-time re-check, so a stale-key event arriving between the UI predicate and the Kind 3177 publish would let the offer go out and silently fail on the driver's decrypt. The driver-ping path has mirrored this protection for some time via \`FollowedDriversRepository.driverPingPreflight\` called from \`AppState.sendDriverPing\` right before publish. This PR ports that pattern.

## First-principles framing

The principle: **validation that affects correctness must run at the action boundary, not just at the UI boundary.** The UI predicate \`canRequestRide(_:)\` answers "should the button be enabled" at render time; \`sendRideOffer\` is the action boundary, and its re-check is the only thing that defends against state arriving between render and publish (a relay event, a status flip, a removal). This PR closes that gap symmetric to the ping path.

## Changes

- New SDK enum \`RideOfferPreflightFailure\` (sibling to \`DriverPingResult\`) — \`.driverNotFollowed\`, \`.missingKey\`, \`.staleKey\`, \`.offline\`.
- New SDK helper \`FollowedDriversRepository.rideOfferPreflight(driverPubkey:) -> RideOfferPreflightFailure?\` — single-lock snapshot, returns nil on eligibility.
- \`canRequestRide(_:)\` refactored to derive from the preflight (\`rideOfferPreflightLocked(...) == nil\`). Single source of truth.
- \`RideCoordinator.sendRideOffer\` calls the preflight before any other work and sets \`lastError\` with a specific user-facing message per failure. Existing publish path unchanged.

## Test plan

- [x] SDK \`RideOfferPreflightTests\` (7 cases) — each failure variant, eligibility, plus precedence (stale-key over offline; missing-key over stale-key)
- [x] Three new \`RideCoordinatorTests\` race-scenario cases (driver not followed / stale-key arrives / driver flips offline) — each asserts no offer event is published and \`lastError\` mentions the right reason
- [x] Existing \`sendRideOffer*\` tests refactored through a new \`makeEligibleDriver(in:)\` helper to preserve their original intent under the new preflight gate
- [x] Full \`xcodebuild test -scheme RoadFlareTests\` — TEST SUCCEEDED

## Protocol compatibility

Kind 3177 wire format unchanged. \`RiderRideSession.sendOffer\` API unchanged. Ridestr / Drivestr peers interoperate exactly as before.

Related: PR #58 (where this gap was first surfaced).